### PR TITLE
Fix reconnect dropping balance updates, and stop showing errors as a zero balance

### DIFF
--- a/docs/proposals/optional-lock-screen.md
+++ b/docs/proposals/optional-lock-screen.md
@@ -1,0 +1,150 @@
+# Proposal: optional lock screen, load-then-authenticate
+
+**Status:** proposed, not yet implemented
+**Scope:** its own PR, after the reconnect/balance fixes land
+
+## Summary
+
+Today FlightDeck locks the whole UI behind a password wall on every start. This proposes
+loading the wallet's **read-only** state (balance, address, receive QR, history) without a
+password, and demanding authentication only for actions that actually need the key — send,
+export, sign, connect-approval. The full lock screen stays available as an opt-in for people who
+want a device-access guard, but it is no longer the default.
+
+This is the model Radiant and several other wallets use. It is safe here specifically because
+**FlightDeck already encrypts keys at rest** (scrypt + AES-GCM) — the lock screen gates the UI,
+not the secrets, and everything shown read-only is public blockchain data anyone with the address
+can already see.
+
+## Why this is an architectural change, not a flag
+
+`isLocked` currently conflates two orthogonal ideas:
+
+1. **UI visibility** — is the whole app hidden behind a wall?
+2. **Credential availability** — is the decryption password held in memory for silent re-auth?
+
+Two facts from the current code make the conflation concrete:
+
+- [`SecurityContext.tsx:316`](../../src/contexts/SecurityContext.tsx#L316) — when `isLocked`,
+  `SecurityProvider` returns `<SecurityLockScreen>` **instead of** `{children}`. Since
+  `SecurityProvider` wraps `WalletProvider`
+  ([`layout.tsx:116`](../../src/app/layout.tsx#L116)), the entire wallet subtree does not mount
+  while locked. There is no "read-only load" to show — the wallet context does not exist.
+- [`SecurityContext.tsx:235`](../../src/contexts/SecurityContext.tsx#L235) — `requireAuth`
+  early-returns `{ success: false }` when `isLocked`. Sensitive actions cannot authenticate while
+  locked, which is fine today because they are unreachable, but blocks the proposed model.
+
+So the work is to **split the two concepts**, not to add a bypass.
+
+## Target model
+
+Introduce two independent pieces of state:
+
+| Concept | Meaning | Replaces |
+| ------- | ------- | -------- |
+| `screenLocked` | The opt-in full-screen wall is showing | today's `isLocked` for the UI gate |
+| `keyUnlocked` | The password is in memory for silent re-auth this session | today's `storedWalletPassword != null` |
+
+- **Default (screen lock off):** `screenLocked` starts `false`. `WalletProvider` mounts and loads
+  read-only immediately. `keyUnlocked` starts `false` — the first send/export/sign prompts, and
+  from then on `requireAuth(msg, autoLogin: true)` reuses the in-memory password for the session.
+- **Screen lock on (opt-in, or after an auto-lock timeout):** `screenLocked` starts `true` and
+  the wall shows exactly as today. Unlocking sets both `screenLocked = false` and
+  `keyUnlocked = true`.
+
+Crucially, `requireAuth` stops gating on the UI wall and gates on `keyUnlocked` instead — so it
+works whether or not the wall was ever shown.
+
+## Concrete changes
+
+### 1. Restructure the provider tree — `layout.tsx`, `SecurityContext.tsx`
+
+`WalletProvider` must mount regardless of lock state. Move the lock-screen render out of the
+provider's early-return so it becomes an **overlay** over the mounted tree rather than a
+replacement for it:
+
+```tsx
+return (
+  <SecurityContext.Provider value={…}>
+    {children}
+    {screenLocked && <SecurityLockScreen onUnlock={handleUnlock} lockReason={lockReason} />}
+    <AuthenticationDialog … />
+  </SecurityContext.Provider>
+);
+```
+
+`SecurityProvider` already tolerates `useWallet()` being absent (try/catch at
+[`SecurityContext.tsx:42`](../../src/contexts/SecurityContext.tsx#L42)), so the two providers can
+also be reordered (`WalletProvider` outer) if that proves cleaner — to be decided during
+implementation, but the overlay approach needs no reorder.
+
+### 2. Split the state — `SecurityContext.tsx`
+
+- Rename the UI flag to `screenLocked`; derive `keyUnlocked` from `storedWalletPassword`.
+- `requireAuth`: replace the `if (isLocked) return {success:false}` guard. When the key is not in
+  memory it should **prompt**, not fail — which is already most of what the function does; only
+  the early return is removed.
+- Keep `manualLock()` / the auto-lock timeout wired to `screenLocked` so the timeout still raises
+  the wall for users who enabled it.
+
+### 3. Settings — `SecurityService` + security settings page
+
+Add `autoLock.screenLockEnabled` (default `false`). The existing `autoLock.enabled` /
+`requirePasswordAfterTimeout` already exist; this adds the "show the wall at all" switch. The
+security-settings page gets one toggle: **"Require password to open the wallet."**
+
+### 4. Read-only safety — already handled
+
+The balance-status work already merged means a read-only load on a flaky connection shows
+"balance unavailable" rather than a misleading `0`. That is exactly the state this model spends
+most of its time in, so no extra work is needed there — but it is a hard dependency, which is why
+this proposal is sequenced after it.
+
+## Security analysis
+
+**What we still protect.** Keys and mnemonics remain encrypted at rest and are never held
+decrypted; only the user's password sits in memory after the first authenticated action, exactly
+as today. Every spend, export, sign and connect-approval still requires `requireAuth`. The
+threat model for *key theft* is unchanged.
+
+**What we give up by default.** Device-access privacy for read-only data: someone who picks up an
+unlocked device sees the balance, address and history without a password. This is already public,
+address-keyed blockchain data — but "visible on my screen" is a real privacy step down from
+today, so the wall stays one toggle away for anyone who wants it.
+
+**What we must not regress.**
+
+- `requireAuth` must never silently succeed without a password in memory. The
+  `validateWalletPassword`-fails-open bug we already fixed is the cautionary tale here.
+- Auto-lock-on-timeout must still work for users who enable the wall.
+- The stored-password lifetime should get a hard session cap (see open questions).
+
+## Testing
+
+- **Unit (SecurityService/context):** `requireAuth` prompts when `keyUnlocked` is false and reuses
+  the password when true, independent of `screenLocked`; the timeout path still raises the wall
+  when enabled.
+- **E2E, both modes** — the `walletPage` fixture makes this cheap:
+  - default: fresh load shows balance without a password; first `send`/export prompts.
+  - screen-lock on: the wall shows on start, unlock reveals the wallet.
+  - the toggle flips behaviour on next load.
+- **Regression:** a locked wallet still cannot sign; a wrong password at any prompt still fails
+  closed.
+
+## Open questions
+
+1. **Session-password lifetime.** Today `storedWalletPassword` lives for the whole session with
+   no cap. Under a load-then-prompt model it is the main secret in memory — a timeout that clears
+   it (re-prompting on the next sensitive action) is worth adding, distinct from the UI wall.
+2. **Biometric-only unlock.** Should enabling the wall + biometrics allow opening read-only with a
+   fingerprint but no password held? Probably out of scope for v1.
+3. **Default for existing users.** New installs default to no wall. Existing users who have been
+   living with the wall should probably keep it on migration and be told the toggle exists, rather
+   than silently dropped to no-wall.
+
+## Rollout
+
+1. Land reconnect + balance-status fixes (done — hard dependency).
+2. This PR: state split, provider restructure, settings toggle, tests. Default off for new
+   installs; on for existing installs on migration.
+3. Follow-up (optional): session-password timeout from open question 1.

--- a/e2e/balance.spec.ts
+++ b/e2e/balance.spec.ts
@@ -1,0 +1,43 @@
+import { WALLET_ADDRESS, expect, test } from './fixtures';
+
+/**
+ * What the balance display claims when the server cannot be reached. The fixture blocks all
+ * WebSocket traffic, so these tests run in exactly the situation the fix is about: a wallet
+ * that cannot confirm anything must say so, not present a confident zero.
+ */
+
+test.describe('balance display while the server is unreachable', () => {
+  test('shows unavailable rather than a zero balance', async ({ walletPage }) => {
+    await walletPage.goto('/');
+
+    // The responsive layout renders a mobile and a desktop copy; exactly one is visible.
+    const unavailable = walletPage.getByTestId('balance-unavailable').filter({ visible: true });
+    await expect(unavailable).toBeVisible();
+    await expect(unavailable).toContainText('balance unavailable');
+
+    // The unavailable marker replaces the figure, rather than sitting next to a "last known"
+    // caveat — this is genuinely no-data, not a remembered value.
+    await expect(walletPage.getByTestId('balance-stale')).toHaveCount(0);
+  });
+
+  test('shows a previously seen balance as last known, not as current', async ({ walletPage }) => {
+    // A previous session saw a real balance; the app persists it per wallet in localStorage.
+    await walletPage.evaluate((address) => {
+      localStorage.setItem(
+        'lastKnownBalances',
+        JSON.stringify({ [address]: { balance: 12_345_678, timestamp: Date.now() } }),
+      );
+    }, WALLET_ADDRESS);
+
+    await walletPage.goto('/');
+
+    const stale = walletPage.getByTestId('balance-stale').filter({ visible: true });
+    await expect(stale).toBeVisible();
+    await expect(stale).toContainText('last known');
+
+    // The remembered figure is shown (it appears in more than one place; any visible one proves
+    // the point), and it is not dressed up as unavailable.
+    await expect(walletPage.getByText('0.12345678 AVN').first()).toBeVisible();
+    await expect(walletPage.getByTestId('balance-unavailable')).toHaveCount(0);
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export default function Home() {
     const router = useRouter();
-    const { wallet, balance, address, isLoading, processingProgress, updateBalance } = useWallet();
+    const { wallet, balance, balanceStatus, address, isLoading, processingProgress, updateBalance } = useWallet();
     const { lockWallet, isLocked } = useSecurity();
     const [activeTab, setActiveTab] = useState<'send' | 'receive' | 'history'>('send');
     const [isRefreshing, setIsRefreshing] = useState(false);
@@ -255,9 +255,25 @@ export default function Home() {
                         <div className="text-xl md:text-2xl lg:text-3xl font-bold mb-2 flex items-center flex-wrap text-white">
                             {isLoading && !processingProgress.isProcessing ? (
                                 'Loading...'
+                            ) : balanceStatus === 'unknown' ? (
+                                // No confirmed or cached figure exists; showing 0 here would
+                                // read as "your funds are gone" on a flaky connection.
+                                <span data-testid="balance-unavailable" className="flex items-baseline">
+                                    —
+                                    <span className="ml-2 text-xs font-normal opacity-80">balance unavailable</span>
+                                </span>
                             ) : (
                                 <>
                                     {`${formatBalance(balance)} AVN`}
+                                    {balanceStatus === 'stale' && (
+                                        <span
+                                            data-testid="balance-stale"
+                                            className="ml-2 text-xs font-normal opacity-80"
+                                            title="Shown from the last successful update; the server has not confirmed it yet"
+                                        >
+                                            last known
+                                        </span>
+                                    )}
                                     {processingProgress.isProcessing && (
                                         <Loader className="w-4 h-4 md:w-5 md:h-5 ml-2 animate-spin opacity-70" />
                                     )}
@@ -386,11 +402,25 @@ export default function Home() {
                         <div className="text-2xl lg:text-3xl font-bold mb-2 flex items-center text-white">
                             {isLoading && !processingProgress.isProcessing ? (
                                 'Loading...'
+                            ) : balanceStatus === 'unknown' ? (
+                                <span data-testid="balance-unavailable" className="flex items-baseline">
+                                    —
+                                    <span className="ml-2 text-xs font-normal opacity-80">balance unavailable</span>
+                                </span>
                             ) : (
                                 <>
                                     <span className="break-all whitespace-normal overflow-hidden">
                                         {`${formatBalance(balance)} AVN`}
                                     </span>
+                                    {balanceStatus === 'stale' && (
+                                        <span
+                                            data-testid="balance-stale"
+                                            className="ml-2 text-xs font-normal opacity-80"
+                                            title="Shown from the last successful update; the server has not confirmed it yet"
+                                        >
+                                            last known
+                                        </span>
+                                    )}
                                     {processingProgress.isProcessing && (
                                         <Loader className="w-5 h-5 ml-2 flex-shrink-0 animate-spin opacity-70" />
                                     )}

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -16,10 +16,19 @@ import { TransactionClientService } from '@/services/notifications/client/Transa
 import { CoinSelectionStrategy, EnhancedUTXO } from '@/services/wallet/UTXOSelectionService';
 import { walletContextLogger } from '@/lib/Logger';
 
+/**
+ * How trustworthy the displayed balance is.
+ * - live:    confirmed by the server this session (directly or via subscription)
+ * - stale:   a real number from an earlier session; the server has not confirmed it yet
+ * - unknown: nothing to go on — the UI must show "unavailable", never 0
+ */
+export type BalanceStatus = 'live' | 'stale' | 'unknown';
+
 interface WalletContextType {
   wallet: WalletService | null;
   electrum: ElectrumService | null;
   balance: number;
+  balanceStatus: BalanceStatus;
   address: string;
   isEncrypted: boolean;
   isLoading: boolean;
@@ -38,11 +47,7 @@ interface WalletContextType {
     password: string,
     passphrase?: string,
   ) => Promise<void>;
-  importWalletFromDescriptor: (
-    name: string,
-    descriptor: string,
-    password: string,
-  ) => Promise<void>;
+  importWalletFromDescriptor: (name: string, descriptor: string, password: string) => Promise<void>;
   sendTransaction: (
     toAddress: string,
     amount: number,
@@ -127,6 +132,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
   const [wallet, setWallet] = useState<WalletService | null>(null);
   const [electrum, setElectrum] = useState<ElectrumService | null>(null);
   const [balance, setBalance] = useState<number>(0); // Initially 0, but will update early with last known balance
+  const [balanceStatus, setBalanceStatus] = useState<BalanceStatus>('unknown');
   const [address, setAddress] = useState<string>('');
   const [isEncrypted, setIsEncrypted] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -178,6 +184,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
         const lastKnownData = TransactionClientService.getLastKnownBalance(activeWallet.address);
         if (lastKnownData && lastKnownData.balance > 0) {
           setBalance(lastKnownData.balance);
+          setBalanceStatus('stale');
         }
 
         // Initialize wallet with subscription for real-time updates
@@ -185,6 +192,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
           activeWallet.address,
           (data) => {
             setBalance(data.balance);
+            setBalanceStatus('live');
           },
           (processed, total, currentTx) => {
             // Set processing progress during initial transaction loading
@@ -204,6 +212,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
         setAddress('');
         setIsEncrypted(false);
         setBalance(0);
+        setBalanceStatus('unknown');
       }
 
       // Run migration for existing transactions if needed
@@ -240,7 +249,9 @@ export function WalletProvider({ children }: WalletProviderProps) {
       const newWallet = await wallet.generateWallet(password, useMnemonic, passphrase);
       setAddress(newWallet.address);
       setIsEncrypted(true); // Always encrypted now
+      // A freshly generated address genuinely holds nothing, so this zero is real.
       setBalance(0);
+      setBalanceStatus('live');
 
       // Save to storage
       await StorageService.setAddress(newWallet.address);
@@ -252,6 +263,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
         newWallet.address,
         (data) => {
           setBalance(data.balance);
+          setBalanceStatus('live');
         },
         (processed, total, currentTx) => {
           // Set processing progress during initial transaction loading
@@ -292,6 +304,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
       const lastKnownData = TransactionClientService.getLastKnownBalance(restoredWallet.address);
       if (lastKnownData && lastKnownData.balance > 0) {
         setBalance(lastKnownData.balance);
+        setBalanceStatus('stale');
       }
 
       // Initialize wallet with subscription for real-time updates
@@ -299,6 +312,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
         restoredWallet.address,
         (data) => {
           setBalance(data.balance);
+          setBalanceStatus('live');
         },
         (processed, total, currentTx) => {
           // Set processing progress during initial transaction loading
@@ -352,6 +366,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
       const lastKnownData = TransactionClientService.getLastKnownBalance(restoredWallet.address);
       if (lastKnownData && lastKnownData.balance > 0) {
         setBalance(lastKnownData.balance);
+        setBalanceStatus('stale');
       }
 
       // Initialize wallet with subscription for real-time updates
@@ -359,6 +374,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
         restoredWallet.address,
         (data) => {
           setBalance(data.balance);
+          setBalanceStatus('live');
         },
         (processed, total, currentTx) => {
           // Set processing progress during initial transaction loading
@@ -455,24 +471,36 @@ export function WalletProvider({ children }: WalletProviderProps) {
     if (!wallet || !address) return;
 
     try {
-      // Force a fresh balance check from the Electrum server
-      // Adding a forceRefresh parameter to bypass any caching
-      const newBalance = await wallet.getBalance(address, true);
+      // Force a fresh balance check from the Electrum server, and keep track of whether the
+      // number we got back is the server's answer or a fallback — the UI shows the difference.
+      const detailed = await wallet.getBalanceDetailed(address, true);
 
-      // Update the balance in the UI
-      setBalance(newBalance);
+      if (detailed.source === 'live' || detailed.source === 'cache') {
+        setBalance(detailed.balance);
+        setBalanceStatus('live');
 
-      // Also update the last known balance in local storage
-      try {
-        const { TransactionClientService } = await import(
-          '@/services/notifications/client/TransactionClientService'
-        );
-        TransactionClientService.saveLastKnownBalance(newBalance, address);
-      } catch (storageError) {
-        walletContextLogger.error('Failed to update last known balance in storage:', storageError);
+        // Also update the last known balance in local storage
+        try {
+          const { TransactionClientService } =
+            await import('@/services/notifications/client/TransactionClientService');
+          TransactionClientService.saveLastKnownBalance(detailed.balance, address);
+        } catch (storageError) {
+          walletContextLogger.error(
+            'Failed to update last known balance in storage:',
+            storageError,
+          );
+        }
+      } else if (detailed.source === 'stored') {
+        setBalance(detailed.balance);
+        setBalanceStatus('stale');
+      } else {
+        // Nothing usable came back. Keep the last number we showed, but stop claiming it is
+        // current; if we never had one, it stays unknown and renders as unavailable.
+        setBalanceStatus((prev) => (prev === 'live' ? 'stale' : prev));
       }
     } catch (error) {
       walletContextLogger.error('Failed to update balance:', error);
+      setBalanceStatus((prev) => (prev === 'live' ? 'stale' : prev));
     }
   }, [wallet, address]);
 
@@ -647,6 +675,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
               const balances = JSON.parse(balancesStr);
               if (balances[activeWallet.address] && balances[activeWallet.address].balance > 0) {
                 setBalance(balances[activeWallet.address].balance);
+                setBalanceStatus('stale');
               }
             }
           } catch (error) {
@@ -655,15 +684,19 @@ export function WalletProvider({ children }: WalletProviderProps) {
 
           // Get the balance for the newly active wallet
           // Force refresh to ensure we get the latest balance from the server
-          const newBalance = await wallet.getBalance(activeWallet.address, true);
-          setBalance(newBalance);
+          const detailed = await wallet.getBalanceDetailed(activeWallet.address, true);
+          if (detailed.source !== 'unknown') {
+            setBalance(detailed.balance);
+            setBalanceStatus(detailed.source === 'stored' ? 'stale' : 'live');
+          }
 
           // Save the initial balance for this wallet if we're switching to it
           // This prevents false balance change notifications when switching wallets
-          const { TransactionClientService } = await import(
-            '@/services/notifications/client/TransactionClientService'
-          );
-          TransactionClientService.saveLastKnownBalance(newBalance, activeWallet.address);
+          if (detailed.source === 'live' || detailed.source === 'cache') {
+            const { TransactionClientService } =
+              await import('@/services/notifications/client/TransactionClientService');
+            TransactionClientService.saveLastKnownBalance(detailed.balance, activeWallet.address);
+          }
 
           // Subscribe to updates for the new wallet address immediately
           try {
@@ -671,6 +704,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
               // Update UI when wallet has updates
               if (data && data.balance !== undefined) {
                 setBalance(data.balance);
+                setBalanceStatus('live');
 
                 // Also update the last known balance when we get updates
                 import('@/services/notifications/client/TransactionClientService').then(
@@ -715,16 +749,19 @@ export function WalletProvider({ children }: WalletProviderProps) {
                 // Update balance again after refreshing transactions
                 // Force refresh to ensure we get the latest balance from the server
                 wallet
-                  .getBalance(activeWallet.address, true)
-                  .then(async (finalBalance) => {
-                    setBalance(finalBalance);
+                  .getBalanceDetailed(activeWallet.address, true)
+                  .then(async (finalDetailed) => {
+                    if (finalDetailed.source === 'unknown') {
+                      return; // Nothing usable; keep whatever we last showed.
+                    }
+                    setBalance(finalDetailed.balance);
+                    setBalanceStatus(finalDetailed.source === 'stored' ? 'stale' : 'live');
 
                     // Update the saved balance after refreshing transactions
-                    const { TransactionClientService } = await import(
-                      '@/services/notifications/client/TransactionClientService'
-                    );
+                    const { TransactionClientService } =
+                      await import('@/services/notifications/client/TransactionClientService');
                     TransactionClientService.saveLastKnownBalance(
-                      finalBalance,
+                      finalDetailed.balance,
                       activeWallet.address,
                     );
 
@@ -747,6 +784,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
         setAddress('');
         setIsEncrypted(false);
         setBalance(0);
+        setBalanceStatus('unknown');
       }
     } catch (error) {
       walletContextLogger.error('Error reloading active wallet:', error);
@@ -811,6 +849,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
         (newBalance) => {
           // Update balance after processing
           setBalance(newBalance);
+          setBalanceStatus('live');
         },
       );
 
@@ -859,6 +898,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
           (newBalance) => {
             // Update balance periodically during processing
             setBalance(newBalance);
+            setBalanceStatus('live');
           },
         );
 
@@ -886,6 +926,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
     wallet,
     electrum,
     balance,
+    balanceStatus,
     address,
     isEncrypted,
     isLoading,
@@ -910,12 +951,20 @@ export function WalletProvider({ children }: WalletProviderProps) {
       if (!wallet) throw new Error('Wallet service not initialized');
       try {
         setIsLoading(true);
-        const newWallet = await wallet.importWalletFromDescriptor({ name, descriptor, password, makeActive: true });
+        const newWallet = await wallet.importWalletFromDescriptor({
+          name,
+          descriptor,
+          password,
+          makeActive: true,
+        });
         setAddress(newWallet.address);
         setIsEncrypted(true);
         await wallet.initializeWallet(
           newWallet.address,
-          (data) => { setBalance(data.balance); },
+          (data) => {
+            setBalance(data.balance);
+            setBalanceStatus('live');
+          },
           (processed, total, currentTx) => {
             setProcessingProgress({ isProcessing: total > 0, processed, total, currentTx });
           },

--- a/src/services/core/ElectrumService.resubscribe.test.ts
+++ b/src/services/core/ElectrumService.resubscribe.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ElectrumService } from './ElectrumService';
+
+/**
+ * Reconnection behaviour, driven through a scripted WebSocket.
+ *
+ * The regression this guards: server-side subscriptions die with the socket, so after an
+ * automatic reconnect every watched address must be re-subscribed — otherwise the wallet looks
+ * healthy but silently stops receiving balance updates until the user forces a refresh.
+ */
+
+interface RpcRequest {
+  id: number;
+  method: string;
+  params: unknown[];
+}
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  sent: RpcRequest[] = [];
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(raw: string): void {
+    const request = JSON.parse(raw) as RpcRequest;
+    this.sent.push(request);
+    // Answer inline, like a well-behaved server. Subscribe requests get a status string that
+    // differs per socket so the test can tell a re-subscription response from the original.
+    const result =
+      request.method === 'blockchain.scripthash.subscribe'
+        ? `status-from-socket-${FakeWebSocket.instances.indexOf(this)}`
+        : null;
+    this.onmessage?.({ data: JSON.stringify({ id: request.id, result }) });
+  }
+
+  close(code = 1000, reason = ''): void {
+    this.onclose?.({ code, reason });
+  }
+
+  /** Simulates the server accepting the connection. */
+  open(): void {
+    this.onopen?.();
+  }
+
+  /** Simulates the connection dropping without a clean close. */
+  drop(): void {
+    this.onclose?.({ code: 1006, reason: 'connection lost' });
+  }
+}
+
+const ADDRESS = 'RMBnRfw6tV7dC7LS4Lr8JBWvocokzHQNeG';
+
+/** Lets the queued microtasks from resubscribeAll's await-chain run to completion. */
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+};
+
+async function connectedService(): Promise<ElectrumService> {
+  const service = new ElectrumService();
+  const pending = service.connect();
+  FakeWebSocket.instances[0].open();
+  await pending;
+  return service;
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  vi.useFakeTimers();
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('reconnection', () => {
+  it('re-subscribes every watched address after an unexpected disconnect', async () => {
+    const service = await connectedService();
+
+    const updates: Array<{ scripthash: string; status: string }> = [];
+    await service.subscribeToAddress(ADDRESS, (data) => updates.push(data));
+    expect(updates).toHaveLength(1);
+    const scripthash = updates[0].scripthash;
+
+    // The connection drops uncleanly; the first backoff delay is 2 s.
+    FakeWebSocket.instances[0].drop();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const second = FakeWebSocket.instances[1];
+    expect(second).toBeDefined();
+    second.open();
+    await flushMicrotasks();
+
+    // The new socket carries a fresh subscribe for the same scripthash…
+    const resubscribed = second.sent.filter(
+      (request) => request.method === 'blockchain.scripthash.subscribe',
+    );
+    expect(resubscribed.map((request) => request.params[0])).toEqual([scripthash]);
+
+    // …and the current status is delivered, so downstream refetches the balance and picks up
+    // anything that changed while the connection was down.
+    expect(updates).toHaveLength(2);
+    expect(updates[1].status).toBe('status-from-socket-1');
+  });
+
+  it('re-subscribes all addresses, not just the first', async () => {
+    const service = await connectedService();
+
+    const seen: string[] = [];
+    await service.subscribeToAddress(ADDRESS, (data) => seen.push(data.scripthash));
+    await service.subscribeToAddress('RJNi221gkDstBPUxeeJgtmDY4EXMEj6uvF', (data) =>
+      seen.push(data.scripthash),
+    );
+
+    FakeWebSocket.instances[0].drop();
+    await vi.advanceTimersByTimeAsync(2_000);
+    FakeWebSocket.instances[1].open();
+    await flushMicrotasks();
+
+    const resubscribed = FakeWebSocket.instances[1].sent
+      .filter((request) => request.method === 'blockchain.scripthash.subscribe')
+      .map((request) => request.params[0]);
+
+    expect(new Set(resubscribed).size).toBe(2);
+  });
+
+  it('does not resubscribe or reconnect after a deliberate disconnect', async () => {
+    const service = await connectedService();
+    await service.subscribeToAddress(ADDRESS, () => undefined);
+
+    await service.disconnect();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    // No new socket was opened, and the subscription registry was cleared.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it('rejects connect() when the socket closes before it ever opens', async () => {
+    // A refused or firewalled connection closes without opening. connect() must settle, or
+    // everything awaiting it — including app start-up — hangs on a loading screen forever.
+    const service = new ElectrumService();
+    const pending = service.connect();
+
+    FakeWebSocket.instances[0].close(1006, 'refused');
+
+    await expect(pending).rejects.toThrow(/closed before opening/);
+  });
+
+  it('sends no subscriptions on a first connect with nothing watched', async () => {
+    await connectedService();
+    await flushMicrotasks();
+
+    const subscribes = FakeWebSocket.instances[0].sent.filter(
+      (request) => request.method === 'blockchain.scripthash.subscribe',
+    );
+    expect(subscribes).toHaveLength(0);
+  });
+});

--- a/src/services/core/ElectrumService.test.ts
+++ b/src/services/core/ElectrumService.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import * as bitcoin from 'bitcoinjs-lib';
 
 import { ElectrumService } from './ElectrumService';
+import { StorageService } from './StorageService';
 import { avianNetwork } from '@/services/wallet/WalletService';
+import { resetStorage } from '@/test/helpers';
 
 /**
  * Only the pure, offline part of the Electrum client is covered here: the address-to-scripthash
@@ -55,6 +57,53 @@ describe('addressToScriptHash', () => {
     const scriptHash = service.addressToScriptHash('not-an-address');
     expect(scriptHash).toMatch(/^[0-9a-f]{64}$/);
     expect(scriptHash).not.toBe(service.addressToScriptHash(P2PKH));
+  });
+});
+
+describe('balance provenance while offline', () => {
+  it('reports unknown when there is nothing to go on — never a confident zero', async () => {
+    resetStorage();
+    const fresh = new ElectrumService();
+
+    const detailed = await fresh.getBalanceDetailed(P2PKH);
+
+    expect(detailed).toEqual({ balance: 0, source: 'unknown' });
+  });
+
+  it('falls back to a balance a subscription pushed earlier in the session', async () => {
+    const fresh = new ElectrumService();
+    fresh.updateRealBalance(P2PKH, 123_456);
+
+    const detailed = await fresh.getBalanceDetailed(P2PKH);
+
+    expect(detailed).toEqual({ balance: 123_456, source: 'cache' });
+  });
+
+  it('falls back to a balance persisted by a previous session, marked as stored', async () => {
+    resetStorage();
+    await StorageService.setLastBalance(777_000);
+    const fresh = new ElectrumService();
+
+    const detailed = await fresh.getBalanceDetailed(P2PKH);
+
+    expect(detailed).toEqual({ balance: 777_000, source: 'stored' });
+  });
+
+  it('treats a stored zero as unknown, since storage cannot tell zero from absent', async () => {
+    resetStorage();
+    await StorageService.setLastBalance(0);
+    const fresh = new ElectrumService();
+
+    const detailed = await fresh.getBalanceDetailed(P2PKH);
+
+    expect(detailed.source).toBe('unknown');
+  });
+
+  it('keeps the plain getBalance shape for callers that only want a number', async () => {
+    resetStorage();
+    const fresh = new ElectrumService();
+
+    await expect(fresh.getBalance(P2PKH)).resolves.toBe(0);
   });
 });
 

--- a/src/services/core/ElectrumService.ts
+++ b/src/services/core/ElectrumService.ts
@@ -5,6 +5,14 @@ interface UTXO {
   height?: number;
 }
 
+/** Where a reported balance came from — see getBalanceDetailed. */
+export type BalanceSource = 'live' | 'cache' | 'stored' | 'unknown';
+
+export interface DetailedBalance {
+  balance: number;
+  source: BalanceSource;
+}
+
 interface BalanceResponse {
   confirmed: number;
   unconfirmed: number;
@@ -124,6 +132,11 @@ export class ElectrumService {
           electrumLogger.debug(`Connected to Electrum server: ${url}`);
 
           resolve();
+
+          // Server-side subscriptions die with the socket, so after a reconnect every address
+          // we were watching must be re-subscribed or balance updates silently stop arriving.
+          // Fire-and-forget: the connection is usable regardless of how re-subscription fares.
+          void this.resubscribeAll();
         };
 
         this.websocket.onclose = (event) => {
@@ -132,6 +145,13 @@ export class ElectrumService {
           electrumLogger.debug(
             `WebSocket closed: code=${event.code}, reason=${event.reason || 'unknown'}`,
           );
+
+          // If the socket closed before it ever opened, nothing else will settle the connect()
+          // promise: onopen never fires, and this handler clears isConnecting, which defuses
+          // the connection-timeout guard below. Without this reject, callers await forever and
+          // the app hangs on its loading screen whenever the server refuses the connection.
+          // (Rejecting an already-settled promise is a no-op, so later closes are harmless.)
+          reject(new Error(`Connection closed before opening (code ${event.code})`));
 
           // Attempt to reconnect if not manually closed and not already reconnecting
           if (
@@ -167,6 +187,38 @@ export class ElectrumService {
       this.isConnecting = false;
       electrumLogger.error('Failed to connect to Electrum server:', error);
       throw new Error('Connection failed');
+    }
+  }
+
+  /**
+   * Re-issues blockchain.scripthash.subscribe for every tracked subscription and delivers the
+   * current status to its callback. Downstream compares the status and refetches the balance,
+   * which also covers anything that changed while the connection was down.
+   */
+  private async resubscribeAll(): Promise<void> {
+    if (this.subscriptions.size === 0) {
+      return;
+    }
+
+    electrumLogger.info(
+      `Re-establishing ${this.subscriptions.size} address subscription(s) after reconnect`,
+    );
+
+    for (const [scriptHash, callback] of Array.from(this.subscriptions.entries())) {
+      try {
+        const status = await this.makeRequest('blockchain.scripthash.subscribe', [scriptHash]);
+        callback({
+          scripthash: scriptHash,
+          status,
+          method: 'blockchain.scripthash.subscribe',
+        });
+      } catch (error) {
+        electrumLogger.error(
+          `Failed to re-subscribe ${scriptHash.substring(0, 8)}… after reconnect:`,
+          error,
+        );
+        // Keep going: one failed re-subscription must not strand the others.
+      }
     }
   }
 
@@ -317,6 +369,20 @@ export class ElectrumService {
   }
 
   async getBalance(address: string, forceRefresh: boolean = false): Promise<number> {
+    return (await this.getBalanceDetailed(address, forceRefresh)).balance;
+  }
+
+  /**
+   * Like getBalance, but reports where the number came from. The fallback chain means a plain
+   * number is ambiguous — a 0 could be the server's answer or "we have no idea" — and the UI
+   * must not present the second as the first.
+   *
+   * - live:    the server answered just now
+   * - cache:   pushed to us by a subscription earlier in this session
+   * - stored:  persisted from a previous session; real, but possibly stale
+   * - unknown: nothing to go on — the balance should be shown as unavailable, not as 0
+   */
+  async getBalanceDetailed(address: string, forceRefresh: boolean = false): Promise<DetailedBalance> {
     try {
       // Log the balance request for debugging
       electrumLogger.debug(
@@ -329,7 +395,7 @@ export class ElectrumService {
         electrumLogger.debug(
           `Using cached balance for ${address.substring(0, 5)}...: ${cachedBalance}`,
         );
-        return cachedBalance;
+        return { balance: cachedBalance, source: 'cache' };
       }
 
       // Convert address to script hash for Electrum protocol
@@ -347,7 +413,7 @@ export class ElectrumService {
         `Balance retrieved for ${address.substring(0, 5)}...: ${totalBalance} (confirmed: ${response.confirmed}, unconfirmed: ${response.unconfirmed})`,
       );
 
-      return totalBalance;
+      return { balance: totalBalance, source: 'live' };
     } catch (error) {
       // Return cached balance if available
       const cachedBalance = this.realBalanceCache.get(address);
@@ -355,20 +421,26 @@ export class ElectrumService {
         electrumLogger.debug(
           `Failed to get balance from server, using cached balance for ${address.substring(0, 5)}...: ${cachedBalance}`,
         );
-        return cachedBalance;
+        return { balance: cachedBalance, source: 'cache' };
       }
 
-      // Last resort: check StorageService for persisted balance
+      // Next: a balance persisted by a previous session. A stored zero is indistinguishable
+      // from "nothing was ever stored" (the storage layer defaults to 0), so only a positive
+      // value counts as real data here.
       try {
         const { StorageService } = await import('./StorageService');
         const walletBalance = await StorageService.getWalletBalance(address);
-
-        return walletBalance;
+        if (walletBalance > 0) {
+          return { balance: walletBalance, source: 'stored' };
+        }
       } catch (storageError) {
-        // Final fallback: check localStorage for persisted balance
         const storedBalance = localStorage.getItem('avian_wallet_last_balance');
-        return storedBalance ? parseInt(storedBalance, 10) : 0;
+        if (storedBalance && parseInt(storedBalance, 10) > 0) {
+          return { balance: parseInt(storedBalance, 10), source: 'stored' };
+        }
       }
+
+      return { balance: 0, source: 'unknown' };
     }
   }
 

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -10,7 +10,7 @@ import { ECPairFactory } from 'ecpair';
 import * as ecc from 'tiny-secp256k1';
 import * as bip39 from 'bip39';
 import { BIP32Factory } from 'bip32';
-import { ElectrumService } from '../core/ElectrumService';
+import { ElectrumService, type DetailedBalance } from '../core/ElectrumService';
 import { StorageService } from '../core/StorageService';
 import { walletLogger } from '@/lib/Logger';
 import {
@@ -449,10 +449,22 @@ export class WalletService {
     }
 
     async getBalance(address: string, forceRefresh: boolean = false): Promise<number> {
+        return (await this.getBalanceDetailed(address, forceRefresh)).balance;
+    }
+
+    /**
+     * Balance plus its provenance. A bare number cannot distinguish "the server says 0" from
+     * "the server is unreachable and nothing is cached" — callers that display the balance
+     * should use this and treat 'unknown' as unavailable rather than as zero.
+     */
+    async getBalanceDetailed(
+        address: string,
+        forceRefresh: boolean = false,
+    ): Promise<DetailedBalance> {
         try {
-            return await this.electrum.getBalance(address, forceRefresh);
+            return await this.electrum.getBalanceDetailed(address, forceRefresh);
         } catch (error) {
-            return 0;
+            return { balance: 0, source: 'unknown' };
         }
     }
 


### PR DESCRIPTION
Two silent-failure bugs from the codebase review — both of a kind a user would read as *my money is gone* — plus a design doc for the lock-screen change we discussed.

## Balance updates died after any reconnect

`ElectrumService` reconnects with exponential backoff, but server-side subscriptions do not survive the socket, and nothing re-issued `blockchain.scripthash.subscribe` afterwards. After a network blip the wallet looked healthy and quietly stopped updating until a manual refresh. `connect()` now re-subscribes every tracked address on open and delivers the current status, which also picks up anything that changed while the connection was down.

## connect() could hang forever

Diagnosing the above surfaced a worse bug. If the socket closed *before it ever opened* — a refused or firewalled server — `connect()` never settled: `onopen` never fired, and the `onclose` handler cleared `isConnecting`, which defused the connection-timeout guard. Everything awaiting the connection hung, including app start-up, which sat on its loading screen indefinitely. `onclose` now rejects the pending `connect()`.

This is what the new E2E balance specs originally tripped over — the app hung with the server blocked.

## A network error was rendered as a balance of 0

`getBalance` caught failures and returned `0`, indistinguishable from a real empty wallet — so a flaky connection showed "0 AVN". `getBalanceDetailed` now reports provenance (`live` / `cache` / `stored` / `unknown`), the wallet context tracks a `balanceStatus`, and the balance card shows **"last known"** against a remembered figure and **"balance unavailable"** instead of a figure when there is genuinely nothing to show. A stored zero is treated as unknown, since the storage layer cannot tell zero from absent.

`getBalance` keeps its number-returning signature, so existing callers are untouched.

## Design doc: optional lock screen

`docs/proposals/optional-lock-screen.md` — **proposed, not implemented.** Captures the plan to load read-only wallet state without a password and require authentication only for actions that need the key, with the full lock screen kept as an opt-in.

The key finding, grounded in the code: `SecurityProvider` renders the lock screen *instead of* its children, so today the wallet subtree never mounts while locked. The change is to split `isLocked` into a UI wall and a credential-in-memory flag — an architectural change, not a bypass. The doc includes the security analysis (what the default model gives up), a test plan, and notes this PR's balance-status fix as a hard dependency.

## Tests

- **Scripted-WebSocket suite** (`ElectrumService.resubscribe.test.ts`): re-subscription across a reconnect (all addresses, not just the first), no reconnect after a deliberate disconnect, and the `connect()`-rejects-on-early-close regression.
- **ElectrumService suite:** each balance-provenance branch, including stored-zero → unknown.
- **E2E** (`balance.spec.ts`): the unavailable and last-known states driven in the real UI with the server blocked.

## Verification

- 526 unit tests, 25 E2E tests passing
- `tsc --noEmit` clean, zero lint errors
- Static export builds; the E2E suite runs against it
