### PR TITLE
feat(ui): onboarding flow + settings landing — brand re-key

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -233,8 +233,8 @@ export default function OnboardingPage() {
                     setStep('form');
                 }}>
                     <CardHeader>
-                        <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mb-4">
-                            <Wallet className="w-6 h-6 text-green-600" />
+                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
+                            <Wallet className="w-6 h-6 text-primary" />
                         </div>
                         <CardTitle className="text-xl">Create New Wallet</CardTitle>
                         <p className="text-muted-foreground">
@@ -249,8 +249,8 @@ export default function OnboardingPage() {
                     setStep('form');
                 }}>
                     <CardHeader>
-                        <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-                            <FileKey className="w-6 h-6 text-blue-600" />
+                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
+                            <FileKey className="w-6 h-6 text-primary" />
                         </div>
                         <CardTitle className="text-xl">Import from Mnemonic</CardTitle>
                         <p className="text-muted-foreground">
@@ -265,8 +265,8 @@ export default function OnboardingPage() {
                     setStep('form');
                 }}>
                     <CardHeader>
-                        <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
-                            <Import className="w-6 h-6 text-purple-600" />
+                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
+                            <Import className="w-6 h-6 text-primary" />
                         </div>
                         <CardTitle className="text-xl">Import Private Key</CardTitle>
                         <p className="text-muted-foreground">
@@ -278,8 +278,8 @@ export default function OnboardingPage() {
                 {/* Restore from Backup */}
                 <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={() => setStep('backup-file')}>
                     <CardHeader>
-                        <div className="w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center mb-4">
-                            <Upload className="w-6 h-6 text-orange-600" />
+                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
+                            <Upload className="w-6 h-6 text-primary" />
                         </div>
                         <CardTitle className="text-xl">Restore from Backup</CardTitle>
                         <p className="text-muted-foreground">
@@ -294,8 +294,8 @@ export default function OnboardingPage() {
                     setStep('form');
                 }}>
                     <CardHeader>
-                        <div className="w-12 h-12 bg-teal-100 rounded-lg flex items-center justify-center mb-4">
-                            <ScrollText className="w-6 h-6 text-teal-600" />
+                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
+                            <ScrollText className="w-6 h-6 text-primary" />
                         </div>
                         <CardTitle className="text-xl">Import from Descriptor</CardTitle>
                         <p className="text-muted-foreground">
