### PR TITLE
Keep the secp256k1 build out of the initial bundle of most routes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,16 @@ import { useWallet } from '@/contexts/WalletContext';
 import { useSecurity } from '@/contexts/SecurityContext';
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import SendForm from '@/components/SendForm';
+import dynamic from 'next/dynamic';
+// SendForm builds and signs transactions, so it pulls the ~1.7 MB secp256k1 build. Loading it
+// lazily keeps the crypto out of the home page's initial bundle — the balance and history render
+// immediately, and the send UI (and its crypto) loads when the user opens the Send tab.
+const SendForm = dynamic(() => import('@/components/SendForm'), {
+    ssr: false,
+    loading: () => (
+        <div className="p-6 text-center text-sm text-muted-foreground">Loading send form…</div>
+    ),
+});
 import ReceiveContent from '@/components/ReceiveContent';
 import WalletSettingsDashboard from '@/components/WalletSettingsDashboard';
 import { TransactionHistory } from '@/components/TransactionHistory';

--- a/src/components/AuthenticationDialog.tsx
+++ b/src/components/AuthenticationDialog.tsx
@@ -3,7 +3,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { securityService } from '@/services/core/SecurityService';
 import { StorageService } from '@/services/core/StorageService';
-import { WalletService } from '@/services/wallet/WalletService';
+// WalletService is loaded lazily in the submit handler below. Importing it statically would pull
+// the ~1.7 MB secp256k1 build into the initial bundle, and this dialog is mounted app-wide by
+// SecurityProvider.
 import { Fingerprint, Lock, X, Eye, EyeOff } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
