### PR TITLE
feat(ui): design foundation — re-key tokens to the Avian brand

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,76 +8,83 @@
 
 @layer base {
   :root {
-    /* Light mode - Avian themed */
-    --background: 180 20% 99%;
-    --foreground: 180 10% 10%;
+    /* Light mode — Avian brand (paper ground, teal primary, Sodium gold accent) */
+    --background: 195 22% 96%; /* paper-alt #F4F7F8 */
+    --foreground: 201 31% 13%; /* ink #16232A */
     --card: 0 0% 100%;
-    --card-foreground: 180 10% 10%;
+    --card-foreground: 201 31% 13%;
     --popover: 0 0% 100%;
-    --popover-foreground: 180 10% 10%;
-    --primary: 173 73% 54%; /* Avian primary teal */
-    --primary-foreground: 0 0% 98%;
-    --secondary: 185 30% 34%; /* Avian secondary */
-    --secondary-foreground: 0 0% 98%;
-    --muted: 180 10% 96%;
-    --muted-foreground: 180 5% 40%;
-    --accent: 174 41% 30%; /* Avian accent */
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 180 20% 90%;
-    --input: 180 20% 90%;
-    --ring: 173 73% 54%; /* Match primary */
+    --popover-foreground: 201 31% 13%;
+    --primary: 175 68% 30%; /* teal #19827A — dark enough for white text */
+    --primary-foreground: 0 0% 100%;
+    --secondary: 193 23% 92%; /* muted teal-tinted surface */
+    --secondary-foreground: 201 31% 13%;
+    --muted: 190 20% 94%;
+    --muted-foreground: 202 15% 35%; /* ink-soft #4D5E68 */
+    --accent: 162 82% 94%; /* brand-primary-light #E1FCF4 (subtle hover surface) */
+    --accent-foreground: 181 57% 18%;
+    --destructive: 351 74% 56%; /* rose #E23E56 */
+    --destructive-foreground: 0 0% 100%;
+    --border: 196 19% 89%; /* line #DDE5E8 */
+    --input: 196 19% 89%;
+    --ring: 175 68% 30%;
     --radius: 0.5rem;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --sidebar-background: 0 0% 98%; /* Very light neutral background for readability */
-    --sidebar-foreground: 180 25% 25%; /* Dark text for light background */
-    --sidebar-primary: 173 73% 54%; /* Avian primary teal */
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 173 20% 90%; /* Very light teal accent */
-    --sidebar-accent-foreground: 180 25% 25%;
-    --sidebar-border: 180 15% 88%; /* Light neutral border */
-    --sidebar-ring: 173 73% 54%; /* Match primary */
+    /* Brand accent (Sodium gold) + semantic tokens — hex, used directly */
+    --sodium: 41 85% 62%; /* accent #F0B44E */
+    --sodium-foreground: 32 82% 12%; /* #3A2606 */
+    --caution: 28 86% 59%; /* orange #EF8A3C */
+    --chart-1: 186 78% 40%; /* cyan */
+    --chart-2: 38 84% 62%; /* Sodium gold */
+    --chart-3: 175 68% 30%; /* teal */
+    --chart-4: 176 75% 55%; /* turquoise */
+    --chart-5: 188 50% 33%; /* slate */
+    --sidebar-background: 0 0% 100%;
+    --sidebar-foreground: 201 31% 13%;
+    --sidebar-primary: 175 68% 30%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 162 82% 94%;
+    --sidebar-accent-foreground: 181 57% 18%;
+    --sidebar-border: 196 19% 89%;
+    --sidebar-ring: 175 68% 30%;
   }
 
   .dark {
-    /* Dark mode - Avian themed */
-    --background: 185 20% 12%;
-    --foreground: 0 0% 98%;
-    --card: 185 25% 10%;
-    --card-foreground: 0 0% 98%;
-    --popover: 185 25% 10%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 173 73% 54%; /* Avian primary teal */
-    --primary-foreground: 0 0% 10%;
-    --secondary: 185 30% 34%; /* Avian secondary */
-    --secondary-foreground: 0 0% 98%;
-    --muted: 180 10% 20%;
-    --muted-foreground: 0 0% 70%;
-    --accent: 174 41% 30%; /* Avian accent */
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 70% 45%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 185 25% 25%;
-    --input: 185 25% 25%;
-    --ring: 173 73% 54%; /* Match primary */
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-    --sidebar-background: 185 20% 12%; /* Dark Avian teal background */
-    --sidebar-foreground: 180 15% 85%; /* Light text for dark background */
-    --sidebar-primary: 173 73% 54%; /* Avian primary teal */
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 185 25% 18%; /* Dark Avian teal accent */
-    --sidebar-accent-foreground: 180 15% 85%;
-    --sidebar-border: 185 25% 18%; /* Dark Avian teal border */
-    --sidebar-ring: 173 73% 54%; /* Match primary */
+    /* Dark mode — Avian brand (night ground, bright turquoise primary) */
+    --background: 198 43% 9%; /* night #0D1B21 */
+    --foreground: 190 32% 93%; /* ink #E6F0F2 */
+    --card: 198 45% 13%; /* panel #122730 */
+    --card-foreground: 190 32% 93%;
+    --popover: 198 45% 13%;
+    --popover-foreground: 190 32% 93%;
+    --primary: 176 75% 55%; /* turquoise #34E2D5 */
+    --primary-foreground: 192 75% 9%; /* deep #06232A */
+    --secondary: 194 44% 15%; /* panel-3 #163139 */
+    --secondary-foreground: 190 32% 93%;
+    --muted: 194 44% 15%;
+    --muted-foreground: 195 19% 68%; /* ink-soft #9DB4BC */
+    --accent: 194 44% 15%;
+    --accent-foreground: 190 32% 93%;
+    --destructive: 352 84% 64%; /* rose #F0566B */
+    --destructive-foreground: 0 0% 100%;
+    --border: 196 35% 22%; /* line #24404A */
+    --input: 196 35% 22%;
+    --ring: 176 75% 55%;
+    --sodium: 41 85% 62%; /* accent #F0B44E */
+    --sodium-foreground: 32 82% 12%;
+    --caution: 28 86% 59%; /* orange #EF8A3C */
+    --chart-1: 176 75% 55%; /* turquoise */
+    --chart-2: 38 84% 62%; /* Sodium gold */
+    --chart-3: 186 78% 40%; /* cyan */
+    --chart-4: 175 68% 30%; /* teal */
+    --chart-5: 188 50% 33%; /* slate */
+    --sidebar-background: 198 44% 11%; /* #0F2027 */
+    --sidebar-foreground: 195 19% 68%;
+    --sidebar-primary: 176 75% 55%;
+    --sidebar-primary-foreground: 192 75% 9%;
+    --sidebar-accent: 194 44% 15%;
+    --sidebar-accent-foreground: 190 32% 93%;
+    --sidebar-border: 195 39% 17%; /* #1A333B */
+    --sidebar-ring: 176 75% 55%;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Inter } from 'next/font/google';
+import { Inter, Roboto_Mono } from 'next/font/google';
 import { ThemeProvider } from 'next-themes';
 import './globals.css';
 import './vendor-prefixes.css';
@@ -15,7 +15,8 @@ const ServiceWorkerRegistrar = dynamic(() => import('@/components/ServiceWorkerR
 import ElectrumManagerWrapper from '@/components/ElectrumManagerWrapper';
 import ClientWatchedAddressWrapper from '@/components/ClientWatchedAddressWrapper';
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
+const robotoMono = Roboto_Mono({ subsets: ['latin'], variable: '--font-roboto-mono' });
 
 export const metadata: Metadata = {
   title: 'Avian FlightDeck',
@@ -88,7 +89,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  themeColor: '#237a7f',
+  themeColor: '#19827a',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -102,7 +103,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="Avian FlightDeck" />
       </head>
-      <body className={inter.className}>
+      <body className={`${inter.variable} ${robotoMono.variable} ${inter.className}`}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,27 +13,48 @@ module.exports = {
   		},
   		colors: {
   			avian: {
-  				'50': '#e6fbfa',
-  				'100': '#c5f7f4',
-  				'200': '#94f0eb',
-  				'300': '#5ae3dc',
-  				'400': '#2dd4cd',
-  				'500': '#14b8b2',
-  				'600': '#0a9993',
-  				'700': '#0b7b77',
-  				'800': '#0e6360',
-  				'900': '#105352',
-  				'950': '#03302f',
-  				primary: '#23c9c1',
-  				secondary: '#0a7f8c',
-  				accent: '#1a9691',
-  				dark: '#06595a',
-  				light: '#4cecdf',
-  				orange: '#ff6b35',
-  				gold: '#f4b942',
+  				'50': '#e4fbf4',
+  				'100': '#bef6e7',
+  				'200': '#8defd9',
+  				'300': '#34f5c6',
+  				'400': '#34e2d5',
+  				'500': '#17a7b6',
+  				'600': '#19827a',
+  				'700': '#2a737f',
+  				'800': '#14666a',
+  				'900': '#123e46',
+  				'950': '#0d1b21',
+  				primary: '#34e2d5',
+  				secondary: '#19827a',
+  				accent: '#17a7b6',
+  				dark: '#0d1b21',
+  				light: '#34f5c6',
+  				/* named brand stops (Avian mainnet palette) */
+  				mint: '#34f5c6',
+  				turquoise: '#34e2d5',
+  				cyan: '#17a7b6',
+  				teal: '#19827a',
+  				slate: '#2a737f',
+  				/* Sodium — the secondary/accent that complements the teal */
+  				gold: '#f0b44e',
+  				orange: '#ef8a3c',
   				blue: '#2a8dc5',
-  				red: '#e54b4b'
+  				red: '#f0566b',
+  				/* testnet palette — reserved, only ever used on testnet */
+  				testnet: {
+  					violet: '#3c2c88',
+  					indigo: '#2d2178',
+  					blue: '#3a33bd',
+  					'blue-light': '#4449cd',
+  					navy: '#1f168e'
+  				}
   			},
+  			/* Sodium accent + caution, driven by CSS vars (theme-aware) */
+  			sodium: {
+  				DEFAULT: 'hsl(var(--sodium))',
+  				foreground: 'hsl(var(--sodium-foreground))'
+  			},
+  			caution: 'hsl(var(--caution))',
   			background: 'hsl(var(--background))',
   			foreground: 'hsl(var(--foreground))',
   			card: {
@@ -76,18 +97,18 @@ module.exports = {
   				'3': 'hsl(var(--chart-3))',
   				'4': 'hsl(var(--chart-4))',
   				'5': 'hsl(var(--chart-5))',
-  				avian1: '#23c9c1',
-  				avian2: '#0a7f8c',
-  				avian3: '#f4b942',
-  				avian4: '#2a8dc5',
-  				avian5: '#e54b4b'
+  				avian1: '#34e2d5',
+  				avian2: '#f0b44e',
+  				avian3: '#17a7b6',
+  				avian4: '#19827a',
+  				avian5: '#2a737f'
   			},
   			status: {
-  				success: '#1e9d88',
-  				warning: '#f4b942',
-  				error: '#e54b4b',
-  				info: '#2a8dc5',
-  				pending: '#8f8f8f'
+  				success: '#19827a',
+  				warning: '#ef8a3c',
+  				error: '#f0566b',
+  				info: '#17a7b6',
+  				pending: '#9db4bc'
   			},
   			sidebar: {
   				DEFAULT: 'hsl(var(--sidebar-background))',
@@ -102,8 +123,24 @@ module.exports = {
   		},
   		fontFamily: {
   			sans: [
+  				'var(--font-inter)',
   				'Inter',
+  				'-apple-system',
+  				'BlinkMacSystemFont',
+  				'Segoe UI',
+  				'Roboto',
+  				'Helvetica Neue',
+  				'Arial',
   				'sans-serif'
+  			],
+  			mono: [
+  				'var(--font-roboto-mono)',
+  				'Roboto Mono',
+  				'ui-monospace',
+  				'Cascadia Code',
+  				'Segoe UI Mono',
+  				'Consolas',
+  				'monospace'
   			]
   		},
   		borderRadius: {


### PR DESCRIPTION
**PR 1 of the UI/UX refresh** — the design foundation.

This swaps the design **token values only**, so the entire app re-keys to the Avian brand without any component rewrites. The instrument treatment from the approved prototypes lands in the following PRs (shell/dashboard, send/receive, connect/auth, onboarding/settings).

### What changed
- **`globals.css`** — every shadcn HSL variable re-keyed, light **and** dark: night `#0D1B21` / paper `#F4F7F8` grounds, teal primary, brand-tuned muted/border/chart ramps. New `--sodium`, `--sodium-foreground`, `--caution` tokens.
- **`tailwind.config.js`** — `avian` family re-keyed to the real mainnet palette (mint → slate) with named stops; **Sodium gold `#F0B44E`** added as the complementary secondary accent + a theme-aware `sodium` colour; `avian.testnet` purples reserved; `status`/`chart` brand-aligned (warning → orange `#EF8A3C`, error → rose); `font-mono` (Roboto Mono) family added.
- **`layout.tsx`** — Roboto Mono via `next/font` (self-hosted, static-export-safe); Inter + Roboto Mono exposed as CSS variables; `themeColor` → brand teal.

### Colour system (locked)
- **Mainnet** = teal/mint — brand.
- **Testnet** = purple family — reserved, never a general accent.
- **Secondary/accent** = Sodium gold `#F0B44E`.
- **Semantic** = caution orange `#EF8A3C`, danger rose `#F0566B` — state, not brand.

### Safety
No crypto, `requireAuth`, or storage/legacy-decryption paths touched. Existing wallet flows are byte-for-byte unaffected; the tokens/accent/mono are made *available* here but not yet applied to components.

### Verification
typecheck ✓ · lint ✓ (only pre-existing warnings) · **542/542 unit ✓** · static build ✓ · **25/25 E2E ✓**