@@ -384,9 +384,9 @@ export default function OnboardingPage() {
                                         onClick={() => setShowBackupPassword(!showBackupPassword)}
                                     >
                                         {showBackupPassword ? (
-                                            <EyeOff className="h-4 w-4 text-gray-500" />
+                                            <EyeOff className="h-4 w-4 text-muted-foreground" />
                                         ) : (
-                                            <Eye className="h-4 w-4 text-gray-500" />
+                                            <Eye className="h-4 w-4 text-muted-foreground" />
                                         )}
                                     </Button>
                                 </div>
@@ -427,8 +427,8 @@ export default function OnboardingPage() {
     const renderSuccess = () => (
         <Card className="max-w-md mx-auto text-center">
             <CardContent className="pt-6">
-                <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <Wallet className="w-8 h-8 text-green-600" />
+                <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <Wallet className="w-8 h-8 text-primary" />
                 </div>
                 <h2 className="text-2xl font-bold mb-2">Setup Complete!</h2>
                 <p className="text-muted-foreground mb-6">

--- a/src/app/settings/advanced/page.tsx
+++ b/src/app/settings/advanced/page.tsx
@@ -99,14 +99,14 @@ export default function AdvancedSettingsPage() {
                 </div>
 
                 {/* RIP-25 Post-Quantum Notice */}
-                <Card className="border-purple-200 dark:border-purple-700 bg-purple-50 dark:bg-purple-900/20">
+                <Card className="border-primary/20 bg-primary/5">
                     <CardHeader className="pb-2">
-                        <CardTitle className="flex items-center gap-2 text-base text-purple-800 dark:text-purple-200">
+                        <CardTitle className="flex items-center gap-2 text-base text-foreground">
                             <FlaskConical className="w-4 h-4" />
                             RIP-25: Post-Quantum Signatures (ML-DSA-44)
                         </CardTitle>
                     </CardHeader>
-                    <CardContent className="text-sm text-purple-700 dark:text-purple-300 space-y-1">
+                    <CardContent className="text-sm text-muted-foreground space-y-1">
                         <p>
                             Avian Core v5.0.0 introduces <strong>RIP-25</strong> — ML-DSA-44 (Dilithium) lattice-based
                             post-quantum signature support.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -34,7 +34,7 @@ const settingsCategories: SettingsCategory[] = [
         description: 'Manage wallets, addresses, and encryption',
         icon: Wallet,
         path: '/settings/wallet',
-        color: 'text-blue-600',
+        color: 'text-primary',
     },
     {
         id: 'security',
@@ -42,7 +42,7 @@ const settingsCategories: SettingsCategory[] = [
         description: 'Authentication, biometrics, and security features',
         icon: Shield,
         path: '/settings/security',
-        color: 'text-green-600',
+        color: 'text-primary',
     },
     {
         id: 'backup',
@@ -50,7 +50,7 @@ const settingsCategories: SettingsCategory[] = [
         description: 'Export, import, and backup your wallet data',
         icon: Archive,
         path: '/settings/backup',
-        color: 'text-orange-600',
+        color: 'text-primary',
     },
     {
         id: 'notifications',
@@ -58,7 +58,7 @@ const settingsCategories: SettingsCategory[] = [
         description: 'Configure alerts and notification preferences',
         icon: Bell,
         path: '/settings/notifications',
-        color: 'text-purple-600',
+        color: 'text-primary',
     },
     {
         id: 'connected-sites',
@@ -66,7 +66,7 @@ const settingsCategories: SettingsCategory[] = [
         description: 'Review and revoke dApps connected to this wallet',
         icon: PlugZap,
         path: '/settings/connected-sites',
-        color: 'text-teal-600',
+        color: 'text-primary',
     },
     {
         id: 'advanced',
@@ -74,7 +74,7 @@ const settingsCategories: SettingsCategory[] = [
         description: 'Developer tools, logs, and advanced configuration',
         icon: Settings,
         path: '/settings/advanced',
-        color: 'text-gray-600',
+        color: 'text-primary',
     },
     {
         id: 'help',
@@ -82,7 +82,7 @@ const settingsCategories: SettingsCategory[] = [
         description: 'Documentation, support, and app information',
         icon: HelpCircle,
         path: '/settings/help',
-        color: 'text-indigo-600',
+        color: 'text-primary',
     },
 ];
 

--- a/src/components/MnemonicModal.tsx
+++ b/src/components/MnemonicModal.tsx
@@ -286,7 +286,7 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
       {mode === 'export' ? (
         // Export Mode
         <div className="space-y-4">
-          <Alert className="bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-700">
+          <Alert className="bg-caution/10 border-caution/30">
             <AlertTriangle className="h-5 w-5" />
             <AlertTitle>Security Warning</AlertTitle>
             <AlertDescription>
@@ -351,7 +351,7 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
 
                 {/* BIP39 Passphrase Indicator */}
                 {hasBip39Passphrase && (
-                  <Alert className="bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-700">
+                  <Alert className="bg-primary/5 border-primary/20">
                     <Key className="h-4 w-4" />
                     <AlertTitle>BIP39 Passphrase (25th Word) Required</AlertTitle>
                     <AlertDescription className="space-y-3">
@@ -360,7 +360,7 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
                         both the mnemonic phrase above AND the passphrase to fully restore this
                         wallet.
                       </p>
-                      <p className="font-medium text-blue-800 dark:text-blue-200">
+                      <p className="font-medium text-foreground">
                         ⚠️ Make sure you have backed up your passphrase separately!
                       </p>
 
@@ -371,7 +371,7 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
                             disabled={isLoadingPassphrase}
                             variant="outline"
                             size="sm"
-                            className="text-blue-700 border-blue-300 hover:bg-blue-100 dark:text-blue-300 dark:border-blue-600 dark:hover:bg-blue-900/30"
+                            className="text-primary border-primary/40 hover:bg-primary/10"
                           >
                             {isLoadingPassphrase ? (
                               <RefreshCw className="w-3 h-3 animate-spin mr-2" />
@@ -383,9 +383,9 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
                         </div>
                       ) : (
                         <div className="pt-2 space-y-3">
-                          <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-md p-3">
+                          <div className="bg-caution/10 border border-caution/30 rounded-md p-3">
                             <div className="flex items-center justify-between mb-2">
-                              <span className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+                              <span className="text-sm font-medium text-caution">
                                 Your BIP39 Passphrase:
                               </span>
                               <Button
@@ -394,16 +394,16 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
                                 }
                                 variant="ghost"
                                 size="sm"
-                                className="h-6 text-yellow-700 hover:text-yellow-900 dark:text-yellow-300 dark:hover:text-yellow-100"
+                                className="h-6 text-caution hover:text-caution"
                               >
                                 <Copy className="w-3 h-3" />
                               </Button>
                             </div>
-                            <div className="font-mono text-sm bg-white dark:bg-gray-800 p-2 rounded border break-all">
+                            <div className="font-mono text-sm bg-background p-2 rounded border break-all">
                               {decryptedPassphrase}
                             </div>
                           </div>
-                          <p className="text-xs text-yellow-700 dark:text-yellow-300">
+                          <p className="text-xs text-muted-foreground">
                             🔒 Store this passphrase separately from your mnemonic for maximum
                             security.
                           </p>
@@ -430,7 +430,7 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
       ) : (
         // Import Mode
         <div className="space-y-4">
-          <Alert className="bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-700">
+          <Alert className="bg-primary/5 border-primary/20">
             <AlertTriangle className="h-5 w-5" />
             <AlertTitle>Import Wallet</AlertTitle>
             <AlertDescription>
@@ -449,18 +449,18 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
               }}
               placeholder="Enter your 12-word mnemonic phrase..."
               className={`${isValidMnemonic === false
-                  ? 'border-red-300 dark:border-red-600'
+                  ? 'border-destructive/50'
                   : isValidMnemonic === true
-                    ? 'border-green-300 dark:border-green-600'
+                    ? 'border-primary/50'
                     : ''
                 }`}
               rows={3}
             />
             {isValidMnemonic === true && (
-              <p className="text-sm text-green-600 dark:text-green-400">✓ Valid mnemonic phrase</p>
+              <p className="text-sm text-primary">✓ Valid mnemonic phrase</p>
             )}
             {isValidMnemonic === false && (
-              <p className="text-sm text-red-600 dark:text-red-400">✗ Invalid mnemonic phrase</p>
+              <p className="text-sm text-destructive">✗ Invalid mnemonic phrase</p>
             )}
           </div>
 
@@ -483,9 +483,9 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
                 onClick={() => setShowPassword(!showPassword)}
               >
                 {showPassword ? (
-                  <EyeOff className="h-4 w-4 text-gray-500" />
+                  <EyeOff className="h-4 w-4 text-muted-foreground" />
                 ) : (
-                  <Eye className="h-4 w-4 text-gray-500" />
+                  <Eye className="h-4 w-4 text-muted-foreground" />
                 )}
               </Button>
             </div>
@@ -510,9 +510,9 @@ export default function MnemonicModal({ isOpen, onClose, mode }: MnemonicModalPr
                 onClick={() => setShowConfirmPassword(!showConfirmPassword)}
               >
                 {showConfirmPassword ? (
-                  <EyeOff className="h-4 w-4 text-gray-500" />
+                  <EyeOff className="h-4 w-4 text-muted-foreground" />
                 ) : (
-                  <Eye className="h-4 w-4 text-gray-500" />
+                  <Eye className="h-4 w-4 text-muted-foreground" />
                 )}
               </Button>
             </div>

--- a/src/components/PasswordStrength.tsx
+++ b/src/components/PasswordStrength.tsx
@@ -7,11 +7,11 @@ export type PasswordStrength = 'weak' | 'medium' | 'strong' | null;
 
 const strengthLabels = ['Too weak', 'Weak', 'Fair', 'Good', 'Strong'];
 const strengthColors = [
-  'bg-red-500',
-  'bg-orange-500',
-  'bg-yellow-400',
-  'bg-blue-500',
-  'bg-green-600',
+  'bg-destructive',
+  'bg-caution',
+  'bg-caution',
+  'bg-sodium',
+  'bg-primary',
 ];
 
 interface PasswordStrengthProps {
@@ -55,7 +55,7 @@ export default function PasswordStrengthChecker({
   return (
     <div className={`space-y-1 ${className}`}>
       {/* Strength Bar */}
-      <div className="h-1.5 w-full bg-gray-200 rounded-full overflow-hidden">
+      <div className="h-1.5 w-full bg-muted rounded-full overflow-hidden">
         <div
           className={`h-full transition-all duration-300 ${strengthColors[score]}`}
           style={{ width: `${(score + 1) * 20}%` }}
@@ -65,7 +65,7 @@ export default function PasswordStrengthChecker({
       {/* Strength Label */}
       <div className="flex justify-between items-center">
         <p
-          className={`text-xs font-medium ${score >= 3 ? 'text-green-600' : score >= 2 ? 'text-yellow-600' : 'text-red-600'}`}
+          className={`text-xs font-medium ${score >= 3 ? 'text-primary' : score >= 2 ? 'text-caution' : 'text-destructive'}`}
         >
           {strengthLabels[score]}
         </p>
@@ -73,7 +73,7 @@ export default function PasswordStrengthChecker({
 
       {/* Suggestions */}
       {showSuggestions && result.feedback.suggestions.length > 0 && (
-        <ul className="text-xs text-gray-600 list-disc pl-4 mt-1">
+        <ul className="text-xs text-muted-foreground list-disc pl-4 mt-1">
           {result.feedback.suggestions.map((s, i) => (
             <li key={i}>{s}</li>
           ))}

--- a/src/components/WalletCreationForm.tsx
+++ b/src/components/WalletCreationForm.tsx
@@ -482,7 +482,7 @@ export default function WalletCreationForm({
           </CardHeader>
         )}
         <CardContent className="space-y-4 pt-4">
-          <p className="text-gray-700 dark:text-gray-300">
+          <p className="text-muted-foreground">
             Set a password to encrypt your new wallet. Make sure to remember this password as it
             cannot be recovered.
           </p>
@@ -516,7 +516,7 @@ export default function WalletCreationForm({
                   Creative bird-themed name! You can keep it or customize your own.
                 </p>
               )}
-              {nameError && <p className="text-red-500 text-sm mt-1">{nameError}</p>}
+              {nameError && <p className="text-destructive text-sm mt-1">{nameError}</p>}
             </div>
 
             {/* Mnemonic Length Selection */}
@@ -551,12 +551,12 @@ export default function WalletCreationForm({
                 </div>
 
                 {mnemonicLength === '24' && (
-                  <Alert className="bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-700">
+                  <Alert className="bg-caution/10 border-caution/30">
                     <AlertTriangle className="h-4 w-4" />
-                    <AlertTitle className="text-amber-800 dark:text-amber-200">
+                    <AlertTitle className="text-caution">
                       Compatibility Warning
                     </AlertTitle>
-                    <AlertDescription className="text-amber-700 dark:text-amber-300">
+                    <AlertDescription className="text-muted-foreground">
                       <div className="space-y-2">
                         <p>
                           24-word recovery phrases provide enhanced security but may not be
@@ -601,9 +601,9 @@ export default function WalletCreationForm({
                   disabled={isSubmitting}
                 >
                   {showPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-500" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-500" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
@@ -638,9 +638,9 @@ export default function WalletCreationForm({
                   disabled={isSubmitting}
                 >
                   {showConfirmPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-500" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-500" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
@@ -691,11 +691,11 @@ export default function WalletCreationForm({
           </CardHeader>
         )}
         <CardContent className="space-y-4 pt-4">
-          <div className="bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 p-4 rounded-md">
-            <p className="text-yellow-800 dark:text-yellow-200 text-sm font-medium mb-2">
+          <div className="bg-caution/10 border border-caution/30 p-4 rounded-md">
+            <p className="text-caution text-sm font-medium mb-2">
               IMPORTANT: Write down your recovery phrase
             </p>
-            <p className="text-yellow-700 dark:text-yellow-300 text-xs">
+            <p className="text-muted-foreground text-xs">
               This {mnemonicLength}-word phrase is the ONLY way to recover your wallet if you lose
               access. Write it down and keep it in a secure location. Never share it with anyone.
             </p>
@@ -705,7 +705,7 @@ export default function WalletCreationForm({
             <div className="relative">
               <Label htmlFor="mnemonic-display">Recovery Phrase</Label>
               <div className="mt-1 relative">
-                <div className="bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded p-4 font-mono text-sm relative">
+                <div className="bg-muted border border-border rounded p-4 font-mono text-sm relative">
                   {generatedMnemonic}
                 </div>
               </div>
@@ -731,7 +731,7 @@ export default function WalletCreationForm({
               </div>
 
               {showAdvancedOptions && (
-                <div className="pt-2 space-y-3 border-t border-gray-200 dark:border-gray-800 mt-2">
+                <div className="pt-2 space-y-3 border-t border-border mt-2">
                   <div className="space-y-2">
                     <Label htmlFor="passphrase" className="flex items-center">
                       <span>BIP39 Passphrase (Optional &quot;25th Word&quot;)</span>
@@ -755,9 +755,9 @@ export default function WalletCreationForm({
                         disabled={isSubmitting}
                       >
                         {showPassphrase ? (
-                          <EyeOff className="h-4 w-4 text-gray-500" />
+                          <EyeOff className="h-4 w-4 text-muted-foreground" />
                         ) : (
-                          <Eye className="h-4 w-4 text-gray-500" />
+                          <Eye className="h-4 w-4 text-muted-foreground" />
                         )}
                       </Button>
                     </div>
@@ -838,7 +838,7 @@ export default function WalletCreationForm({
                   Creative bird-themed name! You can keep it or customize your own.
                 </p>
               )}
-              {nameError && <p className="text-red-500 text-sm mt-1">{nameError}</p>}
+              {nameError && <p className="text-destructive text-sm mt-1">{nameError}</p>}
             </div>
 
             <div className="space-y-2">
@@ -859,12 +859,12 @@ export default function WalletCreationForm({
 
               {/* Show compatibility warning for 24-word imports */}
               {mnemonic.trim() && mnemonic.trim().split(/\s+/).length === 24 && (
-                <Alert className="bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-700">
+                <Alert className="bg-primary/5 border-primary/20">
                   <AlertTriangle className="h-4 w-4" />
-                  <AlertTitle className="text-blue-800 dark:text-blue-200">
+                  <AlertTitle className="text-foreground">
                     24-Word Recovery Phrase Detected
                   </AlertTitle>
-                  <AlertDescription className="text-blue-700 dark:text-blue-300">
+                  <AlertDescription className="text-muted-foreground">
                     <p>
                       You&apos;re importing a 24-word recovery phrase. This provides enhanced
                       security but may not be compatible with other Avian wallet software.
@@ -900,7 +900,7 @@ export default function WalletCreationForm({
               </div>
 
               {showAdvancedOptions && (
-                <div className="pt-2 space-y-3 border-t border-gray-200 dark:border-gray-800 mt-2">
+                <div className="pt-2 space-y-3 border-t border-border mt-2">
                   <div className="space-y-2">
                     <Label htmlFor="passphrase" className="flex items-center">
                       <span>BIP39 Passphrase (Optional &quot;25th Word&quot;)</span>
@@ -924,9 +924,9 @@ export default function WalletCreationForm({
                         disabled={isSubmitting}
                       >
                         {showPassphrase ? (
-                          <EyeOff className="h-4 w-4 text-gray-500" />
+                          <EyeOff className="h-4 w-4 text-muted-foreground" />
                         ) : (
-                          <Eye className="h-4 w-4 text-gray-500" />
+                          <Eye className="h-4 w-4 text-muted-foreground" />
                         )}
                       </Button>
                     </div>
@@ -956,10 +956,10 @@ export default function WalletCreationForm({
                       ))}
                     </div>
                     {addressType !== 'p2pkh' && (
-                      <Alert className="bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-700">
+                      <Alert className="bg-caution/10 border-caution/30">
                         <AlertTriangle className="h-4 w-4" />
-                        <AlertTitle className="text-amber-800 dark:text-amber-200">Asset Transfers Not Supported</AlertTitle>
-                        <AlertDescription className="text-amber-700 dark:text-amber-300">
+                        <AlertTitle className="text-caution">Asset Transfers Not Supported</AlertTitle>
+                        <AlertDescription className="text-muted-foreground">
                           Avian asset operations (issue, transfer) require a Legacy (P2PKH) address.
                           SegWit addresses can only send and receive AVN.
                         </AlertDescription>
@@ -1000,12 +1000,12 @@ export default function WalletCreationForm({
                       </div>
 
                       {coinType === 175 && (
-                        <Alert className="bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-700">
+                        <Alert className="bg-caution/10 border-caution/30">
                           <AlertTriangle className="h-4 w-4" />
-                          <AlertTitle className="text-amber-800 dark:text-amber-200">
+                          <AlertTitle className="text-caution">
                             Legacy Compatibility Mode
                           </AlertTitle>
-                          <AlertDescription className="text-amber-700 dark:text-amber-300">
+                          <AlertDescription className="text-muted-foreground">
                             <p>
                               You&apos;re importing a wallet that may have been created with
                               Ravencoin&apos;s coin type (175). This setting affects the derivation
@@ -1053,9 +1053,9 @@ export default function WalletCreationForm({
                   disabled={isSubmitting}
                 >
                   {showPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-500" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-500" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
@@ -1089,9 +1089,9 @@ export default function WalletCreationForm({
                   disabled={isSubmitting}
                 >
                   {showConfirmPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-500" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-500" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
@@ -1171,7 +1171,7 @@ export default function WalletCreationForm({
                   Creative bird-themed name! You can keep it or customize your own.
                 </p>
               )}
-              {nameError && <p className="text-red-500 text-sm mt-1">{nameError}</p>}
+              {nameError && <p className="text-destructive text-sm mt-1">{nameError}</p>}
             </div>
 
             <div className="space-y-2">
@@ -1189,7 +1189,7 @@ export default function WalletCreationForm({
                   <AlertDescription>{privateKeyError}</AlertDescription>
                 </Alert>
               )}
-              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              <p className="mt-2 text-xs text-muted-foreground">
                 A WIF key typically starts with a &apos;5&apos;, &apos;K&apos;, or &apos;L&apos; and
                 is 51-52 characters long. Keep this key secure and never share it.
               </p>
@@ -1217,9 +1217,9 @@ export default function WalletCreationForm({
                   disabled={isSubmitting}
                 >
                   {showPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-500" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-500" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
@@ -1253,9 +1253,9 @@ export default function WalletCreationForm({
                   disabled={isSubmitting}
                 >
                   {showConfirmPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-500" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-500" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
@@ -1309,9 +1309,9 @@ export default function WalletCreationForm({
           </CardHeader>
         )}
         <CardContent className="space-y-4 pt-4">
-          <Alert className="border-blue-200 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-700">
-            <AlertDescription className="text-sm text-blue-800 dark:text-blue-200">
-              In Avian Core v5, run: <code className="font-mono text-xs bg-blue-100 dark:bg-blue-800 px-1 rounded">listdescriptors true</code> — then paste the descriptor for the address type you want to import.
+          <Alert className="border-primary/20 bg-primary/5">
+            <AlertDescription className="text-sm text-foreground">
+              In Avian Core v5, run: <code className="font-mono text-xs bg-primary/10 px-1 rounded">listdescriptors true</code> — then paste the descriptor for the address type you want to import.
             </AlertDescription>
           </Alert>
 
@@ -1339,7 +1339,7 @@ export default function WalletCreationForm({
                   <RefreshCw className="h-4 w-4" />
                 </Button>
               </div>
-              {nameError && <p className="text-red-500 text-sm mt-1">{nameError}</p>}
+              {nameError && <p className="text-destructive text-sm mt-1">{nameError}</p>}
             </div>
 
             <div className="space-y-2">
@@ -1383,7 +1383,7 @@ export default function WalletCreationForm({
                   onClick={() => setShowPassword(!showPassword)}
                   disabled={isSubmitting}
                 >
-                  {showPassword ? <EyeOff className="h-4 w-4 text-gray-500" /> : <Eye className="h-4 w-4 text-gray-500" />}
+                  {showPassword ? <EyeOff className="h-4 w-4 text-muted-foreground" /> : <Eye className="h-4 w-4 text-muted-foreground" />}
                 </Button>
               </div>
               {passwordStrength && <PasswordStrengthChecker password={password} onStrengthChange={handlePasswordStrengthChange} className="mt-2" />}
@@ -1410,7 +1410,7 @@ export default function WalletCreationForm({
                   onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                   disabled={isSubmitting}
                 >
-                  {showConfirmPassword ? <EyeOff className="h-4 w-4 text-gray-500" /> : <Eye className="h-4 w-4 text-gray-500" />}
+                  {showConfirmPassword ? <EyeOff className="h-4 w-4 text-muted-foreground" /> : <Eye className="h-4 w-4 text-muted-foreground" />}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
**PR 5 of the UI/UX refresh** — first of the settings sweep. Re-keys the first-run flow and settings landing to the Avian brand. Presentation only.

### What changed
- **Onboarding** — the five setup-method tiles unify to brand teal (dropping the rainbow, including a **reserved-for-testnet purple**); success + eye icons → tokens.
- **WalletCreationForm / MnemonicModal** — success → teal, warnings → `caution`, info → teal tint, danger/validation → `destructive`; grays and the mnemonic display surface → tokens.
- **PasswordStrength** — the weak→strong meter now steps `destructive → caution → caution → Sodium → teal` (a real brand scale), label on the same three-stop mapping.
- **Settings hub** — per-category icon colours unify to brand teal (dropping reserved purple/indigo).
- **settings/advanced** — the post-quantum feature card (generic purple) → teal info tint.

### Notes
- **`ContactAvatar` intentionally untouched** — its grays are identicon *contrast logic*, not brand surfaces.
- The app is **mainnet-only**; the reserved testnet-violet palette stands ready for an actual testnet mode that doesn't exist yet, so there's no testnet annunciator to build here.

### Safety
No crypto, `requireAuth`, or storage paths touched.

### Verification
typecheck ✓ · **542/542 unit ✓** · static build ✓ · **25/25 E2E ✓**