### PR TITLE
feat(ui): app shell + dashboard — the balance instrument

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -266,6 +266,36 @@
   animation-name: slide-in-right;
 }
 
+/* Flight-deck instrument primitives — reusable across the refreshed UI.
+   These describe the always-dark "cockpit surface" look (balance readout,
+   annunciators, horizon) and are theme-independent by design. */
+@layer components {
+  .fd-label {
+    font-family: var(--font-roboto-mono), ui-monospace, monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    font-size: 0.64rem;
+    line-height: 1.4;
+  }
+  .fd-readout {
+    font-family: var(--font-roboto-mono), ui-monospace, monospace;
+    font-variant-numeric: tabular-nums;
+  }
+  .fd-glow-teal {
+    text-shadow: 0 0 22px rgba(52, 226, 213, 0.32);
+  }
+  .fd-lamp {
+    box-shadow:
+      0 0 0 2px rgba(52, 245, 198, 0.15),
+      0 0 10px 1px rgba(52, 245, 198, 0.85);
+  }
+  .fd-lamp-amber {
+    box-shadow:
+      0 0 0 2px rgba(239, 138, 60, 0.15),
+      0 0 10px 1px rgba(239, 138, 60, 0.85);
+  }
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,13 +4,10 @@ import {
     Wallet,
     Send,
     QrCode,
-    Settings,
-    RefreshCw,
     History,
     Loader,
     Lock,
     Unlock,
-    Copy,
     HelpCircle,
     Server,
 } from 'lucide-react';
@@ -33,14 +30,14 @@ import WalletSettingsDashboard from '@/components/WalletSettingsDashboard';
 import { TransactionHistory } from '@/components/TransactionHistory';
 import ConnectionStatus from '@/components/ConnectionStatus';
 import ThemeSwitcher from '@/components/ThemeSwitcher';
-import GradientBackground from '@/components/GradientBackground';
 import WelcomeDialog from '@/components/WelcomeDialog';
 import AboutModal from '@/components/AboutModal';
 import { AppLayout } from '@/components/AppLayout';
+import { BalanceInstrument } from '@/components/BalanceInstrument';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export default function Home() {
@@ -234,99 +231,22 @@ export default function Home() {
             <div className="block lg:hidden max-w-xl md:max-w-2xl space-y-6">
                 {/* Mobile layout */}
 
-                {/* Wallet Card */}
-                <Card className="mb-6 wallet-card relative bg-avian-600">
-                    <CardHeader className="py-3 px-4 relative z-10">
-                        <div className="flex justify-between items-center">
-                            <CardTitle className="text-base sm:text-lg md:text-xl text-white">
-                                Balance
-                            </CardTitle>
-                            <Button
-                                onClick={handleRefresh}
-                                onMouseDown={handleRefreshMouseDown}
-                                onMouseUp={handleRefreshMouseUp}
-                                onMouseLeave={handleRefreshMouseUp}
-                                onTouchStart={handleRefreshMouseDown}
-                                onTouchEnd={handleRefreshMouseUp}
-                                disabled={isRefreshing}
-                                variant="ghost"
-                                size="icon"
-                                className="h-7 w-7 md:h-8 md:w-8 text-white hover:text-white/80"
-                                title="Refresh balance (hold for full refresh)"
-                            >
-                                <RefreshCw
-                                    className={`w-3 h-3 md:w-4 md:h-4 ${isRefreshing ? 'animate-spin' : ''}`}
-                                />
-                            </Button>
-                        </div>
-                    </CardHeader>
-                    <CardContent className="relative z-10">
-                        <div className="text-xl md:text-2xl lg:text-3xl font-bold mb-2 flex items-center flex-wrap text-white">
-                            {isLoading && !processingProgress.isProcessing ? (
-                                'Loading...'
-                            ) : balanceStatus === 'unknown' ? (
-                                // No confirmed or cached figure exists; showing 0 here would
-                                // read as "your funds are gone" on a flaky connection.
-                                <span data-testid="balance-unavailable" className="flex items-baseline">
-                                    —
-                                    <span className="ml-2 text-xs font-normal opacity-80">balance unavailable</span>
-                                </span>
-                            ) : (
-                                <>
-                                    {`${formatBalance(balance)} AVN`}
-                                    {balanceStatus === 'stale' && (
-                                        <span
-                                            data-testid="balance-stale"
-                                            className="ml-2 text-xs font-normal opacity-80"
-                                            title="Shown from the last successful update; the server has not confirmed it yet"
-                                        >
-                                            last known
-                                        </span>
-                                    )}
-                                    {processingProgress.isProcessing && (
-                                        <Loader className="w-4 h-4 md:w-5 md:h-5 ml-2 animate-spin opacity-70" />
-                                    )}
-                                </>
-                            )}
-                        </div>
-                        <div className="text-xs md:text-sm font-mono flex items-center space-x-1 text-white/90">
-                            <span className="truncate max-w-[180px] sm:max-w-[220px] md:max-w-[300px]">
-                                {address ? address : 'No wallet loaded'}
-                            </span>
-                            {address && (
-                                <button
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                        handleCopyAddress(address);
-                                    }}
-                                    className="p-1 text-white/90 hover:text-white rounded hover:bg-white/10 transition-colors flex-shrink-0"
-                                    title="Copy address to clipboard"
-                                >
-                                    <Copy
-                                        size={14}
-                                        className={`md:w-4 md:h-4 ${copiedAddress === address ? 'text-green-300' : ''}`}
-                                    />
-                                </button>
-                            )}
-                        </div>
-                        {processingProgress.isProcessing && (
-                            <div className="text-xs mt-2 bg-white/20 p-2 rounded border border-white/30 text-white">
-                                <div className="flex items-center flex-wrap">
-                                    <Loader className="w-3 h-3 mr-1.5 animate-spin text-white flex-shrink-0" />
-                                    <span className="font-medium text-white">
-                                        Processing... {processingProgress.processed}/{processingProgress.total}
-                                    </span>
-                                </div>
-                                {processingProgress.currentTx && (
-                                    <div className="truncate mt-1 pl-4 text-white/80">
-                                        TX: {processingProgress.currentTx.slice(0, 6)}...
-                                    </div>
-                                )}
-                            </div>
-                        )}
-                    </CardContent>
-                </Card>
+                {/* Balance instrument */}
+                <BalanceInstrument
+                    className="mb-6"
+                    balance={balance}
+                    balanceStatus={balanceStatus}
+                    address={address ?? null}
+                    isLoading={isLoading}
+                    processingProgress={processingProgress}
+                    isRefreshing={isRefreshing}
+                    copied={copiedAddress === address}
+                    formatBalance={formatBalance}
+                    onRefresh={handleRefresh}
+                    onRefreshMouseDown={handleRefreshMouseDown}
+                    onRefreshMouseUp={handleRefreshMouseUp}
+                    onCopy={handleCopyAddress}
+                />
 
                 {/* Navigation Tabs */}
                 <Tabs
@@ -339,21 +259,21 @@ export default function Home() {
                     <TabsList className="flex h-auto bg-background p-0 w-full">
                         <TabsTrigger
                             value="send"
-                            className="flex-1 flex flex-col items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-background rounded-tl-lg text-gray-500 dark:text-gray-400 h-auto relative"
+                            className="flex-1 flex flex-col items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:after:h-0.5 data-[state=active]:after:bg-primary data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-background rounded-tl-lg text-muted-foreground h-auto relative"
                         >
                             <Send className="h-4 w-4 mr-2" />
                             <span>Send</span>
                         </TabsTrigger>
                         <TabsTrigger
                             value="receive"
-                            className="flex-1 flex  flex-col items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-background rounded-none text-gray-500 dark:text-gray-400 h-auto relative"
+                            className="flex-1 flex  flex-col items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:after:h-0.5 data-[state=active]:after:bg-primary data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-background rounded-none text-muted-foreground h-auto relative"
                         >
                             <QrCode className="h-4 w-4 mr-2" />
                             <span>Receive</span>
                         </TabsTrigger>
                         <TabsTrigger
                             value="history"
-                            className="flex-1 flex flex-col items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-background rounded-br-lg rounded-tr-lg text-gray-500 dark:text-gray-400 h-auto relative"
+                            className="flex-1 flex flex-col items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:after:h-0.5 data-[state=active]:after:bg-primary data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-background rounded-br-lg rounded-tr-lg text-muted-foreground h-auto relative"
                         >
                             <History className="h-4 w-4 mr-2" />
                             <span>History</span>
@@ -385,101 +305,28 @@ export default function Home() {
 
             {/* Desktop Multi-Panel Dashboard */}
             <div className="hidden lg:block lg:max-w-7xl">
-                {/* Wallet Balance Card - Full Width */}
-                <Card className="wallet-card relative bg-avian-600 mb-8">
-                    <CardHeader className="py-3 px-4 relative z-10">
-                        <div className="flex justify-between items-center">
-                            <CardTitle className="text-xl text-white">Balance</CardTitle>
-                            <Button
-                                onClick={handleRefresh}
-                                onMouseDown={handleRefreshMouseDown}
-                                onMouseUp={handleRefreshMouseUp}
-                                onMouseLeave={handleRefreshMouseUp}
-                                onTouchStart={handleRefreshMouseDown}
-                                onTouchEnd={handleRefreshMouseUp}
-                                disabled={isRefreshing}
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8 text-white hover:text-white/80"
-                                title="Refresh balance (hold for full refresh)"
-                            >
-                                <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-                            </Button>
-                        </div>
-                    </CardHeader>
-                    <CardContent className="relative z-10">
-                        <div className="text-2xl lg:text-3xl font-bold mb-2 flex items-center text-white">
-                            {isLoading && !processingProgress.isProcessing ? (
-                                'Loading...'
-                            ) : balanceStatus === 'unknown' ? (
-                                <span data-testid="balance-unavailable" className="flex items-baseline">
-                                    —
-                                    <span className="ml-2 text-xs font-normal opacity-80">balance unavailable</span>
-                                </span>
-                            ) : (
-                                <>
-                                    <span className="break-all whitespace-normal overflow-hidden">
-                                        {`${formatBalance(balance)} AVN`}
-                                    </span>
-                                    {balanceStatus === 'stale' && (
-                                        <span
-                                            data-testid="balance-stale"
-                                            className="ml-2 text-xs font-normal opacity-80"
-                                            title="Shown from the last successful update; the server has not confirmed it yet"
-                                        >
-                                            last known
-                                        </span>
-                                    )}
-                                    {processingProgress.isProcessing && (
-                                        <Loader className="w-5 h-5 ml-2 flex-shrink-0 animate-spin opacity-70" />
-                                    )}
-                                </>
-                            )}
-                        </div>
-                        <div className="text-sm font-mono flex items-center space-x-1 text-white/90">
-                            <span className="truncate max-w-[300px]">
-                                {address ? address : 'No wallet loaded'}
-                            </span>
-                            {address && (
-                                <button
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                        handleCopyAddress(address);
-                                    }}
-                                    className="p-1 text-white/90 hover:text-white rounded hover:bg-white/10 transition-colors flex-shrink-0"
-                                    title="Copy address to clipboard"
-                                >
-                                    <Copy
-                                        size={14}
-                                        className={`w-4 h-4 ${copiedAddress === address ? 'text-green-300' : ''}`}
-                                    />
-                                </button>
-                            )}
-                        </div>
-                        {processingProgress.isProcessing && (
-                            <div className="text-xs mt-2 bg-white/20 p-2 rounded border border-white/30 text-white">
-                                <div className="flex items-center flex-wrap">
-                                    <Loader className="w-3 h-3 mr-1.5 animate-spin text-white flex-shrink-0" />
-                                    <span className="font-medium text-white">
-                                        Processing... {processingProgress.processed}/{processingProgress.total}
-                                    </span>
-                                </div>
-                                {processingProgress.currentTx && (
-                                    <div className="truncate mt-1 pl-4 text-white/80">
-                                        TX: {processingProgress.currentTx.slice(0, 6)}...
-                                    </div>
-                                )}
-                            </div>
-                        )}
-                    </CardContent>
-                </Card>
+                {/* Balance instrument - Full Width */}
+                <BalanceInstrument
+                    className="mb-8"
+                    balance={balance}
+                    balanceStatus={balanceStatus}
+                    address={address ?? null}
+                    isLoading={isLoading}
+                    processingProgress={processingProgress}
+                    isRefreshing={isRefreshing}
+                    copied={copiedAddress === address}
+                    formatBalance={formatBalance}
+                    onRefresh={handleRefresh}
+                    onRefreshMouseDown={handleRefreshMouseDown}
+                    onRefreshMouseUp={handleRefreshMouseUp}
+                    onCopy={handleCopyAddress}
+                />
 
                 <div className="grid grid-cols-12 gap-8">
                     {/* Send Panel - Left top */}
                     <div className="col-span-12 lg:col-span-6 xl:col-span-6">
                         <Card className="h-full rounded-none rounded-t-md">
-                            <CardHeader className="py-3 px-4 bg-gradient-to-r from-avian-400 via-avian-700 to-avian-400 text-white flex items-center rounded-t-md">
+                            <CardHeader className="flex flex-row items-center gap-2 border-b border-border/60 bg-card px-4 py-3 text-foreground [&_svg]:text-primary rounded-t-md">
                                 <Send className="h-5 w-5 mr-2 flex-shrink-0" />
                                 <CardTitle className="text-lg">Send AVN</CardTitle>
                             </CardHeader>
@@ -492,7 +339,7 @@ export default function Home() {
                     {/* Receive Panel - Right top */}
                     <div className="col-span-12 lg:col-span-6 xl:col-span-6">
                         <Card className="h-full rounded-t-md">
-                            <CardHeader className="py-3 px-4 bg-gradient-to-r from-avian-400 via-avian-700 to-avian-400 text-white flex items-center rounded-t-md">
+                            <CardHeader className="flex flex-row items-center gap-2 border-b border-border/60 bg-card px-4 py-3 text-foreground [&_svg]:text-primary rounded-t-md">
                                 <QrCode className="h-5 w-5 mr-2 flex-shrink-0" />
                                 <CardTitle className="text-lg">Receive AVN</CardTitle>
                             </CardHeader>
@@ -505,7 +352,7 @@ export default function Home() {
                     {/* Transaction History - Full width bottom */}
                     <div className="col-span-12">
                         <Card className="h-full rounded-t-md">
-                            <CardHeader className="py-3 px-4 bg-gradient-to-r from-avian-400 via-avian-700 to-avian-400 text-white flex items-center rounded-t-md">
+                            <CardHeader className="flex flex-row items-center gap-2 border-b border-border/60 bg-card px-4 py-3 text-foreground [&_svg]:text-primary rounded-t-md">
                                 <History className="h-5 w-5 mr-2 flex-shrink-0" />
                                 <CardTitle className="text-lg">Transaction History</CardTitle>
                             </CardHeader>
@@ -518,7 +365,7 @@ export default function Home() {
                     {/* Connection Status - Full width at bottom */}
                     <div className="col-span-12">
                         <Card className="h-full rounded-t-md">
-                            <CardHeader className="py-3 px-4 bg-gradient-to-r from-avian-400 via-avian-700 to-avian-400 text-white flex items-center rounded-t-md">
+                            <CardHeader className="flex flex-row items-center gap-2 border-b border-border/60 bg-card px-4 py-3 text-foreground [&_svg]:text-primary rounded-t-md">
                                 <Server className="h-5 w-5 mr-2 flex-shrink-0" />
                                 <CardTitle className="text-lg">Connection Status</CardTitle>
                             </CardHeader>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -193,7 +193,7 @@ export function AppSidebar({ children, ...props }: AppSidebarProps & React.Compo
                             size="lg"
                             className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                         >
-                            <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+                            <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#34F5C6] to-[#17A7B6] text-[#06232A]">
                                 <svg
                                     className="size-6"
                                     viewBox="0 0 64 64"

--- a/src/components/BalanceInstrument.tsx
+++ b/src/components/BalanceInstrument.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React from 'react';
+import { RefreshCw, Loader, Copy } from 'lucide-react';
+
+/**
+ * BalanceInstrument — the wallet's primary flight display.
+ *
+ * An always-dark "cockpit" surface (in both light and dark themes) carrying the
+ * balance readout, a mainnet annunciator, and the receive address. The state
+ * branches (loading / unavailable / stale / processing) and their data-testids
+ * are preserved exactly from the original balance card, so the E2E balance
+ * contract is unchanged: the figure renders as a single "<value> AVN" text node,
+ * and balance-unavailable / balance-stale mark the no-data and last-known cases.
+ */
+
+interface ProcessingProgress {
+    isProcessing: boolean;
+    processed: number;
+    total: number;
+    currentTx?: string | null;
+}
+
+interface BalanceInstrumentProps {
+    balance: number;
+    balanceStatus: 'live' | 'stale' | 'unknown';
+    address: string | null;
+    isLoading: boolean;
+    processingProgress: ProcessingProgress;
+    isRefreshing: boolean;
+    copied: boolean;
+    formatBalance: (balance: number) => string;
+    onRefresh: () => void;
+    onRefreshMouseDown: () => void;
+    onRefreshMouseUp: () => void;
+    onCopy: (address: string) => void;
+    className?: string;
+}
+
+export function BalanceInstrument({
+    balance,
+    balanceStatus,
+    address,
+    isLoading,
+    processingProgress,
+    isRefreshing,
+    copied,
+    formatBalance,
+    onRefresh,
+    onRefreshMouseDown,
+    onRefreshMouseUp,
+    onCopy,
+    className = '',
+}: BalanceInstrumentProps) {
+    return (
+        <section
+            className={`relative overflow-hidden rounded-2xl border border-[#24404A] bg-[linear-gradient(180deg,#163139,#122730)] shadow-[0_30px_60px_-40px_rgba(0,0,0,0.8)] ${className}`}
+        >
+            {/* artificial-horizon backdrop */}
+            <div aria-hidden className="pointer-events-none absolute inset-0 opacity-50">
+                <div className="absolute inset-x-0 top-0 bottom-[42%] bg-[linear-gradient(180deg,#16525C,#123E46)]" />
+                <div className="absolute inset-x-0 top-[58%] bottom-0 bg-[linear-gradient(180deg,#1A1F52,#12163A)]" />
+                <div className="absolute inset-x-0 top-[58%] h-0.5 bg-[#34F5C6] opacity-60 shadow-[0_0_12px_rgba(52,245,198,0.5)]" />
+            </div>
+
+            <div className="relative p-6">
+                {/* top strip: label + annunciator + refresh */}
+                <div className="mb-4 flex items-center justify-between gap-3">
+                    <span className="fd-label text-[#9DB4BC]">Total balance · Mainnet</span>
+                    <div className="flex items-center gap-2">
+                        <span className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-[rgba(4,18,26,0.5)] px-2.5 py-1.5">
+                            <span className="fd-lamp h-[7px] w-[7px] rounded-full bg-[#34F5C6]" />
+                            <span className="fd-label text-[0.6rem] text-[#E6F0F2]">Keys · Local</span>
+                        </span>
+                        <button
+                            onClick={onRefresh}
+                            onMouseDown={onRefreshMouseDown}
+                            onMouseUp={onRefreshMouseUp}
+                            onMouseLeave={onRefreshMouseUp}
+                            onTouchStart={onRefreshMouseDown}
+                            onTouchEnd={onRefreshMouseUp}
+                            disabled={isRefreshing}
+                            aria-label="Refresh balance (hold for full refresh)"
+                            title="Refresh balance (hold for full refresh)"
+                            className="grid h-8 w-8 place-items-center rounded-lg text-[#9DB4BC] transition-colors hover:bg-white/10 hover:text-white disabled:opacity-60"
+                        >
+                            <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+                        </button>
+                    </div>
+                </div>
+
+                {/* readout */}
+                <div className="fd-readout fd-glow-teal flex flex-wrap items-baseline gap-x-2 text-3xl font-semibold leading-none text-[#34E2D5] md:text-4xl">
+                    {isLoading && !processingProgress.isProcessing ? (
+                        <span className="text-[#9DB4BC]">Loading…</span>
+                    ) : balanceStatus === 'unknown' ? (
+                        // No confirmed or cached figure exists; showing 0 here would read as
+                        // "your funds are gone" on a flaky connection.
+                        <span data-testid="balance-unavailable" className="flex items-baseline text-[#9DB4BC]">
+                            —
+                            <span className="ml-2 text-xs font-normal opacity-80">balance unavailable</span>
+                        </span>
+                    ) : (
+                        <>
+                            <span className="break-all">{`${formatBalance(balance)} AVN`}</span>
+                            {balanceStatus === 'stale' && (
+                                <span
+                                    data-testid="balance-stale"
+                                    className="text-xs font-normal text-[#9DB4BC] opacity-80"
+                                    title="Shown from the last successful update; the server has not confirmed it yet"
+                                >
+                                    last known
+                                </span>
+                            )}
+                            {processingProgress.isProcessing && (
+                                <Loader className="h-5 w-5 animate-spin text-[#9DB4BC] opacity-70" />
+                            )}
+                        </>
+                    )}
+                </div>
+
+                {/* address + copy */}
+                <div className="mt-4 flex items-center gap-1.5 font-mono text-xs text-[#9DB4BC] md:text-sm">
+                    <span className="truncate">{address ? address : 'No wallet loaded'}</span>
+                    {address && (
+                        <button
+                            onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onCopy(address);
+                            }}
+                            className="flex-shrink-0 rounded p-1 text-[#9DB4BC] transition-colors hover:bg-white/10 hover:text-white"
+                            title="Copy address to clipboard"
+                        >
+                            <Copy size={14} className={copied ? 'text-[#34F5C6]' : ''} />
+                        </button>
+                    )}
+                </div>
+
+                {/* processing progress */}
+                {processingProgress.isProcessing && (
+                    <div className="mt-4 rounded-lg border border-white/15 bg-white/10 p-2 text-xs text-white">
+                        <div className="flex flex-wrap items-center">
+                            <Loader className="mr-1.5 h-3 w-3 flex-shrink-0 animate-spin text-white" />
+                            <span className="font-medium">
+                                Processing… {processingProgress.processed}/{processingProgress.total}
+                            </span>
+                        </div>
+                        {processingProgress.currentTx && (
+                            <div className="mt-1 truncate pl-4 text-white/80">
+                                TX: {processingProgress.currentTx.slice(0, 6)}…
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/src/components/GradientBackground.tsx
+++ b/src/components/GradientBackground.tsx
@@ -15,20 +15,20 @@ export default function GradientBackground({
     children,
 }: GradientBackgroundProps) {
     return (
-        <div className="min-h-screen w-full relative bg-white dark:bg-black">
-            {/* Light mode variant */}
+        <div className="min-h-screen w-full relative bg-[#F4F7F8] dark:bg-[#0D1B21]">
+            {/* Light mode variant — paper ground with a faint mint horizon glow */}
             <div
                 className="absolute inset-0 z-0 block dark:hidden"
                 style={{
-                    background: 'radial-gradient(145% 100% at 50% 100%, #ffffff 85%, #e6f7f8 100%)',
+                    background: 'radial-gradient(145% 100% at 50% 100%, #F4F7F8 82%, #E1FCF4 100%)',
                     backgroundSize: '100% 100%',
                 }}
             />
-            {/* Dark mode variant */}
+            {/* Dark mode variant — night ground with a teal horizon glow */}
             <div
                 className="absolute inset-0 z-0 dark:block hidden"
                 style={{
-                    background: 'radial-gradient(145% 100% at 50% 100%, #000000 50%, #2a737f 100%)',
+                    background: 'radial-gradient(145% 100% at 50% 100%, #0D1B21 55%, #16525C 100%)',
                     backgroundSize: '100% 100%',
                 }}
             />


### PR DESCRIPTION
**PR 2 of the UI/UX refresh** — the design becomes visible.

Applies the approved flight-deck treatment to the home screen and shell, using the tokens/fonts from PR 1. **Navigation and flows are unchanged** — this is presentation only.

### What changed
- **`BalanceInstrument`** (new) — the wallet's primary flight display: an always-dark "cockpit" surface (in **both** themes) with an artificial-horizon backdrop, a `Keys · Local` mainnet annunciator, a Roboto Mono turquoise readout, and the receive address. Replaces the two near-identical balance cards.
- **`page.tsx`** — uses `BalanceInstrument` in both mobile and desktop layouts; restyles the desktop panel headers (loud `avian` gradient → subtle instrument header, icon in the accent) and the mobile tabs (primary accent + `muted-foreground` inactive). Removed dead imports.
- **`GradientBackground`** — ambient ground re-keyed to the brand: night `#0D1B21` + teal horizon glow (dark), paper + mint glow (light).
- **`AppSidebar`** — brand-gradient logo tile.
- **`globals.css`** — reusable flight-deck instrument primitives (`.fd-label` / `.fd-readout` / `.fd-glow-teal` / `.fd-lamp`) for the following PRs.

### Preserved contracts
Every balance state branch (loading / unavailable / stale / processing) and the `balance-unavailable` / `balance-stale` testids are carried over verbatim; the figure still renders as a single `"<value> AVN"` text node, so the E2E balance contract is untouched.

### Safety
No crypto, `requireAuth`, or storage paths touched. Existing wallet flows unaffected. The balance readout keeps `toFixed(8)`.

### Verification
typecheck ✓ · lint ✓ · **542/542 unit ✓** · static build ✓ (home 455 kB, unchanged) · **25/25 E2E ✓** (incl. both `balance.spec` cases)