### PR TITLE
Bound best-fit UTXO selection so large wallets don't freeze the tab

### DIFF
--- a/src/services/wallet/UTXOSelectionService.test.ts
+++ b/src/services/wallet/UTXOSelectionService.test.ts
@@ -543,3 +543,85 @@ describe('getRecommendedStrategy', () => {
     );
   });
 });
+
+describe('best fit on large wallets', () => {
+  const FEE = 10_000;
+
+  /** A wallet with `count` confirmed UTXOs of varied value. */
+  const largeWallet = (count: number) =>
+    Array.from({ length: count }, (_, i) =>
+      makeUTXO({ value: 20_000 + ((i * 7919) % 900_000), confirmations: 10 }),
+    );
+
+  it('selects from a 1000-UTXO wallet quickly instead of freezing', () => {
+    // The exhaustive C(n,4) search over 1000 UTXOs is ~41 billion combinations. Capped, this is
+    // a few tens of thousands and returns in milliseconds. A generous ceiling avoids CI flakiness
+    // while still failing loudly if the cap is ever removed.
+    const utxos = largeWallet(1_000);
+
+    const start = Date.now();
+    const result = select(utxos, {
+      targetAmount: 250_000,
+      feeRate: FEE,
+      strategy: CoinSelectionStrategy.BEST_FIT,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result).not.toBeNull();
+    expect(elapsed).toBeLessThan(1_000);
+    expect(result!.totalInput).toBeGreaterThanOrEqual(250_000 + FEE);
+    expect(UTXOSelectionService.validateSelection(result!, 250_000)).toBe(true);
+  });
+
+  it('still returns tight change on a large wallet', () => {
+    // A UTXO sized just above amount + fee exists in the pool; the boundary rule keeps it, so
+    // best-fit should pick it as a near-exact single-input match rather than a sprawl of inputs.
+    const target = 250_000;
+    const utxos = [
+      ...largeWallet(500),
+      makeUTXO({ value: target + FEE + 300, confirmations: 10 }), // change of exactly 300
+    ];
+
+    const result = select(utxos, {
+      targetAmount: target,
+      feeRate: FEE,
+      strategy: CoinSelectionStrategy.BEST_FIT,
+    })!;
+
+    expect(result.change).toBe(300);
+    expect(result.selectedUTXOs).toHaveLength(1);
+  });
+
+  it('finds a covering selection even when every UTXO is smaller than the target', () => {
+    // All building blocks below target, hundreds of them: the cap keeps the largest, which still
+    // combine to cover a multiple-input target.
+    const utxos = Array.from({ length: 400 }, () =>
+      makeUTXO({ value: 80_000, confirmations: 10 }),
+    );
+
+    const result = select(utxos, {
+      targetAmount: 250_000,
+      feeRate: FEE,
+      strategy: CoinSelectionStrategy.BEST_FIT,
+    })!;
+
+    expect(result).not.toBeNull();
+    expect(result.totalInput).toBeGreaterThanOrEqual(260_000);
+    for (const utxo of result.selectedUTXOs) {
+      expect(utxos.some((u) => u.txid === utxo.txid && u.vout === utxo.vout)).toBe(true);
+    }
+  });
+
+  it('returns null when a large wallet genuinely cannot cover the spend', () => {
+    const utxos = Array.from({ length: 300 }, () => makeUTXO({ value: 1_100, confirmations: 10 }));
+
+    const result = select(utxos, {
+      targetAmount: 1_000_000,
+      feeRate: FEE,
+      strategy: CoinSelectionStrategy.BEST_FIT,
+      maxInputs: 4,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/services/wallet/UTXOSelectionService.ts
+++ b/src/services/wallet/UTXOSelectionService.ts
@@ -466,6 +466,49 @@ export class UTXOSelectionService {
   }
 
   /**
+   * The most candidates best-fit will enumerate combinations over. The exhaustive search below is
+   * O(pool^4); left unbounded, a wallet with a few hundred UTXOs (common after receiving lots of
+   * small payments) generates hundreds of millions of arrays and freezes the tab. Capping the
+   * pool keeps the search to at most C(35,4) ≈ 52k combinations. Wallets at or below the cap are
+   * unaffected — they get the exact same exhaustive result as before.
+   */
+  private static readonly MAX_BEST_FIT_CANDIDATES = 35;
+
+  /**
+   * Reduces a large UTXO set to a bounded pool that still contains the combinations best-fit
+   * cares about — those producing the least change.
+   *
+   * Two kinds of candidate matter, and both are kept:
+   * - the smallest UTXOs at or above the target, which are the tightest single-input matches
+   *   (any single UTXO >= target has change = value - target, minimised by the smallest such);
+   * - the largest UTXOs below the target, which are the best building blocks for reaching it in
+   *   two to four inputs.
+   *
+   * This is a heuristic: it can miss an optimum that would need mid-range UTXOs combined across
+   * many inputs, but best-fit is capped at four inputs anyway, and selectBestFit falls back to a
+   * greedy selection when this returns nothing usable. The input is assumed sorted descending.
+   */
+  private static capBestFitCandidates(
+    sortedDesc: EnhancedUTXO[],
+    totalRequired: number,
+    cap: number,
+  ): EnhancedUTXO[] {
+    if (sortedDesc.length <= cap) {
+      return sortedDesc;
+    }
+
+    const atOrAbove = sortedDesc.filter((utxo) => utxo.value >= totalRequired);
+    const below = sortedDesc.filter((utxo) => utxo.value < totalRequired);
+
+    // Up to five tightest single-input matches (the smallest of the at-or-above group).
+    const boundary = atOrAbove.slice(Math.max(0, atOrAbove.length - 5));
+    // Fill the remaining budget with the largest building blocks below the target.
+    const buildingBlocks = below.slice(0, cap - boundary.length);
+
+    return [...boundary, ...buildingBlocks].sort((a, b) => b.value - a.value);
+  }
+
+  /**
    * Find best fit combination with minimal change
    */
   private static findBestFitCombination(
@@ -474,7 +517,14 @@ export class UTXOSelectionService {
     maxInputs: number,
   ): UTXOSelectionResult | null {
     // Sort by value descending for better branch and bound performance
-    const sorted = [...utxos].sort((a, b) => b.value - a.value);
+    const fullySorted = [...utxos].sort((a, b) => b.value - a.value);
+
+    // Bound the search so a large wallet cannot freeze the tab; small wallets are unaffected.
+    const sorted = this.capBestFitCandidates(
+      fullySorted,
+      totalRequired,
+      this.MAX_BEST_FIT_CANDIDATES,
+    );
 
     let bestResult: UTXOSelectionResult | null = null;
     let bestChange = Infinity;


### PR DESCRIPTION
The last item from the codebase review: best-fit UTXO selection could freeze — or crash — the tab on a wallet with many small UTXOs.

## The problem

`findBestFitCombination` enumerated **every** combination of up to four UTXOs via `generateCombinations` — an O(n⁴) exhaustive search that materialises all combinations up front. On a wallet with a few hundred UTXOs (common after receiving many small payments), that is tens of millions to billions of arrays.

A negative-control measurement of the old code:

| UTXOs | combinations | result |
| ----- | ------------ | ------ |
| 50 | 251k | 106 ms |
| 100 | 4.1M | 1,877 ms |
| 150 | — | **out of memory, process crashed** |

In a browser, 150 is a frozen or killed tab. A 300-UTXO wallet was unusable.

## The fix

Best-fit only wants the combination with the least change, and that does not require enumerating all of them. When the set exceeds a cap (35), it is first reduced to the candidates that actually produce minimal change:

- the few **smallest UTXOs at or above the target** — the tightest single-input matches (any single UTXO ≥ target has change = value − target, minimised by the smallest such);
- the **largest UTXOs below the target** — the best building blocks for reaching it in two to four inputs.

The exhaustive search then runs over at most C(35,4) ≈ 52k combinations and returns in milliseconds. A 1000-UTXO wallet now selects in well under a second.

**Wallets at or below the cap are untouched** and get the exact same result as before — all 50 existing selection tests pass unchanged.

The cap is a documented heuristic: it can miss an optimum that would need mid-range UTXOs combined across many inputs, but best-fit is capped at four inputs regardless, and `selectBestFit` already falls back to a greedy selection when this returns nothing usable.

## Tests

New coverage: a 1000-UTXO wallet selects quickly (< 1 s), a near-exact single-input match is still found on a large wallet, a covering selection is found when every UTXO is below target, and a genuinely unaffordable spend still returns null.

## Verification

- 542 unit tests passing (+4; the 50 existing selection tests unchanged)
- `tsc --noEmit` clean, zero lint errors
- Production export builds

The change is confined to one pure function; the end-to-end suite does not exercise coin selection (its fixture wallet holds no UTXOs), so it carries no signal for this change and was not run.