@@ -172,6 +174,7 @@ export default function AuthenticationDialog({
 
     try {
       // Verify the password against the wallet
+      const { WalletService } = await import('@/services/wallet/WalletService');
       const walletService = new WalletService();
 
       const isValid = await walletService.validateWalletPassword(password);

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { StorageService } from '@/services/core/StorageService';
-import { WalletService } from '@/services/wallet/WalletService';
+import { openTransactionInExplorer } from '@/lib/explorer';
 import { useWallet } from '@/contexts/WalletContext';
 import {
   ArrowUpRight,
@@ -350,7 +350,7 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
 
   const openExplorer = (txid: string) => {
     // Open the transaction in the Avian block explorer
-    WalletService.openTransactionInExplorer(txid);
+    openTransactionInExplorer(txid);
   };
 
   return (

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -9,7 +9,11 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
-import { WalletService } from '@/services/wallet/WalletService';
+// Type-only import: WalletService binds the ~1.7 MB secp256k1 build at module load, so it is
+// imported dynamically (below) rather than statically. Keeping only the type here means every
+// route no longer carries the crypto in its initial bundle — it loads asynchronously on mount,
+// after first paint, off the critical path.
+import type { WalletService } from '@/services/wallet/WalletService';
 import { ElectrumService } from '@/services/core/ElectrumService';
 import { StorageService } from '@/services/core/StorageService';
 import { TransactionClientService } from '@/services/notifications/client/TransactionClientService';
@@ -156,7 +160,8 @@ export function WalletProvider({ children }: WalletProviderProps) {
       const electrumService = new ElectrumService();
       setElectrum(electrumService);
 
-      // Create WalletService with shared ElectrumService
+      // Load the crypto-heavy WalletService lazily so it is not in the initial bundle.
+      const { WalletService } = await import('@/services/wallet/WalletService');
       const walletService = new WalletService(electrumService);
       setWallet(walletService);
 
@@ -991,6 +996,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
       addressType,
       changePath,
     ) => {
+      const { WalletService } = await import('@/services/wallet/WalletService');
       return WalletService.deriveAddressesWithBalances(
         mnemonic,
         passphrase,

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,0 +1,17 @@
+/**
+ * Block-explorer URL helpers.
+ *
+ * These are plain string/URL utilities with no crypto dependency. They live here rather than on
+ * WalletService so a read-only view — transaction history, for instance — can link to the
+ * explorer without importing the ~1.7 MB secp256k1 build that WalletService binds at load.
+ */
+
+const EXPLORER_BASE = 'https://flightpath.avn.network';
+
+export function getExplorerUrl(txid: string): string {
+  return `${EXPLORER_BASE}/tx/${txid}`;
+}
+
+export function openTransactionInExplorer(txid: string): void {
+  window.open(getExplorerUrl(txid), '_blank', 'noopener,noreferrer');
+}

--- a/src/services/core/BackupService.ts
+++ b/src/services/core/BackupService.ts
@@ -11,7 +11,7 @@ import {
   BackupValidationResult,
 } from '@/types/backup';
 import { toast } from 'sonner';
-import { secureEncrypt, decryptData } from '../wallet/WalletService';
+import { secureEncrypt, decryptData } from '../wallet/encryption';
 import { Logger } from '@/lib/Logger';
 
 export class BackupService {

--- a/src/services/core/ElectrumService.ts
+++ b/src/services/core/ElectrumService.ts
@@ -46,12 +46,7 @@ interface ElectrumNotification {
 }
 
 import * as bitcoin from 'bitcoinjs-lib';
-import { ECPairFactory } from 'ecpair';
-import * as ecc from 'tiny-secp256k1';
 import { electrumLogger } from '@/lib/Logger';
-
-// ECPair factory for working with key pairs
-const ECPair = ECPairFactory(ecc);
 
 // Avian network configuration (same as in WalletService)
 const avianNetwork: bitcoin.Network = {
@@ -842,6 +837,13 @@ export class ElectrumService {
    */
   async getPublicKeyForAddress(address: string): Promise<string | null> {
     try {
+      // ecpair + tiny-secp256k1 are loaded lazily here — this is the only method in the service
+      // that needs them, and it is rarely called, so keeping them out of the module's static
+      // imports removes ~1.7 MB from the read-only balance path that every route mounts.
+      const { ECPairFactory } = await import('ecpair');
+      const ecc = await import('tiny-secp256k1');
+      const ECPair = ECPairFactory(ecc);
+
       // Make sure we're connected
       if (!this.isConnected || !this.websocket) {
         await this.connect();

--- a/src/services/core/SecurityService.ts
+++ b/src/services/core/SecurityService.ts
@@ -9,8 +9,11 @@ import {
   SecurityState,
 } from '@/types/security';
 import { StorageService } from './StorageService';
-import { secureEncrypt, decryptData, isValidWIF, legacyDecrypt } from '../wallet/WalletService';
-import * as bip39 from 'bip39';
+// Encryption helpers come from the lean module so this service — instantiated eagerly by the
+// lock screen — does not pull the secp256k1 build. The elliptic-curve validation it needs on the
+// legacy-upgrade path is loaded lazily via initializeCrypto() below, and bip39 lazily at its one
+// use site, so neither is in the initial bundle.
+import { secureEncrypt, decryptData, legacyDecrypt } from '../wallet/encryption';
 import { securityLogger } from '@/lib/Logger';
 import { isBrowser } from '@/lib/utils';
 
@@ -768,8 +771,22 @@ export class SecurityService {
           // reliably fail — it can decrypt to plausible-looking rubbish. Checking that the
           // result is a usable key is the only way to tell the two apart, and it has to happen
           // before anything is written back: re-encrypting rubbish over the stored key would
-          // destroy the wallet outright.
-          if (!isValidWIF(decrypted)) {
+          // destroy the wallet outright. ECC is loaded lazily so it stays out of the initial
+          // bundle; validate the WIF here the same way validateWalletPassword does.
+          const { ECPair: ECPairLib } = await initializeCrypto();
+          try {
+            if (ECPairLib) {
+              ECPairLib.fromWIF(decrypted, getAvianNetwork());
+            } else if (
+              !(
+                decrypted.length >= 51 &&
+                decrypted.length <= 52 &&
+                /^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$/.test(decrypted)
+              )
+            ) {
+              throw new Error('invalid WIF');
+            }
+          } catch {
             throw new Error('Decrypted value is not a valid private key, password incorrect.');
           }
 
@@ -785,7 +802,9 @@ export class SecurityService {
                 // We can use the legacy decrypt directly since we know it's an old format
                 const decryptedMnemonic = legacyDecrypt(activeWallet.mnemonic, password);
                 // Same reasoning as the key above: only store something that is demonstrably
-                // a real mnemonic, or the user's recovery phrase is lost.
+                // a real mnemonic, or the user's recovery phrase is lost. bip39 is loaded lazily
+                // so it stays out of the initial bundle.
+                const bip39 = await import('bip39');
                 if (decryptedMnemonic && bip39.validateMnemonic(decryptedMnemonic)) {
                   newEncryptedMnemonic = await secureEncrypt(decryptedMnemonic, password);
                 }

--- a/src/services/core/StorageService.ts
+++ b/src/services/core/StorageService.ts
@@ -2,7 +2,10 @@
 import { SavedAddress } from '../../types/addressBook';
 import { OriginPermission } from '../../types/avianConnect';
 import { toast } from 'sonner';
-import { secureEncrypt, decryptData, type AddressType } from '../wallet/WalletService';
+import { secureEncrypt, decryptData } from '../wallet/encryption';
+// Type-only: erased at compile time, so it does not pull WalletService (and its secp256k1
+// dependency) into the bundle.
+import type { AddressType } from '../wallet/WalletService';
 import { storageLogger } from '@/lib/Logger';
 
 interface WalletData {

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -13,6 +13,7 @@ import { BIP32Factory } from 'bip32';
 import { ElectrumService, type DetailedBalance } from '../core/ElectrumService';
 import { StorageService } from '../core/StorageService';
 import { walletLogger } from '@/lib/Logger';
+import { getExplorerUrl, openTransactionInExplorer } from '@/lib/explorer';
 import {
     UTXOSelectionService,
     EnhancedUTXO,
@@ -21,77 +22,12 @@ import {
 } from './UTXOSelectionService';
 import * as bitcoinMessage from 'bitcoinjs-message';
 import { randomBytes, createHash, createCipheriv, createDecipheriv, createHmac } from 'crypto';
-import { scrypt, ProgressCallback } from 'scrypt-js';
-import * as CryptoJS from 'crypto-js';
+import { secureEncrypt, secureDecrypt, decryptData, legacyDecrypt } from './encryption';
 
-const scryptPromise = (
-    password: Buffer,
-    salt: Buffer,
-    N: number,
-    r: number,
-    p: number,
-    dkLen: number,
-): Promise<Buffer> => {
-    return new Promise((resolve, reject) => {
-        try {
-            walletLogger.debug('Starting scrypt key derivation with parameters:', {
-                passwordLength: password.length,
-                saltLength: salt.length,
-                N,
-                r,
-                p,
-                dkLen,
-            });
-
-            let hasStarted = false;
-            let lastProgress = 0;
-
-            // Based on the scrypt-js v3 documentation, the progress callback only receives one argument
-            // (the progress value between 0-1) and can return true to cancel the operation
-            const progressCallback = (progress: number): boolean | void => {
-                // Mark that we've received at least one callback
-                hasStarted = true;
-
-                // Only log progress occasionally to avoid too many logs
-                if (progress - lastProgress >= 0.1 || progress === 1) {
-                    walletLogger.debug(`Scrypt progress: ${Math.round(progress * 100)}%`);
-                    lastProgress = progress;
-                }
-
-                // Return false to continue (or undefined which is falsy)
-                return false;
-            };
-
-            // Call scrypt with our progress callback
-            scrypt(password, salt, N, r, p, dkLen, progressCallback)
-                .then((key) => {
-                    walletLogger.debug('Scrypt key derivation complete');
-                    resolve(Buffer.from(key));
-                })
-                .catch((error) => {
-                    walletLogger.error('Scrypt error:', error);
-                    reject(error);
-                });
-
-            // Add a safety check in case the callback is never called
-            setTimeout(() => {
-                if (!hasStarted) {
-                    walletLogger.error('Scrypt key derivation timed out - callback was never called');
-                    reject(new Error('Scrypt key derivation timed out - callback was never called'));
-                }
-            }, 10000); // 10 second timeout
-        } catch (e) {
-            // Catch any synchronous errors that might occur when starting scrypt
-            reject(
-                new Error(`Failed to initialize scrypt: ${e instanceof Error ? e.message : String(e)}`),
-            );
-        }
-    });
-};
-const ALGORITHM = 'aes-256-gcm';
-const IV_LENGTH = 16;
-const SALT_LENGTH = 64;
-const TAG_LENGTH = 16;
+// Re-exported so existing importers of these helpers from WalletService keep working. New code
+// that only needs encryption should import from './encryption' directly, to avoid pulling the
+// elliptic-curve dependencies this module binds at load.
+export { secureEncrypt, decryptData, legacyDecrypt } from './encryption';
 
 // Initialize ECPair and BIP32 with secp256k1
 const ECPair = ECPairFactory(ecc);
@@ -233,99 +169,9 @@ export function resolveSendAmounts(
     return { sendAmount, change };
 }
 
-export async function secureEncrypt(data: string, password: string): Promise<string> {
-    const salt = randomBytes(SALT_LENGTH);
-    const N = 16384,
-        r = 8,
-        p = 1,
-        dkLen = 32;
-    const key = await scryptPromise(Buffer.from(password, 'utf-8'), salt, N, r, p, dkLen);
-    const iv = randomBytes(IV_LENGTH);
-    const cipher = createCipheriv(ALGORITHM, key, iv);
-    const encrypted = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    return Buffer.concat([salt, iv, tag, encrypted]).toString('hex');
-}
 
-async function secureDecrypt(encryptedHex: string, password: string): Promise<string> {
-    const encryptedData = Buffer.from(encryptedHex, 'hex');
-    const salt = encryptedData.subarray(0, SALT_LENGTH);
-    const iv = encryptedData.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
-    const tag = encryptedData.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
-    const encrypted = encryptedData.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
-    const N = 16384,
-        r = 8,
-        p = 1,
-        dkLen = 32;
-    const key = await scryptPromise(Buffer.from(password, 'utf-8'), salt, N, r, p, dkLen);
-    const decipher = createDecipheriv(ALGORITHM, key, iv);
-    decipher.setAuthTag(tag);
-    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    return decrypted.toString('utf8');
-}
 
-/**
- * Legacy decryption using CryptoJS for backward compatibility
- */
-export function legacyDecrypt(encryptedData: string, password: string): string {
-    const decryptedBytes = CryptoJS.AES.decrypt(encryptedData, password);
-    const decryptedText = decryptedBytes.toString(CryptoJS.enc.Utf8);
-    if (!decryptedText) {
-        throw new Error('Legacy decryption failed or resulted in empty string.');
-    }
-    return decryptedText;
-}
 
-/**
- * Unified decryption function that handles both new (scrypt) and legacy (CryptoJS) formats.
- *
- * IMPORTANT — the two formats give very different guarantees:
- *
- * - The current format is AES-GCM, which is authenticated. A wrong password always throws.
- * - The legacy CryptoJS format is unauthenticated AES-CBC. There is nothing in the ciphertext
- *   to verify a password against, so a wrong password yields garbage plaintext. Usually that
- *   garbage is invalid UTF-8 and this function throws, but often enough to matter it decodes
- *   cleanly and is returned as if it were correct.
- *
- * So `wasLegacy: true` means "this value has not been authenticated". Callers must validate it
- * against what they expected — isValidWIF for a key, bip39.validateMnemonic for a mnemonic —
- * before trusting it, and certainly before writing it anywhere.
- *
- * @returns An object containing the decrypted data and a flag indicating if legacy format was used.
- */
-export async function decryptData(
-    encryptedData: string,
-    password: string,
-): Promise<{ decrypted: string; wasLegacy: boolean }> {
-    try {
-        // Attempt to decrypt using the new secure method first.
-        // This will fail on non-hex legacy data, triggering the catch block.
-        const decrypted = await secureDecrypt(encryptedData, password);
-        return { decrypted, wasLegacy: false };
-    } catch (secureError) {
-        // Log more useful information about the secure decryption failure
-        walletLogger.debug('Secure decryption failed, attempting legacy method', {
-            error: secureError instanceof Error ? secureError.message : 'Unknown error',
-            isHex: /^[0-9a-fA-F]+$/.test(encryptedData),
-            dataLength: encryptedData.length,
-        });
-
-        try {
-            // If secure decrypt fails, fall back to the legacy method.
-            const decrypted = legacyDecrypt(encryptedData, password);
-            return { decrypted, wasLegacy: true };
-        } catch (legacyError) {
-            // If both methods fail, the password is wrong or data is corrupt.
-            walletLogger.error('Decryption failed for both secure and legacy methods.', {
-                secureError: secureError instanceof Error ? secureError.message : 'Unknown error',
-                legacyError: legacyError instanceof Error ? legacyError.message : 'Unknown error',
-                isHex: /^[0-9a-fA-F]+$/.test(encryptedData),
-                dataLength: encryptedData.length,
-            });
-            throw new Error('Invalid password or corrupted data');
-        }
-    }
-}
 
 /**
  * Recover a secp256k1 public key from a Bitcoin-message signature.
@@ -1600,14 +1446,14 @@ export class WalletService {
     }
 
     // Utility method to open transaction in block explorer
+    // These delegate to the crypto-free helpers in lib/explorer so a read-only view can link to
+    // the explorer without importing this module. Kept here for existing callers.
     static openTransactionInExplorer(txid: string): void {
-        const explorerUrl = `https://flightpath.avn.network/tx/${txid}`;
-        window.open(explorerUrl, '_blank', 'noopener,noreferrer');
+        openTransactionInExplorer(txid);
     }
 
-    // Utility method to get explorer URL for a transaction
     static getExplorerUrl(txid: string): string {
-        return `https://flightpath.avn.network/tx/${txid}`;
+        return getExplorerUrl(txid);
     }
 
     // Utility method for testing WIF compatibility

--- a/src/services/wallet/encryption.ts
+++ b/src/services/wallet/encryption.ts
@@ -1,0 +1,160 @@
+/**
+ * Password-based encryption primitives, deliberately free of any elliptic-curve dependency.
+ *
+ * These helpers use only scrypt + AES-GCM (current format) and CryptoJS (legacy format). Keeping
+ * them in their own module — separate from WalletService, which binds ecpair/tiny-secp256k1 at
+ * module load — means StorageService, SecurityService and BackupService can encrypt and decrypt
+ * without dragging the ~1.7 MB secp256k1 build into the initial bundle of every route.
+ *
+ * Anything that needs actual key operations (signing, WIF validation, HD derivation) still lives
+ * in WalletService.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { scrypt } from 'scrypt-js';
+import * as CryptoJS from 'crypto-js';
+import { walletLogger } from '@/lib/Logger';
+
+const scryptPromise = (
+  password: Buffer,
+  salt: Buffer,
+  N: number,
+  r: number,
+  p: number,
+  dkLen: number,
+): Promise<Buffer> => {
+  return new Promise((resolve, reject) => {
+    try {
+      let hasStarted = false;
+      let lastProgress = 0;
+
+      // scrypt-js v3's progress callback receives a single 0..1 value and may return true to
+      // cancel. We only use it to detect that the derivation actually started.
+      const progressCallback = (progress: number): boolean | void => {
+        hasStarted = true;
+        if (progress - lastProgress >= 0.1 || progress === 1) {
+          walletLogger.debug(`Scrypt progress: ${Math.round(progress * 100)}%`);
+          lastProgress = progress;
+        }
+        return false;
+      };
+
+      scrypt(password, salt, N, r, p, dkLen, progressCallback)
+        .then((key) => resolve(Buffer.from(key)))
+        .catch((error) => {
+          walletLogger.error('Scrypt error:', error);
+          reject(error);
+        });
+
+      // Safety net in case the callback is never invoked.
+      setTimeout(() => {
+        if (!hasStarted) {
+          reject(new Error('Scrypt key derivation timed out - callback was never called'));
+        }
+      }, 10000);
+    } catch (e) {
+      reject(new Error(`Failed to initialize scrypt: ${e instanceof Error ? e.message : String(e)}`));
+    }
+  });
+};
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const SALT_LENGTH = 64;
+const TAG_LENGTH = 16;
+
+/** Scrypt work factors, shared by encrypt and decrypt so a value round-trips. */
+const SCRYPT = { N: 16384, r: 8, p: 1, dkLen: 32 } as const;
+
+export async function secureEncrypt(data: string, password: string): Promise<string> {
+  const salt = randomBytes(SALT_LENGTH);
+  const key = await scryptPromise(
+    Buffer.from(password, 'utf-8'),
+    salt,
+    SCRYPT.N,
+    SCRYPT.r,
+    SCRYPT.p,
+    SCRYPT.dkLen,
+  );
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([salt, iv, tag, encrypted]).toString('hex');
+}
+
+export async function secureDecrypt(encryptedHex: string, password: string): Promise<string> {
+  const encryptedData = Buffer.from(encryptedHex, 'hex');
+  const salt = encryptedData.subarray(0, SALT_LENGTH);
+  const iv = encryptedData.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const tag = encryptedData.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
+  const encrypted = encryptedData.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
+  const key = await scryptPromise(
+    Buffer.from(password, 'utf-8'),
+    salt,
+    SCRYPT.N,
+    SCRYPT.r,
+    SCRYPT.p,
+    SCRYPT.dkLen,
+  );
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
+/**
+ * Legacy decryption using CryptoJS for backward compatibility.
+ */
+export function legacyDecrypt(encryptedData: string, password: string): string {
+  const decryptedBytes = CryptoJS.AES.decrypt(encryptedData, password);
+  const decryptedText = decryptedBytes.toString(CryptoJS.enc.Utf8);
+  if (!decryptedText) {
+    throw new Error('Legacy decryption failed or resulted in empty string.');
+  }
+  return decryptedText;
+}
+
+/**
+ * Unified decryption that handles both the current (scrypt + AES-GCM) and legacy (CryptoJS)
+ * formats.
+ *
+ * IMPORTANT — the two formats give very different guarantees:
+ *
+ * - The current format is AES-GCM, which is authenticated. A wrong password always throws.
+ * - The legacy CryptoJS format is unauthenticated AES-CBC. There is nothing in the ciphertext to
+ *   verify a password against, so a wrong password yields garbage plaintext. Usually that garbage
+ *   is invalid UTF-8 and this throws, but often enough to matter it decodes cleanly and is
+ *   returned as if it were correct.
+ *
+ * So `wasLegacy: true` means "this value has not been authenticated". Callers must validate it
+ * against what they expected — isValidWIF for a key, bip39.validateMnemonic for a mnemonic —
+ * before trusting it, and certainly before writing it anywhere.
+ *
+ * @returns The decrypted data and whether the legacy format was used.
+ */
+export async function decryptData(
+  encryptedData: string,
+  password: string,
+): Promise<{ decrypted: string; wasLegacy: boolean }> {
+  try {
+    // The current format is hex; non-hex legacy data fails here and falls through.
+    const decrypted = await secureDecrypt(encryptedData, password);
+    return { decrypted, wasLegacy: false };
+  } catch (secureError) {
+    walletLogger.debug('Secure decryption failed, attempting legacy method', {
+      error: secureError instanceof Error ? secureError.message : 'Unknown error',
+    });
+
+    try {
+      const decrypted = legacyDecrypt(encryptedData, password);
+      return { decrypted, wasLegacy: true };
+    } catch (legacyError) {
+      walletLogger.error('Decryption failed for both secure and legacy methods.', {
+        secureError: secureError instanceof Error ? secureError.message : 'Unknown error',
+        legacyError: legacyError instanceof Error ? legacyError.message : 'Unknown error',
+      });
+      throw new Error('Invalid password or corrupted data');
+    }
+  }
+}


### PR DESCRIPTION
The last item from the codebase review, and the biggest user-visible one: the ~1.7 MB secp256k1 build was in the initial bundle of **every** route.

## Root cause

`WalletService` binds `ecpair` / `tiny-secp256k1` (the asm.js secp256k1 build) at module load — `const ECPair = ECPairFactory(ecc)` at the top level. It was statically reachable from the root layout's providers, so even `/terms` and `/about` shipped the whole crypto stack before first paint. Every route showed ~1.86 MB First Load JS.

## The change

The eager path is now free of it:

- **A lean `encryption.ts`** holds the scrypt + AES-GCM + CryptoJS helpers, which have no elliptic-curve dependency. `StorageService`, `BackupService` and `SecurityService` — all instantiated eagerly — import from it instead of from `WalletService`. `StorageService` keeps only a **type-only** import of `AddressType`, which is erased at compile time.
- **`SecurityService`** loads ECC lazily (it already had `initializeCrypto()` for exactly this purpose) for the legacy-upgrade WIF check, and `bip39` lazily at its one use site.
- **`ElectrumService`** loads `ecpair`/`tiny-secp256k1` lazily inside `getPublicKeyForAddress`, its only consumer — the read-only balance path no longer pulls them.
- **`WalletContext`** and **`AuthenticationDialog`** import `WalletService` dynamically, so it loads after first paint rather than blocking it.
- Explorer-URL helpers move to a crypto-free **`lib/explorer`**, freeing `TransactionHistory`, and the home page loads `SendForm` via `next/dynamic` so its crypto loads only when the Send tab is opened.

## Result — First Load JS

| Route | Before | After |
| ----- | ------ | ----- |
| `/` (balance + history render immediately) | 1.94 MB | **455 kB** |
| `/terms`, `/about`, `/settings` | ~1.86 MB | **~430 kB** |
| most `/settings/*` | ~1.86 MB | **~415–445 kB** |

A **77% cut** on the home page and every informational route.

Routes whose primary job *is* a key operation — `/onboarding`, `/settings/wallet`, `/settings/advanced`, `/connect` — still load crypto up front, because deferring it there would render a form that cannot function yet. Splitting those (lazy interactive components with loading states) is a natural follow-up.

## Verification

- 542 unit tests passing
- `tsc --noEmit` clean, zero lint errors
- Production export builds; measurements above are from it
- **End-to-end suite passing** — this matters here because the change alters import *timing* across the unlock, wallet-init and sign flows, and the E2E specs exercise all three (one popup test flaked under heavy system load during a 26-minute contended run; it passed in isolation and across a full re-run of its spec, and it rejects before any crypto is involved)
