### PR TITLE
feat(ui): send / receive / history — brand colour + no-red tx rows

### DIFF
--- a/src/components/ReceiveContent.tsx
+++ b/src/components/ReceiveContent.tsx
@@ -344,8 +344,8 @@ export default function ReceiveContent({ address }: ReceiveContentProps) {
             <QrCode className="w-6 h-6 text-primary" />
           </div>
           <CardTitle>Receive AVN</CardTitle>
-          <Alert className="bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800">
-            <AlertDescription className="text-yellow-600 dark:text-yellow-400 text-sm">
+          <Alert className="bg-caution/10 border-caution/30">
+            <AlertDescription className="text-caution text-sm">
               ⚠️ Do not keep large amounts in your wallet
             </AlertDescription>
           </Alert>
@@ -406,8 +406,8 @@ export default function ReceiveContent({ address }: ReceiveContentProps) {
           <QrCode className="w-6 h-6 text-primary" />
         </div>
         <CardTitle>Payment Address</CardTitle>
-        <Alert className="bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800">
-          <AlertDescription className="text-yellow-600 dark:text-yellow-400 text-sm">
+        <Alert className="bg-caution/10 border-caution/30">
+          <AlertDescription className="text-caution text-sm">
             ⚠️ Do not keep large amounts in your wallet
           </AlertDescription>
         </Alert>
@@ -460,7 +460,7 @@ export default function ReceiveContent({ address }: ReceiveContentProps) {
                               {wallet.isActive && (
                                 <Badge
                                   variant="outline"
-                                  className="bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-700"
+                                  className="bg-primary/10 text-primary border-primary/20"
                                 >
                                   Active
                                 </Badge>
@@ -567,7 +567,7 @@ export default function ReceiveContent({ address }: ReceiveContentProps) {
                     className="h-8 w-8 ml-1 rounded-full"
                   >
                     {copied ? (
-                      <CheckCircle className="w-4 h-4 text-green-500" />
+                      <CheckCircle className="w-4 h-4 text-primary" />
                     ) : (
                       <Copy className="w-4 h-4" />
                     )}

--- a/src/components/SendForm.tsx
+++ b/src/components/SendForm.tsx
@@ -949,7 +949,7 @@ export default function SendForm() {
               utxoOptions.feeRate !== 10000 ||
               utxoOptions.maxInputs !== 100 ||
               utxoOptions.minConfirmations !== 6) && (
-                <span className="absolute -top-1 -right-1 h-2 w-2 bg-amber-500 rounded-full"></span>
+                <span className="absolute -top-1 -right-1 h-2 w-2 bg-caution rounded-full"></span>
               )}
           </Button>
         </div>
@@ -964,7 +964,7 @@ export default function SendForm() {
             <div className="mb-4 p-3 bg-secondary/30 border rounded-lg">
               <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
                 <div className="flex items-center">
-                  <Settings className="h-4 w-4 mr-2 text-blue-600 dark:text-blue-400" />
+                  <Settings className="h-4 w-4 mr-2 text-primary" />
                   <span className="text-sm font-medium">Custom Settings Active</span>
                 </div>
                 <div className="flex items-center gap-2">
@@ -1022,10 +1022,10 @@ export default function SendForm() {
         {success && (
           <Alert
             variant="default"
-            className="mb-4 border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950/50"
+            className="mb-4 border-primary/20 bg-primary/5"
           >
-            <Check className="h-4 w-4 text-green-600 dark:text-green-500" />
-            <AlertTitle className="text-green-800 dark:text-green-500">{success}</AlertTitle>
+            <Check className="h-4 w-4 text-primary" />
+            <AlertTitle className="text-foreground">{success}</AlertTitle>
             {successTxId && (
               <AlertDescription>
                 <div className="space-y-2">
@@ -1039,7 +1039,7 @@ export default function SendForm() {
                     variant="link"
                     size="sm"
                     onClick={() => openExplorer(successTxId)}
-                    className="h-6 p-0 text-green-700 dark:text-green-500 hover:text-green-800"
+                    className="h-6 p-0 text-primary hover:text-primary/80"
                   >
                     <ExternalLink className="h-3 w-3 mr-1" />
                     View on Explorer
@@ -1240,9 +1240,9 @@ export default function SendForm() {
 
           {/* Show derived address info if sending from one */}
           {fromDerivedAddress && derivationPath && (
-            <Alert className="mb-4 border-orange-200 dark:border-orange-800 bg-orange-50 dark:bg-orange-950/50">
-              <Coins className="h-4 w-4 text-orange-600 dark:text-orange-500" />
-              <AlertTitle className="text-orange-800 dark:text-orange-500">
+            <Alert className="mb-4 border-caution/30 bg-caution/10">
+              <Coins className="h-4 w-4 text-caution" />
+              <AlertTitle className="text-caution">
                 Sending From Derived Address
               </AlertTitle>
               <AlertDescription className="space-y-2">
@@ -1281,9 +1281,9 @@ export default function SendForm() {
 
           {/* Display authentication requirement for encrypted wallets */}
           {isEncrypted && (
-            <Alert className="mb-4 border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/50">
-              <Lock className="h-4 w-4 text-blue-600 dark:text-blue-500" />
-              <AlertTitle className="text-blue-800 dark:text-blue-500">
+            <Alert className="mb-4 border-primary/20 bg-primary/5">
+              <Lock className="h-4 w-4 text-primary" />
+              <AlertTitle className="text-foreground">
                 {biometricsRequired
                   ? 'Biometric Authentication Required'
                   : 'Wallet Authentication Required'}
@@ -1303,16 +1303,16 @@ export default function SendForm() {
 
         {/* Save Address Prompt */}
         {askToSaveAddress && (
-          <Alert className="mt-4 border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950/50">
-            <AlertTitle className="text-green-800 dark:text-green-400">
+          <Alert className="mt-4 border-primary/20 bg-primary/5">
+            <AlertTitle className="text-foreground">
               💾 Save this address to your address book?
             </AlertTitle>
             <AlertDescription>
-              <div className="text-sm mb-3 text-green-700 dark:text-green-300">
+              <div className="text-sm mb-3 text-muted-foreground">
                 Address: <span className="font-mono break-all">{toAddress}</span>
               </div>
               <div className="mt-3 mb-3">
-                <Label htmlFor="contactName" className="text-green-700 dark:text-green-300">
+                <Label htmlFor="contactName" className="text-muted-foreground">
                   Contact Name
                 </Label>
                 <Input
@@ -1335,7 +1335,7 @@ export default function SendForm() {
                     const input = document.getElementById('contactName') as HTMLInputElement;
                     handleSaveAddressFromTransaction(input.value || 'Contact');
                   }}
-                  className="bg-green-600 hover:bg-green-700"
+                  className="bg-primary hover:bg-primary/90"
                 >
                   💾 Save Address
                 </Button>
@@ -1365,12 +1365,12 @@ export default function SendForm() {
 
         {/* Dust Consolidation Notice */}
         {isConsolidatingToSelf && (
-          <Alert className="my-4 border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/50">
-            <Coins className="h-4 w-4 text-blue-600 dark:text-blue-500" />
-            <AlertTitle className="text-blue-800 dark:text-blue-500">
+          <Alert className="my-4 border-primary/20 bg-primary/5">
+            <Coins className="h-4 w-4 text-primary" />
+            <AlertTitle className="text-foreground">
               Dust Consolidation Mode
             </AlertTitle>
-            <AlertDescription className="text-blue-700 dark:text-blue-300 text-sm">
+            <AlertDescription className="text-muted-foreground text-sm">
               You are consolidating small UTXOs (dust) back to your own wallet address. This helps
               clean up your wallet and may improve performance. Change address selection is disabled
               during consolidation.
@@ -1414,7 +1414,7 @@ export default function SendForm() {
 
         {/* Manual UTXO Selection Notice */}
         {utxoOptions.strategy === CoinSelectionStrategy.MANUAL && (
-          <div className="mt-3 p-3 bg-amber-100 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-800 rounded-lg">
+          <div className="mt-3 p-3 bg-caution/10 border border-caution/30 rounded-lg">
             <div className="font-medium mb-2 flex items-center">
               <UserCheck className="w-4 h-4 mr-2" />
               Manual UTXO Selection Active
@@ -1431,13 +1431,13 @@ export default function SendForm() {
                       </span>
                     </p>
                     {isConsolidatingToSelf && (
-                      <p className="text-amber-700 dark:text-amber-300">
+                      <p className="text-caution">
                         💰 Consolidation mode: All selected UTXOs will be combined into your wallet
                       </p>
                     )}
                   </div>
                 ) : (
-                  <p className="text-amber-700 dark:text-amber-300">No UTXOs selected</p>
+                  <p className="text-caution">No UTXOs selected</p>
                 )}
               </div>
               <div className="flex flex-col sm:flex-row gap-2">

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -295,10 +295,9 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
 
   const formatAmount = (amount: number, type: 'send' | 'receive') => {
     const sign = type === 'send' ? '-' : '+';
-    const color =
-      type === 'send' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400';
+    const color = type === 'send' ? 'text-foreground' : 'text-primary';
     return (
-      <span className={`font-medium ${color}`}>
+      <span className={`font-medium font-mono tabular-nums ${color}`}>
         {sign}
         {amount.toFixed(8)} AVN
       </span>
@@ -332,11 +331,11 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
   const getStatusIcon = (confirmations: number | undefined) => {
     const numConfirmations = Number(confirmations) || 0;
     if (numConfirmations === 0) {
-      return <Clock className="w-4 h-4 text-yellow-500" />;
+      return <Clock className="w-4 h-4 text-muted-foreground" />;
     } else if (numConfirmations < 6) {
-      return <AlertCircle className="w-4 h-4 text-orange-500" />;
+      return <AlertCircle className="w-4 h-4 text-caution" />;
     } else {
-      return <Check className="w-4 h-4 text-green-500" />;
+      return <Check className="w-4 h-4 text-primary" />;
     }
   };
 
@@ -376,7 +375,7 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
       </CardHeader>
 
       {/* Filter Controls */}
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
+      <div className="p-4 border-b border-border flex-shrink-0">
         <Tabs
           defaultValue={filter}
           onValueChange={(value) => setFilter(value as 'all' | 'send' | 'receive')}
@@ -392,7 +391,7 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
               value="receive"
               className="flex-1 data-[state=active]:after:bg-primary relative rounded-none py-2 after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
             >
-              <span className="text-green-600 dark:text-green-400">
+              <span className="text-primary">
                 Received ({transactions.filter((tx) => tx.type === 'receive').length})
               </span>
             </TabsTrigger>
@@ -400,7 +399,7 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
               value="send"
               className="flex-1 data-[state=active]:after:bg-primary relative rounded-none py-2 after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
             >
-              <span className="text-red-600 dark:text-red-400">
+              <span className="text-sodium">
                 Sent ({transactions.filter((tx) => tx.type === 'send').length})
               </span>
             </TabsTrigger>
@@ -409,12 +408,12 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
 
         {/* Processing Progress */}
         {processingProgress.isProcessing && processingProgress.total > 0 && (
-          <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 mt-4 border border-blue-200 dark:border-blue-700">
+          <div className="bg-primary/5 rounded-lg p-3 mt-4 border border-primary/20">
             <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-blue-900 dark:text-blue-200">
+              <span className="text-sm font-medium text-foreground">
                 Processing transaction history...
               </span>
-              <span className="text-xs text-blue-700 dark:text-blue-300">
+              <span className="text-xs text-muted-foreground">
                 {processingProgress.processed}/{processingProgress.total}
               </span>
             </div>
@@ -426,11 +425,11 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
               }
               className="h-2"
             />
-            <div className="text-xs text-blue-600 dark:text-blue-400 mt-1">
+            <div className="text-xs text-muted-foreground mt-1">
               New transactions will appear as they&apos;re processed
             </div>
             {processingProgress.currentTx && (
-              <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 font-mono">
+              <div className="text-xs text-muted-foreground mt-1 font-mono">
                 Processing: {processingProgress.currentTx.slice(0, 16)}...
               </div>
             )}
@@ -443,12 +442,12 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
         <div className="max-h-[500px] overflow-y-auto">
           {isLoading ? (
             <div className="flex items-center justify-center p-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-              <span className="ml-2 text-gray-600 dark:text-gray-300">Loading transactions...</span>
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              <span className="ml-2 text-muted-foreground">Loading transactions...</span>
             </div>
           ) : paginatedTransactions.length === 0 ? (
             <div className="text-center py-12">
-              <div className="text-gray-400 dark:text-gray-500 mb-2">
+              <div className="text-muted-foreground mb-2">
                 <svg
                   className="w-16 h-16 mx-auto"
                   fill="none"
@@ -463,49 +462,49 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
                   />
                 </svg>
               </div>
-              <p className="text-gray-600 dark:text-gray-400 text-lg">
+              <p className="text-muted-foreground text-lg">
                 {filter === 'all' ? 'No transactions found' : `No ${filter} transactions found`}
               </p>
-              <p className="text-gray-500 dark:text-gray-500 text-sm mt-1">
+              <p className="text-muted-foreground text-sm mt-1">
                 Transactions will appear here once you start using your wallet
               </p>
             </div>
           ) : (
-            <div className="divide-y divide-gray-200 dark:divide-gray-700">
+            <div className="divide-y divide-border">
               {paginatedTransactions.map((tx) => (
                 <div
                   key={`${tx.id || tx.txid}-${tx.type}${tx.isVirtual ? '-virtual' : ''}`}
-                  className="p-4 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                  className="p-4 hover:bg-muted/50"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex items-start gap-3 min-w-0 flex-1">
                       {/* Transaction Icon */}
                       <div
                         className={`flex-shrink-0 p-2 rounded-full ${tx.type === 'send'
-                          ? 'bg-red-100 dark:bg-red-900/20'
-                          : 'bg-green-100 dark:bg-green-900/20'
+                          ? 'bg-sodium/10'
+                          : 'bg-primary/10'
                           }`}
                       >
                         {tx.type === 'send' ? (
-                          <ArrowUpRight className="w-4 h-4 text-red-600 dark:text-red-400" />
+                          <ArrowUpRight className="w-4 h-4 text-sodium" />
                         ) : (
-                          <ArrowDownLeft className="w-4 h-4 text-green-600 dark:text-green-400" />
+                          <ArrowDownLeft className="w-4 h-4 text-primary" />
                         )}
                       </div>
 
                       {/* Transaction Details */}
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2 mb-1">
-                          <span className="font-medium text-gray-900 dark:text-white capitalize">
+                          <span className="font-medium text-foreground capitalize">
                             {tx.type}
                           </span>
                           {getStatusIcon(tx.confirmations)}
-                          <span className="text-sm text-gray-500 dark:text-gray-400">
+                          <span className="text-sm text-muted-foreground">
                             {getStatusText(tx.confirmations)}
                           </span>
                         </div>
 
-                        <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">
+                        <div className="text-sm text-muted-foreground mb-1">
                           {tx.type === 'send' ? 'To: ' : 'From: '}
                           <span className="font-mono break-all">
                             {(() => {
@@ -519,12 +518,12 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
                         </div>
 
                         <div className="flex items-center gap-3">
-                          <span className="text-sm text-gray-500 dark:text-gray-400">
+                          <span className="text-sm text-muted-foreground">
                             {formatDate(tx.timestamp)}
                           </span>
                           <button
                             onClick={() => openExplorer(tx.txid)}
-                            className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+                            className="text-xs text-primary hover:underline flex items-center gap-1"
                           >
                             <ExternalLink className="w-3 h-3" />
                             View Details
@@ -537,7 +536,7 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
                     <div className="flex-shrink-0 text-right">
                       {formatAmount(tx.amount, tx.type)}
                       {tx.blockHeight && (
-                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        <div className="text-xs text-muted-foreground mt-1">
                           Block #{tx.blockHeight}
                         </div>
                       )}
@@ -551,8 +550,8 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
       </CardContent>
 
       {/* Footer with Pagination */}
-      <CardFooter className="p-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
-        <div className="flex flex-col sm:flex-row justify-between items-center w-full gap-3 text-sm text-gray-600 dark:text-gray-400">
+      <CardFooter className="p-4 border-t border-border bg-muted/40">
+        <div className="flex flex-col sm:flex-row justify-between items-center w-full gap-3 text-sm text-muted-foreground">
           <span>
             Showing {startIndex + 1}-{Math.min(endIndex, filteredTransactions.length)} of{' '}
             {filteredTransactions.length}{' '}


### PR DESCRIPTION
**PR 3 of the UI/UX refresh** — the transaction surfaces. Presentation only; no logic, flows, or structure changed.

### The signature change
In **TransactionHistory**, a normal send no longer reads as an error:
- **Received = brand teal, Sent = Sodium gold** — never red.
- Amounts render in **Roboto Mono** tabular-nums.
- Confirmation status steps `neutral → caution → teal`; the processing/info box and links move to the teal tint; grays → `muted-foreground` / border tokens.

### Also re-keyed
- **SendForm** — success and save-address alerts → brand teal; info boxes → teal tint; orange/amber warnings → the `caution` token; the save button drops its hardcoded green for `primary`.
- **ReceiveContent** — Active badge and copied-check → brand teal; low-balance warning → `caution`. (QR foreground left near-black for scan reliability.)

### Semantic system (applied consistently)
`success → teal (primary)` · `warning → caution (orange)` · `info → teal tint` · `tx-sent → Sodium (not red)` · `tx-received → teal`.

### Safety
No crypto, `requireAuth`, or storage paths touched. Existing flows unaffected.

### Verification
typecheck ✓ · **542/542 unit ✓** (isolated — a parallel build run produced CPU-contention flakes that cleared when run alone) · static build ✓ · **25/25 E2E ✓**