### PR TITLE
feat(ui): wallet management — brand re-key the settings/wallet cluster

### DIFF
--- a/src/app/settings/wallet/page.tsx
+++ b/src/app/settings/wallet/page.tsx
@@ -377,16 +377,16 @@ export default function WalletSettingsPage() {
                     </CardHeader>
                     <CardContent className="px-3 sm:px-6 pb-4 sm:pb-6">
                         <div className="space-y-4">
-                            <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg p-3 sm:p-4">
+                            <div className="bg-caution/10 border border-caution/30 rounded-lg p-3 sm:p-4">
                                 <div className="flex items-start gap-2 sm:gap-3">
-                                    <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-amber-500 flex items-center justify-center flex-shrink-0 mt-0.5">
+                                    <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-caution flex items-center justify-center flex-shrink-0 mt-0.5">
                                         <AlertTriangle className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-white" />
                                     </div>
                                     <div className="min-w-0 flex-1">
-                                        <h4 className="font-medium text-amber-800 dark:text-amber-200 mb-1 text-sm sm:text-base">
+                                        <h4 className="font-medium text-caution mb-1 text-sm sm:text-base">
                                             Security Warning
                                         </h4>
-                                        <p className="text-sm text-amber-700 dark:text-amber-300">
+                                        <p className="text-sm text-caution">
                                             Your recovery phrase grants full access to your wallet. Never share it with anyone and store it securely offline.
                                         </p>
                                     </div>
@@ -482,17 +482,17 @@ export default function WalletSettingsPage() {
 
                             {/* BIP39 Passphrase Section */}
                             {hasBip39Passphrase && (
-                                <div className="space-y-4 border-t border-gray-200 dark:border-gray-700 pt-4">
-                                    <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
+                                <div className="space-y-4 border-t border-border pt-4">
+                                    <div className="bg-primary/10 border border-primary/30 rounded-lg p-4">
                                         <div className="flex items-start gap-3">
-                                            <div className="w-5 h-5 rounded-full bg-blue-500 flex items-center justify-center flex-shrink-0 mt-0.5">
+                                            <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0 mt-0.5">
                                                 <Key className="w-3 h-3 text-white" />
                                             </div>
                                             <div>
-                                                <h4 className="font-medium text-blue-800 dark:text-blue-200 mb-1">
+                                                <h4 className="font-medium text-primary mb-1">
                                                     BIP39 Passphrase (25th Word) Available
                                                 </h4>
-                                                <p className="text-sm text-blue-700 dark:text-blue-300">
+                                                <p className="text-sm text-primary">
                                                     This wallet uses an additional BIP39 passphrase. You need BOTH the recovery phrase above AND the passphrase to fully restore this wallet.
                                                 </p>
                                             </div>
@@ -545,7 +545,7 @@ export default function WalletSettingsPage() {
                                                     </Button>
                                                 </div>
 
-                                                <div className={`bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-lg p-4 ${showPassphrase ? '' : 'filter blur-sm'}`}>
+                                                <div className={`bg-caution/10 border border-caution/30 rounded-lg p-4 ${showPassphrase ? '' : 'filter blur-sm'}`}>
                                                     <div className="font-mono text-sm break-all">
                                                         {exportedPassphrase}
                                                     </div>
@@ -575,8 +575,8 @@ export default function WalletSettingsPage() {
                                                 </div>
                                             )}
 
-                                            <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg p-3">
-                                                <p className="text-xs text-amber-700 dark:text-amber-300">
+                                            <div className="bg-caution/10 border border-caution/30 rounded-lg p-3">
+                                                <p className="text-xs text-caution">
                                                     🔒 Store this passphrase separately from your recovery phrase for maximum security. You need both to restore your wallet.
                                                 </p>
                                             </div>
@@ -601,16 +601,16 @@ export default function WalletSettingsPage() {
                     </CardHeader>
                     <CardContent className="px-3 sm:px-6 pb-4 sm:pb-6">
                         <div className="space-y-4">
-                            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg p-3 sm:p-4">
+                            <div className="bg-destructive/10 border border-destructive/30 rounded-lg p-3 sm:p-4">
                                 <div className="flex items-start gap-2 sm:gap-3">
-                                    <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-red-500 flex items-center justify-center flex-shrink-0 mt-0.5">
+                                    <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-destructive flex items-center justify-center flex-shrink-0 mt-0.5">
                                         <AlertTriangle className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-white" />
                                     </div>
                                     <div className="min-w-0 flex-1">
-                                        <h4 className="font-medium text-red-800 dark:text-red-200 mb-1 text-sm sm:text-base">
+                                        <h4 className="font-medium text-destructive mb-1 text-sm sm:text-base">
                                             Critical Security Warning
                                         </h4>
-                                        <p className="text-xs sm:text-sm text-red-700 dark:text-red-300">
+                                        <p className="text-xs sm:text-sm text-destructive">
                                             Your private key provides complete control over your funds. Only export when absolutely necessary and keep it secure.
                                         </p>
                                     </div>
@@ -715,16 +715,16 @@ export default function WalletSettingsPage() {
                     </CardHeader>
                     <CardContent className="px-3 sm:px-6 pb-4 sm:pb-6">
                         <div className="space-y-4">
-                            <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-3 sm:p-4">
+                            <div className="bg-primary/10 border border-primary/30 rounded-lg p-3 sm:p-4">
                                 <div className="flex items-start gap-2 sm:gap-3">
-                                    <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-blue-500 flex items-center justify-center flex-shrink-0 mt-0.5">
+                                    <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0 mt-0.5">
                                         <Lock className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-white" />
                                     </div>
                                     <div className="min-w-0 flex-1">
-                                        <h4 className="font-medium text-blue-800 dark:text-blue-200 mb-1 text-sm sm:text-base">
+                                        <h4 className="font-medium text-primary mb-1 text-sm sm:text-base">
                                             Wallet Encryption Status
                                         </h4>
-                                        <p className="text-xs sm:text-sm text-blue-700 dark:text-blue-300">
+                                        <p className="text-xs sm:text-sm text-primary">
                                             {isEncrypted
                                                 ? 'Your wallet is currently encrypted with a password. This provides additional security for your private keys.'
                                                 : 'Your wallet is not encrypted. Consider encrypting it with a password for additional security.'
@@ -738,12 +738,12 @@ export default function WalletSettingsPage() {
                                 <div className="flex items-center justify-between p-3 bg-muted/30 rounded-lg">
                                     <div className="flex items-center gap-3">
                                         {isEncrypted ? (
-                                            <div className="w-8 h-8 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
-                                                <Lock className="w-4 h-4 text-green-600 dark:text-green-400" />
+                                            <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
+                                                <Lock className="w-4 h-4 text-primary" />
                                             </div>
                                         ) : (
-                                            <div className="w-8 h-8 rounded-full bg-orange-100 dark:bg-orange-900/30 flex items-center justify-center">
-                                                <Unlock className="w-4 h-4 text-orange-600 dark:text-orange-400" />
+                                            <div className="w-8 h-8 rounded-full bg-caution/10 flex items-center justify-center">
+                                                <Unlock className="w-4 h-4 text-caution" />
                                             </div>
                                         )}
                                         <div>
@@ -756,8 +756,8 @@ export default function WalletSettingsPage() {
                                         </div>
                                     </div>
                                     <div className={`px-3 py-1 rounded-full text-xs font-medium ${isEncrypted
-                                        ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300'
-                                        : 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300'
+                                        ? 'bg-primary/10 text-primary'
+                                        : 'bg-caution/10 text-caution'
                                         }`}>
                                         {isEncrypted ? 'Encrypted' : 'Not Encrypted'}
                                     </div>
@@ -807,16 +807,16 @@ export default function WalletSettingsPage() {
                     <CardContent className="px-3 sm:px-6 pb-4 sm:pb-6">
                         <div className="space-y-4 sm:space-y-6">
                             {currentWalletAddress && (
-                                <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-3 sm:p-4">
+                                <div className="bg-primary/10 border border-primary/30 rounded-lg p-3 sm:p-4">
                                     <div className="flex items-start gap-2 sm:gap-3">
-                                        <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-blue-500 flex items-center justify-center flex-shrink-0 mt-0.5">
+                                        <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0 mt-0.5">
                                             <Wallet className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-white" />
                                         </div>
                                         <div className="min-w-0 flex-1">
-                                            <h4 className="font-medium text-blue-800 dark:text-blue-200 mb-1 text-sm sm:text-base">
+                                            <h4 className="font-medium text-primary mb-1 text-sm sm:text-base">
                                                 Current Wallet
                                             </h4>
-                                            <p className="text-xs sm:text-sm text-blue-700 dark:text-blue-300 font-mono break-all">
+                                            <p className="text-xs sm:text-sm text-primary font-mono break-all">
                                                 {currentWalletAddress}
                                             </p>
                                         </div>
@@ -824,16 +824,16 @@ export default function WalletSettingsPage() {
                                 </div>
                             )}
 
-                            <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded-lg p-3 sm:p-4">
+                            <div className="bg-primary/10 border border-primary/30 rounded-lg p-3 sm:p-4">
                                 <div className="flex items-start gap-2 sm:gap-3">
-                                    <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-green-500 flex items-center justify-center flex-shrink-0 mt-0.5">
+                                    <div className="w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0 mt-0.5">
                                         <Hash className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-white" />
                                     </div>
                                     <div className="min-w-0 flex-1">
-                                        <h4 className="font-medium text-green-800 dark:text-green-200 mb-1 text-sm sm:text-base">
+                                        <h4 className="font-medium text-primary mb-1 text-sm sm:text-base">
                                             HD Wallet Settings
                                         </h4>
-                                        <p className="text-xs sm:text-sm text-green-700 dark:text-green-300">
+                                        <p className="text-xs sm:text-sm text-primary">
                                             Configure how many addresses your HD wallet generates and manages. More addresses provide better privacy but use more resources.
                                         </p>
                                     </div>
@@ -860,10 +860,10 @@ export default function WalletSettingsPage() {
                                         </div>
                                     </div>
                                     <div className="flex items-center justify-center sm:justify-start gap-2 sm:ml-3">
-                                        <Badge className="bg-amber-200 text-amber-900 dark:bg-amber-800 dark:text-amber-100 text-xs">
+                                        <Badge className="bg-caution/10 text-caution dark:bg-caution/10 dark:text-caution text-xs">
                                             ×{addressCount}
                                         </Badge>
-                                        <Badge className="bg-indigo-200 text-indigo-900 dark:bg-indigo-800 dark:text-indigo-100 text-xs">
+                                        <Badge className="bg-primary/10 text-primary dark:bg-primary/10 dark:text-primary text-xs">
                                             ×{addressCount}
                                         </Badge>
                                     </div>
@@ -889,8 +889,8 @@ export default function WalletSettingsPage() {
                     </CardHeader>
                     <CardContent className="px-3 sm:px-6 pb-4 sm:pb-6">
                         <div className="space-y-4">
-                            <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-3 sm:p-4">
-                                <p className="text-sm text-blue-800 dark:text-blue-200">
+                            <div className="bg-primary/10 border border-primary/30 rounded-lg p-3 sm:p-4">
+                                <p className="text-sm text-primary">
                                     A BIP380 output script descriptor encodes your wallet&apos;s public key derivation policy.
                                     It can be imported into <strong>Avian Core v5.0.0</strong> (or compatible wallets) to create a watch-only descriptor wallet.
                                     It contains only your <em>public</em> key — no private key material is exposed.
@@ -941,7 +941,7 @@ export default function WalletSettingsPage() {
 
                                     <div className="flex flex-col items-center gap-2">
                                         <Label>QR Code</Label>
-                                        <div className="p-4 bg-white rounded-xl border">
+                                        <div className="p-4 bg-card rounded-xl border">
                                             <QRCodeSVG value={exportedDescriptor} size={200} />
                                         </div>
                                         <p className="text-xs text-muted-foreground text-center">

--- a/src/components/AddressBook.tsx
+++ b/src/components/AddressBook.tsx
@@ -242,7 +242,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
     <div className="space-y-4 mx-2 my-2 flex flex-col min-h-0">
       {/* Header */}
       <div className="flex items-center justify-between flex-shrink-0">
-        <h3 className="text-sm font-medium text-gray-900 dark:text-white">
+        <h3 className="text-sm font-medium text-foreground dark:text-white">
           Address Book ({addresses.length})
         </h3>
         <div className="flex gap-2">
@@ -274,7 +274,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
       {addresses.length > 0 && (
         <div className="space-y-3 flex-shrink-0">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
             <Input
               type="text"
               placeholder="Search addresses..."
@@ -288,7 +288,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
           <div className="flex flex-wrap gap-2">
             {/* Sort Options */}
             <div className="flex items-center">
-              <span className="text-xs text-gray-500 dark:text-gray-400 mr-2">Sort:</span>
+              <span className="text-xs text-muted-foreground mr-2">Sort:</span>
               <select
                 value={sortOrder}
                 onChange={(e) => setSortOrder(e.target.value as any)}
@@ -302,7 +302,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
 
             {/* Category Filter */}
             <div className="flex items-center">
-              <span className="text-xs text-gray-500 dark:text-gray-400 mr-2">Category:</span>
+              <span className="text-xs text-muted-foreground mr-2">Category:</span>
               <select
                 value={selectedCategory || ''}
                 onChange={(e) => setSelectedCategory(e.target.value || null)}
@@ -320,7 +320,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
             {/* Tag Filter */}
             {allTags.length > 0 && (
               <div className="flex items-center flex-wrap gap-1 ml-auto">
-                <span className="text-xs text-gray-500 dark:text-gray-400 mr-1">
+                <span className="text-xs text-muted-foreground mr-1">
                   Filter by tag:
                 </span>
                 <Button
@@ -438,7 +438,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                       <Button
                         variant="ghost"
                         size="sm"
-                        className="ml-1 h-4 w-4 p-0 hover:text-red-600 transition-colors"
+                        className="ml-1 h-4 w-4 p-0 hover:text-destructive transition-colors"
                         onClick={() =>
                           setNewAddress({
                             ...newAddress,
@@ -490,7 +490,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                 </div>
 
                 {allTags.length > 0 && (
-                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                  <div className="text-xs text-muted-foreground">
                     Existing tags:{' '}
                     {allTags.map((tag, i) => (
                       <Button
@@ -606,7 +606,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                   address={editAddress.address || 'contact'}
                   size="lg"
                 />
-                <div className="text-sm text-gray-600 dark:text-gray-400">
+                <div className="text-sm text-muted-foreground">
                   Avatar is automatically generated from the address
                 </div>
               </div>
@@ -626,7 +626,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="ml-1 h-4 w-4 p-0 hover:text-red-600"
+                      className="ml-1 h-4 w-4 p-0 hover:text-destructive"
                       onClick={() =>
                         setEditAddress({
                           ...editAddress,
@@ -677,7 +677,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                 </Button>
               </div>
               {allTags.length > 0 && (
-                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                <div className="text-xs text-muted-foreground mt-1">
                   Existing tags:{' '}
                   {allTags.map((tag, i) => (
                     <Button
@@ -721,8 +721,8 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
 
       {/* Delete Confirmation */}
       {showDeleteConfirm && (
-        <div className="p-4 border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 rounded-lg mb-4 flex-shrink-0">
-          <p className="text-sm text-red-600 dark:text-red-400 mb-3">
+        <div className="p-4 border border-destructive/30 bg-destructive/10 rounded-lg mb-4 flex-shrink-0">
+          <p className="text-sm text-destructive mb-3">
             Are you sure you want to delete this address? This cannot be undone.
           </p>
           <div className="flex gap-2">
@@ -743,7 +743,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
         className={`space-y-2 ${isAddingNew || editingId ? 'max-h-64 overflow-y-auto' : 'flex-1 overflow-y-auto'} min-h-0 border-t border-avian-100 dark:border-avian-800 pt-2`}
       >
         {filteredAddresses.length === 0 ? (
-          <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+          <div className="text-center py-8 text-muted-foreground">
             {searchQuery ? 'No addresses match your search' : 'No saved addresses'}
           </div>
         ) : (
@@ -773,7 +773,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                         </span>
                       )
                     )}
-                    <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
+                    <span className="font-medium text-sm text-foreground dark:text-white truncate">
                       {address.name}
                     </span>
                     {address.isOwnWallet && (
@@ -782,21 +782,21 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                       </span>
                     )}
                     {address.category && !address.isOwnWallet && (
-                      <span className="text-xs px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
+                      <span className="text-xs px-2 py-1 bg-muted/40 dark:bg-card text-muted-foreground rounded-full">
                         {DEFAULT_CATEGORIES.find((cat) => cat.id === address.category)?.name}
                       </span>
                     )}
                     {address.useCount > 0 && (
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                      <span className="text-xs text-muted-foreground">
                         ({address.useCount} uses)
                       </span>
                     )}
                   </div>
-                  <div className="text-xs font-mono text-gray-600 dark:text-gray-300 truncate">
+                  <div className="text-xs font-mono text-muted-foreground truncate">
                     {address.address}
                   </div>
                   {address.description && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate">
+                    <div className="text-xs text-muted-foreground mt-1 truncate">
                       {address.description}
                     </div>
                   )}
@@ -820,7 +820,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                   )}
 
                   {address.lastUsed && (
-                    <div className="flex items-center gap-1 mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <div className="flex items-center gap-1 mt-1 text-xs text-muted-foreground">
                       <Clock className="w-3 h-3" />
                       Last used: {new Date(address.lastUsed).toLocaleDateString()}
                     </div>
@@ -835,7 +835,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                       e.stopPropagation();
                       showQRCode(address);
                     }}
-                    className="h-8 w-8 p-0 text-gray-400 hover:text-avian-500"
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-avian-500"
                     title="Show QR Code"
                   >
                     <Share2 className="w-4 h-4" />
@@ -847,7 +847,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                       e.stopPropagation();
                       handleStartEdit(address);
                     }}
-                    className="h-8 w-8 p-0 text-gray-400 hover:text-blue-500"
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-primary"
                     title="Edit"
                   >
                     <Edit className="w-4 h-4" />
@@ -859,7 +859,7 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
                       e.stopPropagation();
                       setShowDeleteConfirm(address.id);
                     }}
-                    className="h-8 w-8 p-0 text-gray-400 hover:text-red-500"
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
                     title="Delete"
                   >
                     <Trash2 className="w-4 h-4" />

--- a/src/components/AddressBookButton.tsx
+++ b/src/components/AddressBookButton.tsx
@@ -61,7 +61,7 @@ export default function AddressBookButton({
         <div className="flex gap-2">
           <button
             onClick={handleOpenDrawer}
-            className={`p-2 text-gray-400 hover:text-avian-500 transition-colors ${className}`}
+            className={`p-2 text-muted-foreground hover:text-avian-500 transition-colors ${className}`}
             title="Address Book"
             type="button"
           >
@@ -70,7 +70,7 @@ export default function AddressBookButton({
           {showQRScanner && (
             <button
               onClick={handleOpenScanner}
-              className={`p-2 text-gray-400 hover:text-avian-500 transition-colors ${className}`}
+              className={`p-2 text-muted-foreground hover:text-avian-500 transition-colors ${className}`}
               title="Scan QR Code"
               type="button"
             >
@@ -103,7 +103,7 @@ export default function AddressBookButton({
         <div className="flex gap-1">
           <button
             onClick={handleOpenDrawer}
-            className={`px-2 py-1 text-xs bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded transition-colors ${className}`}
+            className={`px-2 py-1 text-xs bg-muted/40 dark:bg-card hover:bg-muted/40 dark:hover:bg-card text-muted-foreground rounded transition-colors ${className}`}
             type="button"
           >
             <Book className="w-3 h-3 inline mr-1" />
@@ -112,7 +112,7 @@ export default function AddressBookButton({
           {showQRScanner && (
             <button
               onClick={handleOpenScanner}
-              className={`px-2 py-1 text-xs bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded transition-colors ${className}`}
+              className={`px-2 py-1 text-xs bg-muted/40 dark:bg-card hover:bg-muted/40 dark:hover:bg-card text-muted-foreground rounded transition-colors ${className}`}
               type="button"
             >
               <QrCode className="w-3 h-3" />
@@ -153,7 +153,7 @@ export default function AddressBookButton({
         {showQRScanner && (
           <button
             onClick={handleOpenScanner}
-            className={`flex items-center px-3 py-2 text-sm bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors ${className}`}
+            className={`flex items-center px-3 py-2 text-sm bg-card hover:bg-card text-white rounded-lg transition-colors ${className}`}
             type="button"
           >
             <QrCode className="w-4 h-4 mr-2" />

--- a/src/components/DerivedAddressesPanel.tsx
+++ b/src/components/DerivedAddressesPanel.tsx
@@ -84,7 +84,7 @@ const AddressDetailsDialog = ({
         <div className="space-y-6">
             {/* QR Code */}
             <div className="flex justify-center">
-                <div className="p-4 bg-white rounded-lg shadow-sm border border-gray-100 dark:border-gray-600">
+                <div className="p-4 bg-card rounded-lg shadow-sm border border-border">
                     <QRCodeSVG
                         value={addressDetails.address}
                         size={isMobile ? 160 : 180}
@@ -99,16 +99,16 @@ const AddressDetailsDialog = ({
             <div className="grid gap-4">
                 {/* Address */}
                 <div className="space-y-1.5">
-                    <Label className="text-sm font-medium text-gray-600 dark:text-gray-300">Address</Label>
+                    <Label className="text-sm font-medium text-muted-foreground">Address</Label>
                     <div className="relative">
-                        <div className="p-3 pr-10 bg-gray-100 dark:bg-gray-800 rounded-md border border-gray-200 dark:border-gray-700 font-mono text-sm break-all">
+                        <div className="p-3 pr-10 bg-muted/40 dark:bg-card rounded-md border border-border font-mono text-sm break-all">
                             {addressDetails.address}
                         </div>
                         <Button
                             variant="ghost"
                             size="icon"
                             onClick={() => onCopy(addressDetails.address)}
-                            className="absolute right-1.5 top-1.5 h-7 w-7 opacity-70 hover:opacity-100 bg-gray-100/50 dark:bg-gray-800/50 backdrop-blur-sm"
+                            className="absolute right-1.5 top-1.5 h-7 w-7 opacity-70 hover:opacity-100 bg-muted/40 dark:bg-card backdrop-blur-sm"
                             title="Copy address"
                         >
                             <Copy className="h-4 w-4" />
@@ -118,16 +118,16 @@ const AddressDetailsDialog = ({
 
                 {/* Balance */}
                 <div className="space-y-1.5">
-                    <Label className="text-sm font-medium text-gray-600 dark:text-gray-300">Balance</Label>
+                    <Label className="text-sm font-medium text-muted-foreground">Balance</Label>
                     <div
-                        className={`p-3 bg-gray-100 dark:bg-gray-800 rounded-md border ${addressDetails.balance > 0
-                            ? 'border-emerald-300 dark:border-emerald-700'
-                            : 'border-gray-200 dark:border-gray-700'
+                        className={`p-3 bg-muted/40 dark:bg-card rounded-md border ${addressDetails.balance > 0
+                            ? 'border-primary/30'
+                            : 'border-border'
                             }`}
                     >
                         <span
                             className={`font-mono text-lg ${addressDetails.balance > 0
-                                ? 'text-emerald-600 dark:text-emerald-400'
+                                ? 'text-primary'
                                 : 'text-muted-foreground'
                                 }`}
                         >
@@ -138,7 +138,7 @@ const AddressDetailsDialog = ({
                                 })
                                 : '0.00000000'}
                         </span>
-                        <span className="ml-1.5 font-medium text-gray-600 dark:text-gray-400">AVN</span>
+                        <span className="ml-1.5 font-medium text-muted-foreground">AVN</span>
                     </div>
                 </div>
 
@@ -146,15 +146,15 @@ const AddressDetailsDialog = ({
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     {/* Type */}
                     <div className="space-y-1.5">
-                        <Label className="text-sm font-medium text-gray-600 dark:text-gray-300">Type</Label>
+                        <Label className="text-sm font-medium text-muted-foreground">Type</Label>
                         <div>
                             {addressDetails.path.includes('(receiving)') ? (
-                                <Badge className="px-3 py-1.5 bg-amber-200 dark:bg-amber-800/60 text-amber-900 dark:text-amber-100 border-amber-300 dark:border-amber-700 font-medium">
+                                <Badge className="px-3 py-1.5 bg-caution/10 text-caution border-caution/30 font-medium">
                                     <ArrowDownLeft className="w-3.5 h-3.5 mr-1.5" />
                                     Receiving
                                 </Badge>
                             ) : (
-                                <Badge className="px-3 py-1.5 bg-indigo-200 dark:bg-indigo-800/60 text-indigo-900 dark:text-indigo-100 border-indigo-300 dark:border-indigo-700 font-medium">
+                                <Badge className="px-3 py-1.5 bg-primary/10 text-primary border-primary/30 font-medium">
                                     <ArrowUpRight className="w-3.5 h-3.5 mr-1.5" />
                                     Change
                                 </Badge>
@@ -164,17 +164,17 @@ const AddressDetailsDialog = ({
 
                     {/* Transaction History */}
                     <div className="space-y-1.5 mb-4">
-                        <Label className="text-sm font-medium text-gray-600 dark:text-gray-300">Status</Label>
+                        <Label className="text-sm font-medium text-muted-foreground">Status</Label>
                         <div>
                             {addressDetails.hasTransactions ? (
-                                <Badge className="px-3 py-1.5 bg-blue-200 dark:bg-blue-800/60 text-blue-900 dark:text-blue-100 border-blue-300 dark:border-blue-700 font-medium">
+                                <Badge className="px-3 py-1.5 bg-primary/10 text-primary border-primary/30 font-medium">
                                     <Activity className="w-3.5 h-3.5 mr-1.5" />
                                     Has Transactions
                                 </Badge>
                             ) : (
                                 <Badge
                                     variant="outline"
-                                    className="px-3 py-1.5 bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-300 border-gray-300 dark:border-gray-700 font-medium"
+                                    className="px-3 py-1.5 bg-muted/40 dark:bg-card text-foreground dark:text-muted-foreground border-border font-medium"
                                 >
                                     <Ban className="w-3.5 h-3.5 mr-1.5" />
                                     No Transactions
@@ -233,7 +233,7 @@ const AddressDetailsDialog = ({
 
                     <div className="px-4 overflow-y-auto">{dialogContent}</div>
 
-                    <DrawerFooter className="border-t border-gray-200 dark:border-gray-700 pt-4">
+                    <DrawerFooter className="border-t border-border pt-4">
                         {actionButtons}
                     </DrawerFooter>
                 </DrawerContent>
@@ -256,7 +256,7 @@ const AddressDetailsDialog = ({
 
                 <div className="py-4">{dialogContent}</div>
 
-                <DialogFooter className="border-t border-gray-200 dark:border-gray-700 pt-4">
+                <DialogFooter className="border-t border-border pt-4">
                     {actionButtons}
                 </DialogFooter>
             </DialogContent>
@@ -268,7 +268,7 @@ const LoadingIndicator = ({ isLoading }: { isLoading: boolean }) => {
     if (!isLoading) return null;
 
     return (
-        <Card className="bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-100 dark:border-blue-800 mb-4">
+        <Card className="bg-primary/10 text-primary border-primary/30 mb-4">
             <CardContent className="flex items-center p-2">
                 <svg
                     className="animate-spin -ml-1 mr-3 h-5 w-5"
@@ -720,22 +720,22 @@ export default function DerivedAddressesPanel() {
     if (!isHdWallet) {
         return (
             <div
-                className={`mt-4 rounded-lg shadow-md bg-white dark:bg-gray-800 ${isMobile ? 'p-4' : 'p-4'}`}
+                className={`mt-4 rounded-lg shadow-md bg-card ${isMobile ? 'p-4' : 'p-4'}`}
             >
                 <div className="flex items-center justify-between">
                     <h2
-                        className={`font-semibold text-gray-800 dark:text-gray-200 ${isMobile ? 'text-lg' : 'text-lg'}`}
+                        className={`font-semibold text-foreground dark:text-muted-foreground ${isMobile ? 'text-lg' : 'text-lg'}`}
                     >
                         HD Wallet Addresses
                     </h2>
                 </div>
                 <div
-                    className={`mt-2 rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 text-center ${isMobile ? 'p-3' : 'p-4'}`}
+                    className={`mt-2 rounded-md border border-caution/30 bg-caution/10 text-center ${isMobile ? 'p-3' : 'p-4'}`}
                 >
-                    <p className="text-sm text-amber-700 dark:text-amber-300">
+                    <p className="text-sm text-caution">
                         This wallet was not created with HD (hierarchical deterministic) capabilities.
                     </p>
-                    <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                    <p className="text-xs text-caution mt-1">
                         Only wallets created with a seed phrase support derived addresses.
                     </p>
                 </div>
@@ -828,10 +828,10 @@ export default function DerivedAddressesPanel() {
                                         </div>
                                     </div>
                                     <div className="flex items-center justify-center sm:justify-start gap-2">
-                                        <Badge className="bg-amber-200 text-amber-900 dark:bg-amber-800 dark:text-amber-100">
+                                        <Badge className="bg-caution/10 text-caution dark:bg-caution/10 dark:text-caution">
                                             ×{addressCount}
                                         </Badge>
-                                        <Badge className="bg-indigo-200 text-indigo-900 dark:bg-indigo-800 dark:text-indigo-100">
+                                        <Badge className="bg-primary/10 text-primary dark:bg-primary/10 dark:text-primary">
                                             ×{addressCount}
                                         </Badge>
                                     </div>
@@ -861,7 +861,7 @@ export default function DerivedAddressesPanel() {
                                         This value is automatically determined by your wallet. Different coin types generate completely different addresses.
                                     </p>
                                     {coinType === 175 && (
-                                        <p className="text-amber-600 dark:text-amber-400 font-medium">
+                                        <p className="text-caution font-medium">
                                             ⚠️ Using Ravencoin compatibility mode
                                         </p>
                                     )}
@@ -901,12 +901,12 @@ export default function DerivedAddressesPanel() {
                                         onValueChange={(val: string) =>
                                             setActiveTab(val as 'all' | 'receiving' | 'change' | 'with-balance')
                                         }
-                                        className="w-full border-b border-gray-200 dark:border-gray-700"
+                                        className="w-full border-b border-border"
                                     >
                                         <TabsList className="flex h-auto bg-transparent p-0 w-full">
                                             <TabsTrigger
                                                 value="all"
-                                                className={`flex-1 flex items-center justify-center ${isMobile ? 'px-2 py-3' : 'px-6 py-4'} data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-gray-500 dark:text-gray-400 h-auto relative`}
+                                                className={`flex-1 flex items-center justify-center ${isMobile ? 'px-2 py-3' : 'px-6 py-4'} data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-muted-foreground h-auto relative`}
                                             >
                                                 <Wallet className={`${isMobile ? 'w-3 h-3 mr-1' : 'w-4 h-4 mr-2'}`} />
                                                 <span className={isMobile ? 'text-xs' : ''}>
@@ -915,7 +915,7 @@ export default function DerivedAddressesPanel() {
                                             </TabsTrigger>
                                             <TabsTrigger
                                                 value="receiving"
-                                                className={`flex-1 flex items-center justify-center ${isMobile ? 'px-2 py-3' : 'px-6 py-4'} data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-gray-500 dark:text-gray-400 h-auto relative`}
+                                                className={`flex-1 flex items-center justify-center ${isMobile ? 'px-2 py-3' : 'px-6 py-4'} data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-muted-foreground h-auto relative`}
                                             >
                                                 <ArrowDownLeft className={`${isMobile ? 'w-3 h-3 mr-1' : 'w-4 h-4 mr-2'}`} />
                                                 <span className={isMobile ? 'text-xs' : ''}>
@@ -924,14 +924,14 @@ export default function DerivedAddressesPanel() {
                                             </TabsTrigger>
                                             <TabsTrigger
                                                 value="change"
-                                                className={`flex-1 flex items-center justify-center ${isMobile ? 'px-2 py-3' : 'px-6 py-4'} data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-gray-500 dark:text-gray-400 h-auto relative`}
+                                                className={`flex-1 flex items-center justify-center ${isMobile ? 'px-2 py-3' : 'px-6 py-4'} data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-muted-foreground h-auto relative`}
                                             >
                                                 <ArrowUpRight className={`${isMobile ? 'w-3 h-3 mr-1' : 'w-4 h-4 mr-2'}`} />
                                                 <span className={isMobile ? 'text-xs' : ''}>Change</span>
                                             </TabsTrigger>
                                             <TabsTrigger
                                                 value="with-balance"
-                                                className={`flex-1 flex items-center justify-center ${isMobile ? 'px-2 py-3' : 'px-6 py-4'} data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-gray-500 dark:text-gray-400 h-auto relative`}
+                                                className={`flex-1 flex items-center justify-center ${isMobile ? 'px-2 py-3' : 'px-6 py-4'} data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-muted-foreground h-auto relative`}
                                             >
                                                 <Banknote className={`${isMobile ? 'w-3 h-3 mr-1' : 'w-4 h-4 mr-2'}`} />
                                                 <span className={isMobile ? 'text-xs' : ''}>
@@ -962,22 +962,22 @@ export default function DerivedAddressesPanel() {
                                 </div>
                             )}{' '}
                             {filteredAddresses.length > 0 && (
-                                <div className="p-3 mb-4 bg-gray-50 dark:bg-gray-800/80 border border-gray-200 dark:border-gray-700 rounded-md">
-                                    <h3 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-200">
+                                <div className="p-3 mb-4 bg-muted/40 dark:bg-card border border-border rounded-md">
+                                    <h3 className="text-sm font-medium mb-2 text-muted-foreground">
                                         Legend
                                     </h3>
                                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                                         {/* Row indicators - Enhanced contrast */}
                                         <div className="space-y-2">
                                             <div className="flex items-center">
-                                                <div className="w-5 h-5 bg-emerald-200 dark:bg-emerald-800/60 border border-emerald-300 dark:border-emerald-600 mr-3 rounded"></div>
-                                                <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
+                                                <div className="w-5 h-5 bg-primary/10 border border-primary/30 mr-3 rounded"></div>
+                                                <span className="text-sm text-muted-foreground font-medium">
                                                     Address with balance
                                                 </span>
                                             </div>
                                             <div className="flex items-center">
-                                                <div className="w-5 h-5 bg-blue-200 dark:bg-blue-800/60 border border-blue-300 dark:border-blue-600 mr-3 rounded"></div>
-                                                <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
+                                                <div className="w-5 h-5 bg-primary/10 border border-primary/30 mr-3 rounded"></div>
+                                                <span className="text-sm text-muted-foreground font-medium">
                                                     Address with transaction history
                                                 </span>
                                             </div>
@@ -986,14 +986,14 @@ export default function DerivedAddressesPanel() {
                                         {/* Type indicators - Enhanced contrast */}
                                         <div className="space-y-2">
                                             <div className="flex items-center">
-                                                <div className="w-5 h-5 border-l-4 border-amber-500 dark:border-amber-400 bg-amber-100/50 dark:bg-amber-900/30 mr-3 rounded"></div>
-                                                <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
+                                                <div className="w-5 h-5 border-l-4 border-caution bg-caution/10 mr-3 rounded"></div>
+                                                <span className="text-sm text-muted-foreground font-medium">
                                                     Receiving address (m/{walletAddressType === 'p2wpkh' ? 84 : walletAddressType === 'p2sh-p2wpkh' ? 49 : 44}&apos;/{coinType}&apos;/0&apos;/0/x)
                                                 </span>
                                             </div>
                                             <div className="flex items-center">
-                                                <div className="w-5 h-5 border-l-4 border-indigo-500 dark:border-indigo-400 bg-indigo-100/50 dark:bg-indigo-900/30 mr-3 rounded"></div>
-                                                <span className="text-sm text-gray-700 dark:text-gray-300 font-medium">
+                                                <div className="w-5 h-5 border-l-4 border-primary bg-primary/10 mr-3 rounded"></div>
+                                                <span className="text-sm text-muted-foreground font-medium">
                                                     Change address (m/{walletAddressType === 'p2wpkh' ? 84 : walletAddressType === 'p2sh-p2wpkh' ? 49 : 44}&apos;/{coinType}&apos;/0&apos;/1/x)
                                                 </span>
                                             </div>
@@ -1009,8 +1009,8 @@ export default function DerivedAddressesPanel() {
                     <div className="mt-2 sm:overflow-visible overflow-x-auto">
                         {/* Mobile hint */}
                         {isMobile && (
-                            <div className="mb-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-md sm:hidden">
-                                <p className="text-xs text-blue-700 dark:text-blue-300 flex items-center">
+                            <div className="mb-3 px-3 py-2 bg-primary/10 border border-primary/30 rounded-md sm:hidden">
+                                <p className="text-xs text-primary flex items-center">
                                     <svg className="w-3 h-3 mr-1.5" fill="currentColor" viewBox="0 0 20 20">
                                         <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                                     </svg>
@@ -1018,45 +1018,45 @@ export default function DerivedAddressesPanel() {
                                 </p>
                             </div>
                         )}
-                        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-600">
-                            <thead className="bg-gray-50 dark:bg-gray-700 dark:bg-opacity-80">
+                        <table className="min-w-full divide-y divide-border">
+                            <thead className="bg-muted/40 dark:bg-card dark:bg-opacity-80">
                                 <tr>
-                                    <th className="px-3 py-3 text-left text-xs font-medium text-gray-600 dark:text-gray-200 uppercase tracking-wider w-1/4">
+                                    <th className="px-3 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider w-1/4">
                                         Details
                                     </th>
                                     {/* Address column - hidden on mobile */}
-                                    <th className="hidden sm:table-cell px-3 py-3 text-left text-xs font-medium text-gray-600 dark:text-gray-200 uppercase tracking-wider">
+                                    <th className="hidden sm:table-cell px-3 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
                                         Address
                                     </th>
-                                    <th className="px-3 py-3 text-center text-xs font-medium text-gray-600 dark:text-gray-200 uppercase tracking-wider w-[120px]">
+                                    <th className="px-3 py-3 text-center text-xs font-medium text-muted-foreground uppercase tracking-wider w-[120px]">
                                         Balance
                                     </th>
                                     {/* Actions column - hidden on mobile */}
-                                    <th className="hidden sm:table-cell px-3 py-3 text-center text-xs font-medium text-gray-600 dark:text-gray-200 uppercase tracking-wider w-[140px]">
+                                    <th className="hidden sm:table-cell px-3 py-3 text-center text-xs font-medium text-muted-foreground uppercase tracking-wider w-[140px]">
                                         Actions
                                     </th>
                                 </tr>
                             </thead>
-                            <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
+                            <tbody className="divide-y divide-border">
                                 {filteredAddresses.map((item, index) => {
                                     // Build comprehensive class string
                                     const baseClasses = isMobile
-                                        ? 'transition-colors bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer'
-                                        : 'transition-colors bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700';
+                                        ? 'transition-colors bg-card hover:bg-muted/40 dark:hover:bg-card cursor-pointer'
+                                        : 'transition-colors bg-card hover:bg-muted/40 dark:hover:bg-card';
 
                                     // Background color classes based on balance/transaction status
                                     const backgroundClasses =
                                         item.balance > 0
-                                            ? 'bg-emerald-200/60 dark:bg-emerald-800/40 hover:bg-emerald-200/80 dark:hover:bg-emerald-800/50'
+                                            ? 'bg-primary/10 hover:bg-primary/20 dark:hover:bg-primary/20'
                                             : item.hasTransactions && item.balance <= 0
-                                                ? 'bg-blue-200/60 dark:bg-blue-800/40 hover:bg-blue-200/80 dark:hover:bg-blue-800/50'
+                                                ? 'bg-muted/50 hover:bg-muted dark:hover:bg-muted'
                                                 : '';
 
                                     // Border classes based on address type - ensure specificity
                                     const borderClasses = item.path.includes('(receiving)')
-                                        ? '!border-l-4 !border-amber-500 dark:!border-amber-400'
+                                        ? '!border-l-4 !border-caution'
                                         : item.path.includes('(change)')
-                                            ? '!border-l-4 !border-indigo-500 dark:!border-indigo-400'
+                                            ? '!border-l-4 !border-primary'
                                             : '';
 
                                     const rowClasses = [baseClasses, backgroundClasses, borderClasses]
@@ -1081,7 +1081,7 @@ export default function DerivedAddressesPanel() {
                                             }}
                                         >
                                             <td
-                                                className="px-3 py-2 text-xs font-mono text-gray-700 dark:text-gray-300"
+                                                className="px-3 py-2 text-xs font-mono text-muted-foreground"
                                                 title={item.path}
                                             >
                                                 <div className="flex flex-wrap items-center gap-2">
@@ -1092,7 +1092,7 @@ export default function DerivedAddressesPanel() {
                                                     {item.path.includes('(receiving)') && (
                                                         <Badge
                                                             variant="outline"
-                                                            className="bg-amber-200 dark:bg-amber-800/60 text-amber-900 dark:text-amber-100 border-amber-300 dark:border-amber-700 font-medium whitespace-nowrap"
+                                                            className="bg-caution/10 text-caution border-caution/30 font-medium whitespace-nowrap"
                                                         >
                                                             Receive
                                                         </Badge>
@@ -1101,7 +1101,7 @@ export default function DerivedAddressesPanel() {
                                                     {item.path.includes('(change)') && (
                                                         <Badge
                                                             variant="outline"
-                                                            className="bg-indigo-200 dark:bg-indigo-800/60 text-indigo-900 dark:text-indigo-100 border-indigo-300 dark:border-indigo-700 font-medium whitespace-nowrap"
+                                                            className="bg-primary/10 text-primary border-primary/30 font-medium whitespace-nowrap"
                                                         >
                                                             Change
                                                         </Badge>
@@ -1109,15 +1109,15 @@ export default function DerivedAddressesPanel() {
                                                 </div>
                                             </td>
                                             {/* Address column - hidden on mobile */}
-                                            <td className="hidden sm:table-cell px-3 py-2 text-sm font-mono text-gray-700 dark:text-gray-300">
+                                            <td className="hidden sm:table-cell px-3 py-2 text-sm font-mono text-muted-foreground">
                                                 <div className="flex items-center" title={item.address}>
-                                                    <div className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded w-full max-w-full">
+                                                    <div className="bg-muted/40 dark:bg-card px-2 py-1 rounded w-full max-w-full">
                                                         <span className="hidden sm:inline font-medium tracking-wide break-all">
                                                             {item.address}
                                                         </span>
                                                         <span className="sm:hidden font-medium tracking-wide">
                                                             {item.address.substring(0, 6)}
-                                                            <span className="text-gray-400 dark:text-gray-500 px-1">...</span>
+                                                            <span className="text-muted-foreground px-1">...</span>
                                                             {item.address.substring(item.address.length - 6)}
                                                         </span>
                                                     </div>
@@ -1125,17 +1125,17 @@ export default function DerivedAddressesPanel() {
                                             </td>
                                             <td className="px-3 py-2 text-center">
                                                 {item.balance > 0 ? (
-                                                    <Badge className="bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800 hover:bg-emerald-200 dark:hover:bg-emerald-800/60 transition-colors">
+                                                    <Badge className="bg-primary/10 text-primary border-primary/30 hover:bg-primary/10 dark:hover:bg-primary/10 transition-colors">
                                                         {(item.balance / 100000000).toFixed(8)} AVN
                                                     </Badge>
                                                 ) : item.hasTransactions ? (
-                                                    <Badge className="bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800 hover:bg-blue-200 dark:hover:bg-blue-800/60 transition-colors">
+                                                    <Badge className="bg-primary/10 text-primary border-primary/30 hover:bg-primary/10 dark:hover:bg-primary/10 transition-colors">
                                                         0 AVN
                                                     </Badge>
                                                 ) : (
                                                     <Badge
                                                         variant="outline"
-                                                        className="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                                                        className="text-muted-foreground hover:bg-muted/40 dark:hover:bg-card transition-colors"
                                                     >
                                                         0 AVN
                                                     </Badge>
@@ -1148,11 +1148,11 @@ export default function DerivedAddressesPanel() {
                                                         onClick={() => openAddressDetails(item)}
                                                         size="icon"
                                                         variant="ghost"
-                                                        className="text-blue-500 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 group relative transition-colors h-8 w-8"
+                                                        className="text-primary hover:text-primary dark:hover:text-primary group relative transition-colors h-8 w-8"
                                                         aria-label="View address details"
                                                     >
                                                         <Info className="w-4 h-4" />
-                                                        <span className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-2 py-1 text-xs rounded opacity-0 group-hover:opacity-100 whitespace-nowrap pointer-events-none transition-opacity shadow-lg">
+                                                        <span className="absolute -top-8 left-1/2 -translate-x-1/2 bg-card text-white px-2 py-1 text-xs rounded opacity-0 group-hover:opacity-100 whitespace-nowrap pointer-events-none transition-opacity shadow-lg">
                                                             View Details
                                                         </span>
                                                     </Button>
@@ -1161,15 +1161,15 @@ export default function DerivedAddressesPanel() {
                                                         onClick={() => copyAddressWithFeedback(item.address)}
                                                         size="icon"
                                                         variant="ghost"
-                                                        className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 group relative transition-colors h-8 w-8"
+                                                        className="text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground group relative transition-colors h-8 w-8"
                                                         aria-label="Copy address to clipboard"
                                                     >
                                                         {copiedAddress === item.address ? (
-                                                            <CheckCircle className="w-4 h-4 text-green-500" />
+                                                            <CheckCircle className="w-4 h-4 text-primary" />
                                                         ) : (
                                                             <Copy className="w-4 h-4" />
                                                         )}
-                                                        <span className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-2 py-1 text-xs rounded opacity-0 group-hover:opacity-100 whitespace-nowrap pointer-events-none transition-opacity shadow-lg">
+                                                        <span className="absolute -top-8 left-1/2 -translate-x-1/2 bg-card text-white px-2 py-1 text-xs rounded opacity-0 group-hover:opacity-100 whitespace-nowrap pointer-events-none transition-opacity shadow-lg">
                                                             {copiedAddress === item.address ? 'Copied!' : 'Copy Address'}
                                                         </span>
                                                     </Button>
@@ -1187,7 +1187,7 @@ export default function DerivedAddressesPanel() {
                                                             aria-label="Open address in Avian Explorer (opens in new tab)"
                                                         >
                                                             <ExternalLink className="w-4 h-4" />
-                                                            <span className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-2 py-1 text-xs rounded opacity-0 group-hover:opacity-100 whitespace-nowrap pointer-events-none transition-opacity shadow-lg">
+                                                            <span className="absolute -top-8 left-1/2 -translate-x-1/2 bg-card text-white px-2 py-1 text-xs rounded opacity-0 group-hover:opacity-100 whitespace-nowrap pointer-events-none transition-opacity shadow-lg">
                                                                 View on Explorer
                                                             </span>
                                                         </a>
@@ -1202,9 +1202,9 @@ export default function DerivedAddressesPanel() {
                     </div>
                 ) : (
                     !isLoading && (
-                        <div className="p-6 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-center">
+                        <div className="p-6 rounded-md border border-border bg-muted/40 dark:bg-card text-center">
                             <div className="flex flex-col items-center justify-center space-y-4">
-                                <div className="rounded-full p-3 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400">
+                                <div className="rounded-full p-3 bg-primary/10 text-primary">
                                     <svg
                                         className="w-6 h-6"
                                         xmlns="http://www.w3.org/2000/svg"
@@ -1218,17 +1218,17 @@ export default function DerivedAddressesPanel() {
                                         <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
                                     </svg>
                                 </div>
-                                <h3 className="text-base font-medium text-gray-700 dark:text-gray-300">
+                                <h3 className="text-base font-medium text-muted-foreground">
                                     No Addresses Loaded
                                 </h3>
-                                <p className="text-sm text-gray-500 dark:text-gray-400 max-w-md">
+                                <p className="text-sm text-muted-foreground max-w-md">
                                     Click the button below to authenticate and load your wallet&apos;s derived
                                     addresses.
                                 </p>
                                 <Button
                                     onClick={loadDerivedAddresses}
                                     size="lg"
-                                    className="bg-emerald-500 hover:bg-emerald-600 dark:bg-emerald-600 dark:hover:bg-emerald-700 mt-2"
+                                    className="bg-primary hover:bg-primary dark:hover:bg-primary mt-2"
                                 >
                                     <svg
                                         className="w-5 h-5 mr-2"

--- a/src/components/UTXOOverview.tsx
+++ b/src/components/UTXOOverview.tsx
@@ -108,9 +108,9 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
   };
 
   const getConfirmationIcon = (confirmations: number) => {
-    if (confirmations === 0) return <Clock className="w-4 h-4 text-yellow-500" />;
-    if (confirmations < 6) return <AlertCircle className="w-4 h-4 text-orange-500" />;
-    return <Check className="w-4 h-4 text-green-500" />;
+    if (confirmations === 0) return <Clock className="w-4 h-4 text-caution" />;
+    if (confirmations < 6) return <AlertCircle className="w-4 h-4 text-caution" />;
+    return <Check className="w-4 h-4 text-primary" />;
   };
 
   const getConfirmationStatus = (confirmations: number) => {
@@ -231,7 +231,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
               {isDust && (
                 <Badge
                   variant="outline"
-                  className="bg-red-100 dark:bg-red-900/20 text-red-700 dark:text-red-400 border-red-200 dark:border-red-800"
+                  className="bg-destructive/10 text-destructive border-destructive/30"
                 >
                   Dust
                 </Badge>
@@ -239,7 +239,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
               {!isDust && isSmall && (
                 <Badge
                   variant="outline"
-                  className="bg-yellow-100 dark:bg-yellow-900/20 text-yellow-700 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800"
+                  className="bg-caution/10 text-caution border-caution/30"
                 >
                   Small
                 </Badge>
@@ -512,7 +512,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
         </Card>
         <Card>
           <CardContent className="p-4 text-center">
-            <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+            <div className="text-2xl font-bold text-primary">
               {confirmedUTXOs}
             </div>
             <div className="text-sm text-muted-foreground">Confirmed</div>
@@ -520,7 +520,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
         </Card>
         <Card>
           <CardContent className="p-4 text-center">
-            <div className="text-2xl font-bold text-orange-600 dark:text-orange-400">
+            <div className="text-2xl font-bold text-caution">
               {smallUTXOs}
             </div>
             <div className="text-sm text-muted-foreground">Small UTXOs</div>
@@ -528,7 +528,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
         </Card>
         <Card>
           <CardContent className="p-4 text-center">
-            <div className="text-2xl font-bold text-red-600 dark:text-red-400">{dustUTXOs}</div>
+            <div className="text-2xl font-bold text-destructive">{dustUTXOs}</div>
             <div className="text-sm text-muted-foreground">Dust UTXOs</div>
           </CardContent>
         </Card>
@@ -558,8 +558,8 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
 
       {/* HD Wallet Warning */}
       {isHdWallet && !allAddressesLoaded && (
-        <Alert className="mb-4 bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200">
-          <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+        <Alert className="mb-4 bg-caution/10 border-caution/30 text-caution">
+          <AlertCircle className="h-4 w-4 text-caution" />
           <AlertTitle>HD Wallet Detected</AlertTitle>
           <AlertDescription className="space-y-3">
             <p>
@@ -571,7 +571,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
               size="sm"
               onClick={loadAllHDUTXOs}
               disabled={loadingHdAddresses}
-              className="bg-amber-100 dark:bg-amber-900/40 border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200 hover:bg-amber-200 dark:hover:bg-amber-900/60"
+              className="bg-caution/10 border-caution/30 text-caution hover:bg-caution/10 dark:hover:bg-caution/10"
             >
               {loadingHdAddresses ? (
                 <>
@@ -590,8 +590,8 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
       )}
 
       {allAddressesLoaded && (
-        <Alert className="mb-4 bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-800 dark:text-green-200">
-          <Check className="h-4 w-4 text-green-600 dark:text-green-400" />
+        <Alert className="mb-4 bg-primary/10 border-primary/30 text-primary">
+          <Check className="h-4 w-4 text-primary" />
           <AlertTitle>All HD Addresses Loaded</AlertTitle>
           <AlertDescription className="space-y-3">
             <p>
@@ -603,7 +603,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
               size="sm"
               onClick={loadAllHDUTXOs}
               disabled={loadingHdAddresses}
-              className="bg-green-100 dark:bg-green-900/40 border-green-300 dark:border-green-700 text-green-800 dark:text-green-200 hover:bg-green-200 dark:hover:bg-green-900/60"
+              className="bg-primary/10 border-primary/30 text-primary hover:bg-primary/10 dark:hover:bg-primary/10"
             >
               {loadingHdAddresses ? (
                 <>
@@ -782,8 +782,8 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
 
           {/* Recommendations */}
           {(dustUTXOs > 0 || smallUTXOs > 3) && (
-            <Alert className="bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800 text-yellow-800 dark:text-yellow-200">
-              <AlertCircle className="h-4 w-4 text-yellow-600 dark:text-yellow-400" />
+            <Alert className="bg-caution/10 border-caution/30 text-caution">
+              <AlertCircle className="h-4 w-4 text-caution" />
               <AlertTitle>UTXO Consolidation Recommended</AlertTitle>
               <AlertDescription className="space-y-3">
                 {dustUTXOs > 0 && (
@@ -804,7 +804,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
                     variant="outline"
                     size="sm"
                     onClick={handleConsolidateClick}
-                    className="bg-yellow-100 dark:bg-yellow-900/40 border-yellow-300 dark:border-yellow-700 text-yellow-800 dark:text-yellow-200 hover:bg-yellow-200 dark:hover:bg-yellow-900/60"
+                    className="bg-caution/10 border-caution/30 text-caution hover:bg-caution/10 dark:hover:bg-caution/10"
                   >
                     <Shuffle className="h-4 w-4 mr-2" />
                     Consolidate UTXOs {(dustUTXOs + smallUTXOs) > maxInputs && `(${maxInputs} max)`}

--- a/src/components/UTXOSelectionSettings.tsx
+++ b/src/components/UTXOSelectionSettings.tsx
@@ -176,7 +176,7 @@ export function UTXOSelectionSettings({
                     {s.recommended && (
                       <Badge
                         variant="outline"
-                        className="bg-green-100 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800"
+                        className="bg-primary/10 text-primary border-primary/30"
                       >
                         Recommended
                       </Badge>

--- a/src/components/UTXOSelector.tsx
+++ b/src/components/UTXOSelector.tsx
@@ -348,7 +348,7 @@ export function UTXOSelector({
 
         {targetAmount > 0 && (
           <Card
-            className={`${enoughSelected ? 'border-green-500 dark:border-green-500' : 'border-orange-500 dark:border-orange-500'}`}
+            className={`${enoughSelected ? 'border-primary/30' : 'border-caution/30'}`}
           >
             <CardContent className="p-4 space-y-2">
               <div className="flex items-center justify-between">
@@ -361,8 +361,8 @@ export function UTXOSelector({
                   variant={enoughSelected ? 'default' : 'outline'}
                   className={
                     enoughSelected
-                      ? 'bg-green-500 hover:bg-green-600'
-                      : 'text-orange-500 border-orange-500'
+                      ? 'bg-primary hover:bg-primary'
+                      : 'text-caution border-caution/30'
                   }
                 >
                   {enoughSelected ? 'Sufficient' : 'Insufficient'}
@@ -450,8 +450,8 @@ export function UTXOSelector({
 
       {/* HD Wallet Warning */}
       {isHdWallet && !allAddressesLoaded && (
-        <Alert className="mb-4 bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200">
-          <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+        <Alert className="mb-4 bg-caution/10 border-caution/30 text-caution">
+          <AlertCircle className="h-4 w-4 text-caution" />
           <AlertTitle>HD Wallet Detected</AlertTitle>
           <AlertDescription className="space-y-3">
             <p>
@@ -463,7 +463,7 @@ export function UTXOSelector({
               size="sm"
               onClick={loadAllHDUTXOs}
               disabled={loadingHdAddresses}
-              className="bg-amber-100 dark:bg-amber-900/40 border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200 hover:bg-amber-200 dark:hover:bg-amber-900/60"
+              className="bg-caution/10 border-caution/30 text-caution hover:bg-caution/10 dark:hover:bg-caution/10"
             >
               {loadingHdAddresses ? (
                 <>
@@ -482,8 +482,8 @@ export function UTXOSelector({
       )}
 
       {allAddressesLoaded && (
-        <Alert className="mb-4 bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-800 dark:text-green-200">
-          <Check className="h-4 w-4 text-green-600 dark:text-green-400" />
+        <Alert className="mb-4 bg-primary/10 border-primary/30 text-primary">
+          <Check className="h-4 w-4 text-primary" />
           <AlertTitle>All HD Addresses Loaded</AlertTitle>
           <AlertDescription className="space-y-3">
             <p>
@@ -495,7 +495,7 @@ export function UTXOSelector({
               size="sm"
               onClick={loadAllHDUTXOs}
               disabled={loadingHdAddresses}
-              className="bg-green-100 dark:bg-green-900/40 border-green-300 dark:border-green-700 text-green-800 dark:text-green-200 hover:bg-green-200 dark:hover:bg-green-900/60"
+              className="bg-primary/10 border-primary/30 text-primary hover:bg-primary/10 dark:hover:bg-primary/10"
             >
               {loadingHdAddresses ? (
                 <>
@@ -579,7 +579,7 @@ export function UTXOSelector({
                         variant={utxo.isDust ? 'outline' : 'secondary'}
                         className={
                           utxo.isDust
-                            ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 border-amber-200 dark:border-amber-800'
+                            ? 'bg-caution/10 text-caution border-caution/30'
                             : ''
                         }
                       >

--- a/src/components/WalletManager.tsx
+++ b/src/components/WalletManager.tsx
@@ -117,9 +117,9 @@ function WalletCard({
       name="WalletCard"
       isolate={true}
       fallback={
-        <Card className="overflow-hidden border-red-200 bg-red-50 dark:bg-red-900/20">
+        <Card className="overflow-hidden border-destructive/30 bg-destructive/10">
           <CardContent className="p-4">
-            <div className="text-red-600 dark:text-red-400 text-sm">
+            <div className="text-destructive text-sm">
               Error loading wallet card. Please refresh the page.
             </div>
           </CardContent>
@@ -140,7 +140,7 @@ function WalletCard({
                         type="text"
                         value={editingWalletName}
                         onChange={(e) => onEditingNameChange(e.target.value)}
-                        className="font-semibold text-lg bg-transparent border-b border-gray-300 dark:border-gray-600 focus:border-avian-500 dark:focus:border-avian-400 outline-none flex-1 min-w-0"
+                        className="font-semibold text-lg bg-transparent border-b border-border focus:border-avian-500 dark:focus:border-avian-400 outline-none flex-1 min-w-0"
                         autoFocus
                         onKeyDown={(e) => {
                           if (e.key === 'Enter') {
@@ -187,7 +187,7 @@ function WalletCard({
                   {isActive && (
                     <Badge
                       variant="default"
-                      className="bg-blue-500 hover:bg-blue-600 h-5 text-xs px-1.5"
+                      className="bg-primary hover:bg-primary h-5 text-xs px-1.5"
                     >
                       Active
                     </Badge>
@@ -197,7 +197,7 @@ function WalletCard({
                   {wallet.isEncrypted && (
                     <Badge
                       variant="outline"
-                      className="bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700 h-5 px-1.5 text-xs"
+                      className="bg-caution/10 text-caution border-caution/30 dark:bg-caution/10 dark:text-caution dark:border-caution/30 h-5 px-1.5 text-xs"
                     >
                       <Lock className="h-3 w-3 mr-0.5" /> Encrypted
                     </Badge>
@@ -205,7 +205,7 @@ function WalletCard({
                   {wallet.mnemonic && (
                     <Badge
                       variant="outline"
-                      className="bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700 h-5 px-1.5 text-xs"
+                      className="bg-primary/10 text-primary border-primary/30 dark:bg-primary/10 dark:text-primary dark:border-primary/30 h-5 px-1.5 text-xs"
                     >
                       <Shield className="h-3 w-3 mr-0.5" /> HD Wallet
                     </Badge>
@@ -223,7 +223,7 @@ function WalletCard({
                   className="h-6 w-6 p-0"
                   onClick={() => onCopy(wallet.address)}
                 >
-                  <Copy className={`h-3 w-3 ${isCopied ? 'text-green-500' : ''}`} />
+                  <Copy className={`h-3 w-3 ${isCopied ? 'text-primary' : ''}`} />
                 </Button>
               </div>
 
@@ -257,7 +257,7 @@ function WalletCard({
                 <Button
                   variant="destructive"
                   size="sm"
-                  className="bg-red-600 hover:bg-red-700 h-8 px-3"
+                  className="bg-destructive hover:bg-destructive h-8 px-3"
                   onClick={onDelete}
                 >
                   Delete
@@ -994,8 +994,8 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
         </Tabs>
 
         {showCreateForm && (
-          <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
+          <div className="mb-6 p-4 bg-muted/40 dark:bg-card rounded-lg">
+            <h3 className="text-lg font-medium text-foreground dark:text-white mb-3">
               Create New Wallet
             </h3>
             <div className="space-y-3">
@@ -1004,13 +1004,13 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                 value={newWalletName}
                 onChange={(e) => setNewWalletName(e.target.value)}
                 placeholder="Wallet name"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border border-border rounded-lg bg-card text-foreground dark:text-white"
               />
 
-              <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-3">
+              <div className="bg-primary/10 border border-primary/30 rounded-lg p-3">
                 <div className="flex items-start">
                   <div className="flex-shrink-0">
-                    <svg className="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
+                    <svg className="h-5 w-5 text-primary" viewBox="0 0 20 20" fill="currentColor">
                       <path
                         fillRule="evenodd"
                         d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
@@ -1019,10 +1019,10 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     </svg>
                   </div>
                   <div className="ml-3 text-sm">
-                    <p className="text-blue-800 dark:text-blue-200 font-medium">
+                    <p className="text-primary font-medium">
                       Security Requirement
                     </p>
-                    <p className="text-blue-700 dark:text-blue-300 mt-1">
+                    <p className="text-primary mt-1">
                       All wallets must be password protected for your security. Choose a strong
                       password you&apos;ll remember.
                     </p>
@@ -1036,11 +1036,11 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                   value={newWalletPassword}
                   onChange={(e) => setNewWalletPassword(e.target.value)}
                   placeholder="Enter wallet password (required)"
-                  className="w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  className="w-full px-3 py-2 pr-10 border border-border rounded-lg bg-card text-foreground dark:text-white"
                 />
                 <button
                   type="button"
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground"
                   onClick={() => setShowNewWalletPassword(!showNewWalletPassword)}
                 >
                   {showNewWalletPassword ? (
@@ -1056,11 +1056,11 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                   value={newWalletPasswordConfirm}
                   onChange={(e) => setNewWalletPasswordConfirm(e.target.value)}
                   placeholder="Confirm wallet password"
-                  className="w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  className="w-full px-3 py-2 pr-10 border border-border rounded-lg bg-card text-foreground dark:text-white"
                 />
                 <button
                   type="button"
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground"
                   onClick={() => setShowNewWalletPasswordConfirm(!showNewWalletPasswordConfirm)}
                 >
                   {showNewWalletPasswordConfirm ? (
@@ -1072,8 +1072,8 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
               </div>
 
               {passwordError && (
-                <div className="p-3 bg-red-100 dark:bg-red-900/20 border border-red-300 dark:border-red-700 rounded-lg">
-                  <p className="text-sm text-red-700 dark:text-red-200">{passwordError}</p>
+                <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-lg">
+                  <p className="text-sm text-destructive">{passwordError}</p>
                 </div>
               )}
 
@@ -1086,7 +1086,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     !newWalletPassword ||
                     !newWalletPasswordConfirm
                   }
-                  className="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="flex-1 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   {isCreating ? 'Creating...' : 'Create Wallet'}
                 </button>
@@ -1098,7 +1098,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     setNewWalletPasswordConfirm('');
                     setPasswordError('');
                   }}
-                  className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+                  className="px-4 py-2 bg-card text-white rounded-lg hover:bg-card transition-colors"
                 >
                   Cancel
                 </button>
@@ -1109,8 +1109,8 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
 
         {/* Import Private Key Form */}
         {showImportKeyForm && (
-          <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
+          <div className="mb-6 p-4 bg-muted/40 dark:bg-card rounded-lg">
+            <h3 className="text-lg font-medium text-foreground dark:text-white mb-3">
               Import Private Key
             </h3>
             <div className="space-y-3">
@@ -1119,19 +1119,19 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                 value={importWalletName}
                 onChange={(e) => setImportWalletName(e.target.value)}
                 placeholder="Wallet name"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border border-border rounded-lg bg-card text-foreground dark:text-white"
               />
               <textarea
                 value={importPrivateKey}
                 onChange={(e) => setImportPrivateKey(e.target.value)}
                 placeholder="Enter your private key (WIF format)"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white h-20 resize-none"
+                className="w-full px-3 py-2 border border-border rounded-lg bg-card text-foreground dark:text-white h-20 resize-none"
               />
 
-              <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg p-3">
+              <div className="bg-caution/10 border border-caution/30 rounded-lg p-3">
                 <div className="flex items-start">
                   <div className="flex-shrink-0">
-                    <svg className="h-5 w-5 text-amber-400" viewBox="0 0 20 20" fill="currentColor">
+                    <svg className="h-5 w-5 text-caution" viewBox="0 0 20 20" fill="currentColor">
                       <path
                         fillRule="evenodd"
                         d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
@@ -1140,10 +1140,10 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     </svg>
                   </div>
                   <div className="ml-3 text-sm">
-                    <p className="text-amber-800 dark:text-amber-200 font-medium">
+                    <p className="text-caution font-medium">
                       Security Required
                     </p>
-                    <p className="text-amber-700 dark:text-amber-300 mt-1">
+                    <p className="text-caution mt-1">
                       Your imported wallet will be encrypted with a password for security.
                     </p>
                   </div>
@@ -1156,11 +1156,11 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                   value={importWalletPassword}
                   onChange={(e) => setImportWalletPassword(e.target.value)}
                   placeholder="Create wallet password (required)"
-                  className="w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  className="w-full px-3 py-2 pr-10 border border-border rounded-lg bg-card text-foreground dark:text-white"
                 />
                 <button
                   type="button"
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground"
                   onClick={() => setShowImportWalletPassword(!showImportWalletPassword)}
                 >
                   {showImportWalletPassword ? (
@@ -1176,11 +1176,11 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                   value={importWalletPasswordConfirm}
                   onChange={(e) => setImportWalletPasswordConfirm(e.target.value)}
                   placeholder="Confirm wallet password"
-                  className="w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  className="w-full px-3 py-2 pr-10 border border-border rounded-lg bg-card text-foreground dark:text-white"
                 />
                 <button
                   type="button"
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground"
                   onClick={() => setShowImportWalletPasswordConfirm(!showImportWalletPasswordConfirm)}
                 >
                   {showImportWalletPasswordConfirm ? (
@@ -1192,8 +1192,8 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
               </div>
 
               {passwordError && (
-                <div className="p-3 bg-red-100 dark:bg-red-900/20 border border-red-300 dark:border-red-700 rounded-lg">
-                  <p className="text-sm text-red-700 dark:text-red-200">{passwordError}</p>
+                <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-lg">
+                  <p className="text-sm text-destructive">{passwordError}</p>
                 </div>
               )}
 
@@ -1207,7 +1207,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     !importWalletPassword ||
                     !importWalletPasswordConfirm
                   }
-                  className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="flex-1 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   {isCreating ? 'Importing...' : 'Import Wallet'}
                 </button>
@@ -1220,7 +1220,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     setImportPrivateKey('');
                     setPasswordError('');
                   }}
-                  className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+                  className="px-4 py-2 bg-card text-white rounded-lg hover:bg-card transition-colors"
                 >
                   Cancel
                 </button>
@@ -1231,8 +1231,8 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
 
         {/* Import Mnemonic Form */}
         {showImportMnemonicForm && (
-          <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
+          <div className="mb-6 p-4 bg-muted/40 dark:bg-card rounded-lg">
+            <h3 className="text-lg font-medium text-foreground dark:text-white mb-3">
               Import Recovery Phrase
             </h3>
             <div className="space-y-3">
@@ -1241,17 +1241,17 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                 value={importWalletName}
                 onChange={(e) => setImportWalletName(e.target.value)}
                 placeholder="Wallet name"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                className="w-full px-3 py-2 border border-border rounded-lg bg-card text-foreground dark:text-white"
               />
               <textarea
                 value={importMnemonic}
                 onChange={(e) => setImportMnemonic(e.target.value)}
                 placeholder="Enter your 12-word mnemonic phrase (separated by spaces)"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white h-20 resize-none"
+                className="w-full px-3 py-2 border border-border rounded-lg bg-card text-foreground dark:text-white h-20 resize-none"
               />
 
               <div className="space-y-1">
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                <label className="block text-sm font-medium text-muted-foreground">
                   BIP39 Passphrase (Optional)
                 </label>
                 <div className="relative">
@@ -1260,11 +1260,11 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     value={importMnemonicPassphrase}
                     onChange={(e) => setImportMnemonicPassphrase(e.target.value)}
                     placeholder="Enter optional BIP39 passphrase"
-                    className="w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                    className="w-full px-3 py-2 pr-10 border border-border rounded-lg bg-card text-foreground dark:text-white"
                   />
                   <button
                     type="button"
-                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground"
                     onClick={() => setShowImportMnemonicPassphrase(!showImportMnemonicPassphrase)}
                   >
                     {showImportMnemonicPassphrase ? (
@@ -1274,16 +1274,16 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     )}
                   </button>
                 </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-muted-foreground">
                   Also known as the &quot;25th word&quot; - only enter if you used one when creating
                   the wallet
                 </p>
               </div>
 
-              <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded-lg p-3">
+              <div className="bg-primary/10 border border-primary/30 rounded-lg p-3">
                 <div className="flex items-start">
                   <div className="flex-shrink-0">
-                    <svg className="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+                    <svg className="h-5 w-5 text-primary" viewBox="0 0 20 20" fill="currentColor">
                       <path
                         fillRule="evenodd"
                         d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
@@ -1292,10 +1292,10 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     </svg>
                   </div>
                   <div className="ml-3 text-sm">
-                    <p className="text-green-800 dark:text-green-200 font-medium">
+                    <p className="text-primary font-medium">
                       Secure Recovery
                     </p>
-                    <p className="text-green-700 dark:text-green-300 mt-1">
+                    <p className="text-primary mt-1">
                       Your recovered wallet will be encrypted with a password for enhanced security.
                     </p>
                   </div>
@@ -1308,11 +1308,11 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                   value={importWalletPassword}
                   onChange={(e) => setImportWalletPassword(e.target.value)}
                   placeholder="Create wallet password (required)"
-                  className="w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  className="w-full px-3 py-2 pr-10 border border-border rounded-lg bg-card text-foreground dark:text-white"
                 />
                 <button
                   type="button"
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground"
                   onClick={() => setShowImportWalletPassword(!showImportWalletPassword)}
                 >
                   {showImportWalletPassword ? (
@@ -1328,11 +1328,11 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                   value={importWalletPasswordConfirm}
                   onChange={(e) => setImportWalletPasswordConfirm(e.target.value)}
                   placeholder="Confirm wallet password"
-                  className="w-full px-3 py-2 pr-10 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  className="w-full px-3 py-2 pr-10 border border-border rounded-lg bg-card text-foreground dark:text-white"
                 />
                 <button
                   type="button"
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-muted-foreground dark:hover:text-muted-foreground"
                   onClick={() => setShowImportWalletPasswordConfirm(!showImportWalletPasswordConfirm)}
                 >
                   {showImportWalletPasswordConfirm ? (
@@ -1344,8 +1344,8 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
               </div>
 
               {passwordError && (
-                <div className="p-3 bg-red-100 dark:bg-red-900/20 border border-red-300 dark:border-red-700 rounded-lg">
-                  <p className="text-sm text-red-700 dark:text-red-200">{passwordError}</p>
+                <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-lg">
+                  <p className="text-sm text-destructive">{passwordError}</p>
                 </div>
               )}
 
@@ -1359,7 +1359,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     !importWalletPassword ||
                     !importWalletPasswordConfirm
                   }
-                  className="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="flex-1 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   {isCreating ? 'Importing...' : 'Import Wallet'}
                 </button>
@@ -1373,7 +1373,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                     setImportMnemonicPassphrase('');
                     setPasswordError('');
                   }}
-                  className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+                  className="px-4 py-2 bg-card text-white rounded-lg hover:bg-card transition-colors"
                 >
                   Cancel
                 </button>
@@ -1395,7 +1395,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                 <DrawerDescription id="delete-wallet-description">
                   Are you sure you want to delete this wallet? This action cannot be undone.
                   <br />
-                  <span className="font-medium text-red-500">
+                  <span className="font-medium text-destructive">
                     All funds in this wallet will be lost if you haven&apos;t backed up your private
                     key or recovery phrase.
                   </span>
@@ -1403,7 +1403,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
               </DrawerHeader>
               <DrawerFooter className="gap-2">
                 <Button
-                  className="bg-red-600 hover:bg-red-700 text-white"
+                  className="bg-destructive hover:bg-destructive text-white"
                   onClick={confirmDeleteWallet}
                   autoFocus
                 >
@@ -1417,13 +1417,13 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
           </Drawer>
         ) : (
           <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-            <AlertDialogContent className="dark:bg-gray-800 border dark:border-gray-700">
+            <AlertDialogContent className="dark:bg-card border dark:border-border">
               <AlertDialogHeader>
                 <AlertDialogTitle>Delete Wallet</AlertDialogTitle>
                 <AlertDialogDescription>
                   Are you sure you want to delete this wallet? This action cannot be undone.
                   <br />
-                  <span className="font-medium text-red-500">
+                  <span className="font-medium text-destructive">
                     All funds in this wallet will be lost if you haven&apos;t backed up your private
                     key or recovery phrase.
                   </span>
@@ -1434,7 +1434,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                   Cancel
                 </AlertDialogCancel>
                 <AlertDialogAction
-                  className="bg-red-600 hover:bg-red-700"
+                  className="bg-destructive hover:bg-destructive"
                   onClick={confirmDeleteWallet}
                 >
                   Delete Wallet
@@ -1446,12 +1446,12 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
 
         {wallets.length === 0 && (
           <div className="text-center py-8">
-            <p className="text-gray-600 dark:text-gray-400 mb-4">
+            <p className="text-muted-foreground mb-4">
               No wallets found. Create your first wallet to get started.
             </p>
             <button
               onClick={() => setShowCreateForm(true)}
-              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary transition-colors"
             >
               Create First Wallet
             </button>

--- a/src/components/WalletSelector.tsx
+++ b/src/components/WalletSelector.tsx
@@ -125,7 +125,7 @@ const WalletAvatar = ({ name, address, size = 'lg' }: { name: string; address: s
     }, [identiconSvg, size, canvasDataUrl, isIOS, imageError, sizePx]);
 
     return (
-        <Avatar className={`${sizeClasses[size]} bg-gray-100 dark:bg-gray-800 flex-shrink-0`}>
+        <Avatar className={`${sizeClasses[size]} bg-muted/40 dark:bg-card flex-shrink-0`}>
             {!isIOS && svgDataUrl && !imageError ? (
                 <img
                     src={svgDataUrl}
@@ -378,7 +378,7 @@ export function WalletSelector() {
                             )}
                         </div>
                         {copiedAddress === currentWallet.address ? (
-                            <Check className="w-4 h-4 text-green-600" />
+                            <Check className="w-4 h-4 text-primary" />
                         ) : (
                             <Copy className="w-4 h-4" />
                         )}

--- a/src/components/WatchAddressesPanel.tsx
+++ b/src/components/WatchAddressesPanel.tsx
@@ -290,8 +290,8 @@ export default function WatchAddressesPanel() {
   // Validate if notifications are enabled
   if (!isEnabled) {
     return (
-      <Alert className="bg-orange-50 dark:bg-orange-900/20 border-orange-200 dark:border-orange-700">
-        <AlertDescription className="text-orange-800 dark:text-orange-200">
+      <Alert className="bg-caution/10 border-caution/30">
+        <AlertDescription className="text-caution">
           Enable notifications to monitor other wallet addresses.
         </AlertDescription>
       </Alert>


### PR DESCRIPTION
**PR 6 of the UI/UX refresh** — the wallet-management cluster (the heaviest colour files in the app). Presentation only.

### What changed
`settings/wallet` page + WalletManager, DerivedAddressesPanel, AddressBook, AddressBookButton, UTXOOverview, UTXOSelector, UTXOSelectionSettings, WatchAddressesPanel, WalletSelector — all mapped onto the token system: success → teal, danger → `destructive`, warning → `caution`, info → teal, neutrals → `muted`/`border`/`card`.

### Semantic colour-coding preserved
- UTXO **"enough selected" → teal** vs **"insufficient" → caution**.
- Derived **receiving** addresses keep an amber (caution) marker, **change** addresses a teal one — bumped back to full opacity so the markers (and legend) stay legible after the sweep.
- Balance/status badges brand-tinted.

### Safety
- **QR codes untouched** — `bgColor`/`fgColor` are hex props, not classes, so they stay scannable.
- **ContactAvatar left alone** — its grays are identicon contrast logic.
- No crypto, auth, or storage paths touched; UTXO selection logic unchanged.

### Verification
typecheck ✓ · **542/542 unit ✓** · static build ✓ · **25/25 E2E ✓**