### PR TITLE
feat(ui): finish the reskin — backup/security/logs + site/shared

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -551,12 +551,12 @@ export default function AboutPage() {
                                         </div>
                                     </div>
 
-                                    <div className="bg-gradient-to-r from-orange-50 to-red-50 dark:from-orange-950/30 dark:to-red-950/30 border border-orange-200 dark:border-orange-800 p-6 rounded-lg">
-                                        <h4 className="font-semibold mb-3 flex items-center gap-2 text-orange-800 dark:text-orange-200">
+                                    <div className="bg-gradient-to-r from-caution to-destructive dark:from-caution dark:to-destructive border border-caution/30 p-6 rounded-lg">
+                                        <h4 className="font-semibold mb-3 flex items-center gap-2 text-caution">
                                             <Lock className="h-4 w-4" />
                                             Security Notice
                                         </h4>
-                                        <p className="text-orange-700 dark:text-orange-300 leading-relaxed">
+                                        <p className="text-caution leading-relaxed">
                                             This wallet stores all data locally on your device. Never share your recovery
                                             phrases or passwords. Always verify addresses before sending transactions.
                                         </p>

--- a/src/app/backup/qr/page.tsx
+++ b/src/app/backup/qr/page.tsx
@@ -616,7 +616,7 @@ export default function BackupQRPage() {
                                     {backupChunks.length > 0 ? (
                                         <div className="space-y-6">
                                             <div className="flex flex-col items-center">
-                                                <div className="bg-white p-6 rounded-lg shadow-sm border">
+                                                <div className="bg-card p-6 rounded-lg shadow-sm border">
                                                     <QRCodeSVG
                                                         value={backupChunks[currentChunkIndex]}
                                                         size={isMobile ? 280 : 320}
@@ -741,9 +741,9 @@ export default function BackupQRPage() {
                                                             onClick={() => setShowBackupPassword(!showBackupPassword)}
                                                         >
                                                             {showBackupPassword ? (
-                                                                <EyeOff className="h-4 w-4 text-gray-500" />
+                                                                <EyeOff className="h-4 w-4 text-muted-foreground" />
                                                             ) : (
-                                                                <Eye className="h-4 w-4 text-gray-500" />
+                                                                <Eye className="h-4 w-4 text-muted-foreground" />
                                                             )}
                                                         </Button>
                                                     </div>
@@ -803,7 +803,7 @@ export default function BackupQRPage() {
                                                                     <div
                                                                         key={chunkNumber}
                                                                         className={`w-10 h-10 rounded text-sm font-medium flex items-center justify-center border ${isScanned
-                                                                            ? 'bg-green-500 text-white border-green-600'
+                                                                            ? 'bg-primary text-white border-primary/30'
                                                                             : 'bg-muted text-muted-foreground border-border'
                                                                             }`}
                                                                         title={`QR Code ${chunkNumber} - ${isScanned ? 'Scanned' : 'Not scanned'}`}
@@ -900,9 +900,9 @@ export default function BackupQRPage() {
                                                             onClick={() => setShowRestorePassword(!showRestorePassword)}
                                                         >
                                                             {showRestorePassword ? (
-                                                                <EyeOff className="h-4 w-4 text-gray-500" />
+                                                                <EyeOff className="h-4 w-4 text-muted-foreground" />
                                                             ) : (
-                                                                <Eye className="h-4 w-4 text-gray-500" />
+                                                                <Eye className="h-4 w-4 text-muted-foreground" />
                                                             )}
                                                         </Button>
                                                     </div>
@@ -984,9 +984,9 @@ export default function BackupQRPage() {
                                                                 onClick={() => setShowRestorePassword(!showRestorePassword)}
                                                             >
                                                                 {showRestorePassword ? (
-                                                                    <EyeOff className="h-4 w-4 text-gray-500" />
+                                                                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                                                                 ) : (
-                                                                    <Eye className="h-4 w-4 text-gray-500" />
+                                                                    <Eye className="h-4 w-4 text-muted-foreground" />
                                                                 )}
                                                             </Button>
                                                         </div>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -222,14 +222,14 @@ export default function TermsPage() {
                             <CardTitle className="text-xl">License Agreement</CardTitle>
                         </CardHeader>
                         <CardContent>
-                            <Card className="shadow-sm border border-gray-200 dark:border-gray-800">
+                            <Card className="shadow-sm border border-border">
                                 <ScrollArea className="h-96 rounded-lg bg-avian-50 dark:bg-avian-950">
-                                    <CardContent className="p-6 space-y-4 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+                                    <CardContent className="p-6 space-y-4 text-sm text-muted-foreground leading-relaxed">
                                         <div>
-                                            <h4 className="font-medium text-gray-900 dark:text-gray-100 text-base">
+                                            <h4 className="font-medium text-foreground dark:text-muted-foreground text-base">
                                                 MIT License
                                             </h4>
-                                            <p className="mt-2 text-gray-600 dark:text-gray-400">
+                                            <p className="mt-2 text-muted-foreground">
                                                 Copyright (c) 2024 The Avian Developers
                                             </p>
                                         </div>
@@ -248,7 +248,7 @@ export default function TermsPage() {
                                             or substantial portions of the Software.
                                         </p>
 
-                                        <p className="font-medium text-gray-900 dark:text-gray-100">
+                                        <p className="font-medium text-foreground dark:text-muted-foreground">
                                             THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS
                                             OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
                                             FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -307,20 +307,20 @@ export default function TermsPage() {
                             <CardTitle className="text-xl">License Agreement</CardTitle>
                         </CardHeader>
                         <CardContent>
-                            <Card className="shadow-sm border border-gray-200 dark:border-gray-800">
+                            <Card className="shadow-sm border border-border">
                                 <ScrollArea
                                     className="h-96 rounded-lg bg-avian-50 dark:bg-avian-950"
                                     onScrollCapture={handleScroll}
                                 >
                                     <CardContent
                                         ref={scrollContentRef}
-                                        className="p-6 space-y-4 text-sm text-gray-700 dark:text-gray-300 leading-relaxed"
+                                        className="p-6 space-y-4 text-sm text-muted-foreground leading-relaxed"
                                     >
                                         <div>
-                                            <h4 className="font-medium text-gray-900 dark:text-gray-100 text-base">
+                                            <h4 className="font-medium text-foreground dark:text-muted-foreground text-base">
                                                 MIT License
                                             </h4>
-                                            <p className="mt-2 text-gray-600 dark:text-gray-400">
+                                            <p className="mt-2 text-muted-foreground">
                                                 Copyright (c) 2024 The Avian Developers
                                             </p>
                                         </div>
@@ -339,7 +339,7 @@ export default function TermsPage() {
                                             copies or substantial portions of the Software.
                                         </p>
 
-                                        <p className="uppercase font-medium text-gray-900 dark:text-gray-100">
+                                        <p className="uppercase font-medium text-foreground dark:text-muted-foreground">
                                             The Software is provided &quot;as is&quot;, without warranty of any kind, express or
                                             implied, including but not limited to the warranties of merchantability, fitness for
                                             a particular purpose and noninfringement. In no event shall the authors or copyright
@@ -351,7 +351,7 @@ export default function TermsPage() {
                                         <Separator className="my-6" />
 
                                         <div className="space-y-4">
-                                            <h4 className="font-medium text-gray-900 dark:text-gray-100 text-base">
+                                            <h4 className="font-medium text-foreground dark:text-muted-foreground text-base">
                                                 Important Disclaimer
                                             </h4>
                                             <p>
@@ -368,7 +368,7 @@ export default function TermsPage() {
                                         <Separator className="my-6" />
 
                                         <div className="space-y-4">
-                                            <h4 className="font-medium text-gray-900 dark:text-gray-100 text-base">
+                                            <h4 className="font-medium text-foreground dark:text-muted-foreground text-base">
                                                 Privacy Notice
                                             </h4>
                                             <p>
@@ -397,7 +397,7 @@ export default function TermsPage() {
                             {/* Agreement Section - Only show if not in view mode */}
                             {!viewMode && (
                                 <div className="mt-6 space-y-6">
-                                    <h4 className="text-lg font-medium text-gray-900 dark:text-white">
+                                    <h4 className="text-lg font-medium text-foreground dark:text-white">
                                         Make your selection:
                                     </h4>
 
@@ -416,7 +416,7 @@ export default function TermsPage() {
                                                 htmlFor="accept-terms"
                                                 className={`text-sm font-medium cursor-pointer leading-relaxed ${hasScrolledToBottom
                                                     ? 'text-avian-700 dark:text-avian-300'
-                                                    : 'text-gray-400 dark:text-gray-500'
+                                                    : 'text-muted-foreground'
                                                     }`}
                                             >
                                                 I accept the terms of the License Agreement and agree to use Avian FlightDeck
@@ -424,15 +424,15 @@ export default function TermsPage() {
                                             </Label>
                                         </div>
 
-                                        <div className="flex items-start space-x-3 p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/70 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+                                        <div className="flex items-start space-x-3 p-4 rounded-lg border border-border bg-muted/40 dark:bg-card hover:bg-muted/40 dark:hover:bg-card transition-colors">
                                             <RadioGroupItem
                                                 value="decline"
                                                 id="decline-terms"
-                                                className="text-gray-600 dark:text-gray-400 mt-0.5"
+                                                className="text-muted-foreground mt-0.5"
                                             />
                                             <Label
                                                 htmlFor="decline-terms"
-                                                className="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer leading-relaxed"
+                                                className="text-sm font-medium text-muted-foreground cursor-pointer leading-relaxed"
                                             >
                                                 I do not accept the terms of the License Agreement
                                             </Label>
@@ -444,7 +444,7 @@ export default function TermsPage() {
                                         <Button
                                             variant="outline"
                                             onClick={() => setShowDeclineDialog(true)}
-                                            className="w-full sm:w-auto border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+                                            className="w-full sm:w-auto border-border text-muted-foreground hover:bg-muted/40 dark:hover:bg-card"
                                             size="lg"
                                         >
                                             <X className="w-4 h-4 mr-2" />
@@ -483,7 +483,7 @@ export default function TermsPage() {
             <AlertDialog open={showDeclineDialog} onOpenChange={setShowDeclineDialog}>
                 <AlertDialogContent className="max-w-md">
                     <AlertDialogHeader>
-                        <AlertDialogTitle className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+                        <AlertDialogTitle className="flex items-center gap-2 text-caution">
                             <AlertTriangle className="h-5 w-5" />
                             Terms Agreement Required
                         </AlertDialogTitle>
@@ -497,7 +497,7 @@ export default function TermsPage() {
                     <AlertDialogFooter>
                         <AlertDialogCancel
                             onClick={() => setShowDeclineDialog(false)}
-                            className="border-gray-300 dark:border-gray-600"
+                            className="border-border"
                         >
                             Return to Terms
                         </AlertDialogCancel>

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -31,7 +31,7 @@ export default function AddressInput({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className={`pr-20 font-mono ${error ? 'border-red-500' : ''} ${className}`}
+        className={`pr-20 font-mono ${error ? 'border-destructive/30' : ''} ${className}`}
         disabled={disabled}
       />
       <div className="absolute right-2 top-1/2 transform -translate-y-1/2 z-10">

--- a/src/components/BackupDrawer.tsx
+++ b/src/components/BackupDrawer.tsx
@@ -210,19 +210,19 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
       <Tabs
         value={activeTab}
         onValueChange={(value) => setActiveTab(value as 'backup' | 'restore')}
-        className="w-full border-b border-gray-200 dark:border-gray-700"
+        className="w-full border-b border-border"
       >
         <TabsList className="flex h-auto bg-transparent p-0 w-full">
           <TabsTrigger
             value="backup"
-            className="flex-1 flex items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-gray-500 dark:text-gray-400 h-auto relative"
+            className="flex-1 flex items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-muted-foreground h-auto relative"
           >
             <Download className="w-4 h-4 mr-2" />
             Create Backup
           </TabsTrigger>
           <TabsTrigger
             value="restore"
-            className="flex-1 flex items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-gray-500 dark:text-gray-400 h-auto relative"
+            className="flex-1 flex items-center justify-center px-6 py-4 data-[state=active]:border-b-1 data-[state=active]:border-avian-400 data-[state=active]:text-avian-400 data-[state=active]:after:h-0.5 data-[state=active]:after:bg-avian-400 data-[state=active]:after:absolute data-[state=active]:after:bottom-0 data-[state=active]:after:left-0 data-[state=active]:after:w-full bg-transparent rounded-none text-muted-foreground h-auto relative"
           >
             <Upload className="w-4 h-4 mr-2" />
             Restore Backup
@@ -246,7 +246,7 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="full" id="full" />
                   <Label htmlFor="full" className="flex items-center cursor-pointer">
-                    <Database className="w-4 h-4 mr-2 text-blue-600" />
+                    <Database className="w-4 h-4 mr-2 text-primary" />
                     <div>
                       <span className="font-medium">Full Backup</span>
                       <p className="text-xs text-muted-foreground">
@@ -258,7 +258,7 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="wallets" id="wallets" />
                   <Label htmlFor="wallets" className="flex items-center cursor-pointer">
-                    <FileText className="w-4 h-4 mr-2 text-green-600" />
+                    <FileText className="w-4 h-4 mr-2 text-primary" />
                     <div>
                       <span className="font-medium">Wallets Only</span>
                       <p className="text-xs text-muted-foreground">
@@ -279,7 +279,7 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
                   onCheckedChange={(checked) => setUseEncryption(checked as boolean)}
                 />
                 <Label htmlFor="encryption" className="flex items-center cursor-pointer">
-                  <Lock className="w-4 h-4 mr-2 text-amber-600" />
+                  <Lock className="w-4 h-4 mr-2 text-caution" />
                   <span className="font-medium">Encrypt backup file</span>
                 </Label>
               </div>
@@ -310,9 +310,9 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
                       onClick={() => setShowPassword(!showPassword)}
                     >
                       {showPassword ? (
-                        <EyeOff className="h-4 w-4 text-gray-500" />
+                        <EyeOff className="h-4 w-4 text-muted-foreground" />
                       ) : (
-                        <Eye className="h-4 w-4 text-gray-500" />
+                        <Eye className="h-4 w-4 text-muted-foreground" />
                       )}
                     </Button>
                   </div>
@@ -336,9 +336,9 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
                       onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                     >
                       {showConfirmPassword ? (
-                        <EyeOff className="h-4 w-4 text-gray-500" />
+                        <EyeOff className="h-4 w-4 text-muted-foreground" />
                       ) : (
-                        <Eye className="h-4 w-4 text-gray-500" />
+                        <Eye className="h-4 w-4 text-muted-foreground" />
                       )}
                     </Button>
                   </div>
@@ -348,14 +348,14 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
 
             {/* Backup Summary */}
             {backupSummary && (
-              <Alert className="bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-700">
+              <Alert className="bg-primary/10 border-primary/30">
                 <div className="flex items-center mb-2">
-                  <CheckCircle className="w-4 h-4 mr-2 text-green-600" />
-                  <span className="font-medium text-green-900 dark:text-green-200">
+                  <CheckCircle className="w-4 h-4 mr-2 text-primary" />
+                  <span className="font-medium text-primary">
                     Backup Created Successfully
                   </span>
                 </div>
-                <AlertDescription className="text-sm text-green-800 dark:text-green-300 space-y-1">
+                <AlertDescription className="text-sm text-primary space-y-1">
                   <p>• {backupSummary.walletsCount} wallets backed up</p>
                   <p>• {backupSummary.addressesCount} address book entries backed up</p>
                   <p>• Type: {backupSummary.backupType}</p>
@@ -394,23 +394,23 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
 
             {/* Backup Preview */}
             {backupPreview && (
-              <Card className="bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-700">
+              <Card className="bg-primary/10 border-primary/30">
                 <CardContent className="pt-6">
                   <div className="flex items-center mb-2">
-                    <FileText className="w-4 h-4 mr-2 text-blue-600" />
-                    <span className="font-medium text-blue-900 dark:text-blue-200">
+                    <FileText className="w-4 h-4 mr-2 text-primary" />
+                    <span className="font-medium text-primary">
                       Backup Preview
                     </span>
                   </div>
-                  <div className="text-sm text-blue-800 dark:text-blue-300 space-y-1">
+                  <div className="text-sm text-primary space-y-1">
                     <p>• Created: {new Date(backupPreview.timestamp).toLocaleDateString()}</p>
                     <p>• Version: {backupPreview.version}</p>
                     <p>• Wallets: {backupPreview.wallets.length}</p>
                     <p>• Address Book entries: {backupPreview.addressBook.length}</p>
                     <p>• Type: {backupPreview.metadata.backupType}</p>
                     {backupPreview.wallets.some((w) => w.isEncrypted) && (
-                      <Alert className="mt-2 bg-yellow-100 dark:bg-yellow-900/30 border-yellow-300 dark:border-yellow-600">
-                        <AlertDescription className="text-yellow-800 dark:text-yellow-200 text-xs">
+                      <Alert className="mt-2 bg-caution/10 border-caution/30">
+                        <AlertDescription className="text-caution text-xs">
                           ⚠️ This backup contains encrypted wallets. You&apos;ll need the individual
                           wallet passwords when accessing them.
                         </AlertDescription>
@@ -445,9 +445,9 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
                       onClick={() => setShowRestorePassword(!showRestorePassword)}
                     >
                       {showRestorePassword ? (
-                        <EyeOff className="h-4 w-4 text-gray-500" />
+                        <EyeOff className="h-4 w-4 text-muted-foreground" />
                       ) : (
-                        <Eye className="h-4 w-4 text-gray-500" />
+                        <Eye className="h-4 w-4 text-muted-foreground" />
                       )}
                     </Button>
                   </div>
@@ -527,10 +527,10 @@ export default function BackupDrawer({ isOpen, onClose, onSuccess, onError }: Ba
                     </Label>
                   </div>
                 </div>
-                <Alert className="mt-2 bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-700">
+                <Alert className="mt-2 bg-caution/10 border-caution/30">
                   <div className="flex items-start">
-                    <AlertCircle className="w-4 h-4 mr-2 text-amber-600 mt-0.5" />
-                    <AlertDescription className="text-xs text-amber-800 dark:text-amber-200">
+                    <AlertCircle className="w-4 h-4 mr-2 text-caution mt-0.5" />
+                    <AlertDescription className="text-xs text-caution">
                       <p className="font-medium">Warning:</p>
                       <p>
                         If &quot;Overwrite existing&quot; is checked, this will replace your current

--- a/src/components/BackupExport.tsx
+++ b/src/components/BackupExport.tsx
@@ -78,7 +78,7 @@ export function BackupExport() {
                         <div className="flex items-center space-x-2">
                             <RadioGroupItem value="full" id="full" />
                             <Label htmlFor="full" className="flex items-center cursor-pointer">
-                                <Database className="w-4 h-4 mr-2 text-blue-600" />
+                                <Database className="w-4 h-4 mr-2 text-primary" />
                                 <div>
                                     <span className="font-medium">Full Backup</span>
                                     <p className="text-xs text-muted-foreground">
@@ -90,7 +90,7 @@ export function BackupExport() {
                         <div className="flex items-center space-x-2">
                             <RadioGroupItem value="wallets" id="wallets" />
                             <Label htmlFor="wallets" className="flex items-center cursor-pointer">
-                                <FileText className="w-4 h-4 mr-2 text-green-600" />
+                                <FileText className="w-4 h-4 mr-2 text-primary" />
                                 <div>
                                     <span className="font-medium">Wallets Only</span>
                                     <p className="text-xs text-muted-foreground">
@@ -111,7 +111,7 @@ export function BackupExport() {
                             onCheckedChange={(checked) => setUseEncryption(checked as boolean)}
                         />
                         <Label htmlFor="encryption" className="flex items-center cursor-pointer">
-                            <Lock className="w-4 h-4 mr-2 text-amber-600" />
+                            <Lock className="w-4 h-4 mr-2 text-caution" />
                             <span className="font-medium">Encrypt backup file</span>
                         </Label>
                     </div>
@@ -142,9 +142,9 @@ export function BackupExport() {
                                     onClick={() => setShowPassword(!showPassword)}
                                 >
                                     {showPassword ? (
-                                        <EyeOff className="h-4 w-4 text-gray-500" />
+                                        <EyeOff className="h-4 w-4 text-muted-foreground" />
                                     ) : (
-                                        <Eye className="h-4 w-4 text-gray-500" />
+                                        <Eye className="h-4 w-4 text-muted-foreground" />
                                     )}
                                 </Button>
                             </div>
@@ -168,9 +168,9 @@ export function BackupExport() {
                                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                                 >
                                     {showConfirmPassword ? (
-                                        <EyeOff className="h-4 w-4 text-gray-500" />
+                                        <EyeOff className="h-4 w-4 text-muted-foreground" />
                                     ) : (
-                                        <Eye className="h-4 w-4 text-gray-500" />
+                                        <Eye className="h-4 w-4 text-muted-foreground" />
                                     )}
                                 </Button>
                             </div>
@@ -180,14 +180,14 @@ export function BackupExport() {
 
                 {/* Backup Summary */}
                 {backupSummary && (
-                    <Alert className="bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-700">
+                    <Alert className="bg-primary/10 border-primary/30">
                         <div className="flex items-center mb-2">
-                            <CheckCircle className="w-4 h-4 mr-2 text-green-600" />
-                            <span className="font-medium text-green-900 dark:text-green-200">
+                            <CheckCircle className="w-4 h-4 mr-2 text-primary" />
+                            <span className="font-medium text-primary">
                                 Backup Created Successfully
                             </span>
                         </div>
-                        <AlertDescription className="text-sm text-green-800 dark:text-green-300 space-y-1">
+                        <AlertDescription className="text-sm text-primary space-y-1">
                             <p>• {backupSummary.walletsCount} wallets backed up</p>
                             <p>• {backupSummary.addressesCount} address book entries backed up</p>
                             <p>• Type: {backupSummary.backupType}</p>

--- a/src/components/BackupRestore.tsx
+++ b/src/components/BackupRestore.tsx
@@ -141,23 +141,23 @@ export function BackupRestore() {
 
                 {/* Backup Preview */}
                 {backupPreview && (
-                    <Card className="bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-700">
+                    <Card className="bg-primary/10 border-primary/30">
                         <CardContent className="pt-6">
                             <div className="flex items-center mb-2">
-                                <FileText className="w-4 h-4 mr-2 text-blue-600" />
-                                <span className="font-medium text-blue-900 dark:text-blue-200">
+                                <FileText className="w-4 h-4 mr-2 text-primary" />
+                                <span className="font-medium text-primary">
                                     Backup Preview
                                 </span>
                             </div>
-                            <div className="text-sm text-blue-800 dark:text-blue-300 space-y-1">
+                            <div className="text-sm text-primary space-y-1">
                                 <p>• Created: {new Date(backupPreview.timestamp).toLocaleDateString()}</p>
                                 <p>• Version: {backupPreview.version}</p>
                                 <p>• Wallets: {backupPreview.wallets.length}</p>
                                 <p>• Address Book entries: {backupPreview.addressBook.length}</p>
                                 <p>• Type: {backupPreview.metadata.backupType}</p>
                                 {backupPreview.wallets.some((w) => w.isEncrypted) && (
-                                    <Alert className="mt-2 bg-yellow-100 dark:bg-yellow-900/30 border-yellow-300 dark:border-yellow-600">
-                                        <AlertDescription className="text-yellow-800 dark:text-yellow-200 text-xs">
+                                    <Alert className="mt-2 bg-caution/10 border-caution/30">
+                                        <AlertDescription className="text-caution text-xs">
                                             ⚠️ This backup contains encrypted wallets. You'll need the individual
                                             wallet passwords when accessing them.
                                         </AlertDescription>
@@ -192,9 +192,9 @@ export function BackupRestore() {
                                     onClick={() => setShowRestorePassword(!showRestorePassword)}
                                 >
                                     {showRestorePassword ? (
-                                        <EyeOff className="h-4 w-4 text-gray-500" />
+                                        <EyeOff className="h-4 w-4 text-muted-foreground" />
                                     ) : (
-                                        <Eye className="h-4 w-4 text-gray-500" />
+                                        <Eye className="h-4 w-4 text-muted-foreground" />
                                     )}
                                 </Button>
                             </div>
@@ -274,10 +274,10 @@ export function BackupRestore() {
                                 </Label>
                             </div>
                         </div>
-                        <Alert className="mt-2 bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-700">
+                        <Alert className="mt-2 bg-caution/10 border-caution/30">
                             <div className="flex items-start">
-                                <AlertCircle className="w-4 h-4 mr-2 text-amber-600 mt-0.5" />
-                                <AlertDescription className="text-xs text-amber-800 dark:text-amber-200">
+                                <AlertCircle className="w-4 h-4 mr-2 text-caution mt-0.5" />
+                                <AlertDescription className="text-xs text-caution">
                                     <p className="font-medium">Warning:</p>
                                     <p>
                                         If "Overwrite existing" is checked, this will replace your current

--- a/src/components/BiometricSetupButton.tsx
+++ b/src/components/BiometricSetupButton.tsx
@@ -185,14 +185,14 @@ export default function BiometricSetupButton({
           <input
             type={showPassword ? "text" : "password"}
             placeholder="Enter wallet password"
-            className="w-full bg-white/10 border-0 text-white px-4 py-3 pr-12 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full bg-card/10 border-0 text-white px-4 py-3 pr-12 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             disabled={isLoading}
           />
           <button
             type="button"
-            className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-white"
+            className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground hover:text-white"
             onClick={() => setShowPassword(!showPassword)}
             disabled={isLoading}
           >
@@ -205,14 +205,14 @@ export default function BiometricSetupButton({
         </div>
         <div className="flex gap-3 mt-2">
           <button
-            className="flex-1 py-3 px-4 bg-transparent border border-gray-600 text-white rounded-lg hover:bg-white/5"
+            className="flex-1 py-3 px-4 bg-transparent border border-border text-white rounded-lg hover:bg-card/5"
             onClick={() => setShowPasswordInput(false)}
             disabled={isLoading}
           >
             Cancel
           </button>
           <button
-            className="flex-1 py-3 px-4 bg-transparent border border-blue-500 text-white rounded-lg hover:bg-blue-900/30 flex items-center justify-center"
+            className="flex-1 py-3 px-4 bg-transparent border border-primary/30 text-white rounded-lg hover:bg-primary/10 flex items-center justify-center"
             onClick={handleSetupBiometrics}
             disabled={isLoading || !password}
           >

--- a/src/components/BrowserNotificationHelp.tsx
+++ b/src/components/BrowserNotificationHelp.tsx
@@ -30,25 +30,25 @@ export const BrowserNotificationHelp: React.FC = () => {
   }, []);
 
   return (
-    <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-      <h3 className="flex items-center gap-2 text-blue-800 dark:text-blue-300 font-medium">
+    <div className="p-4 bg-primary/10 rounded-lg">
+      <h3 className="flex items-center gap-2 text-primary font-medium">
         <Info size={16} />
         Browser Notification Settings
       </h3>
 
-      <p className="text-sm mt-2 text-blue-700 dark:text-blue-200">
+      <p className="text-sm mt-2 text-primary">
         You&apos;ve enabled notifications, but they might not always appear as pop-up banners. To
         ensure you see important alerts, you may need to adjust your {browserName} settings.
       </p>
 
       <Accordion type="single" collapsible className="mt-2">
         <AccordionItem value="browser-settings">
-          <AccordionTrigger className="text-sm font-medium text-blue-800 dark:text-blue-300 py-2">
+          <AccordionTrigger className="text-sm font-medium text-primary py-2">
             How to configure {browserName} notification settings
           </AccordionTrigger>
           <AccordionContent>
             {browserName === 'Brave' && (
-              <div className="space-y-3 text-sm text-blue-700 dark:text-blue-200">
+              <div className="space-y-3 text-sm text-primary">
                 <p>Follow these steps to ensure Brave shows notification banners:</p>
                 <ol className="list-decimal list-inside space-y-2 ml-2">
                   <li>Click the menu button (three lines) in the top right</li>
@@ -66,14 +66,14 @@ export const BrowserNotificationHelp: React.FC = () => {
                     is enabled
                   </li>
                 </ol>
-                <div className="mt-3 flex items-center gap-2 text-blue-600 dark:text-blue-300">
+                <div className="mt-3 flex items-center gap-2 text-primary">
                   <CheckCircle2 size={16} />
                   <span>Restart Brave after making these changes</span>
                 </div>
               </div>
             )}
             {browserName === 'Chrome' && (
-              <div className="space-y-3 text-sm text-blue-700 dark:text-blue-200">
+              <div className="space-y-3 text-sm text-primary">
                 <p>Follow these steps to ensure Chrome shows notification banners:</p>
                 <ol className="list-decimal list-inside space-y-2 ml-2">
                   <li>Click the menu button (three dots) in the top right</li>
@@ -88,7 +88,7 @@ export const BrowserNotificationHelp: React.FC = () => {
               </div>
             )}
             {browserName === 'Firefox' && (
-              <div className="space-y-3 text-sm text-blue-700 dark:text-blue-200">
+              <div className="space-y-3 text-sm text-primary">
                 <p>Follow these steps to ensure Firefox shows notification banners:</p>
                 <ol className="list-decimal list-inside space-y-2 ml-2">
                   <li>Click the menu button (three lines) in the top right</li>
@@ -109,7 +109,7 @@ export const BrowserNotificationHelp: React.FC = () => {
               </div>
             )}
             {browserName !== 'Brave' && browserName !== 'Chrome' && browserName !== 'Firefox' && (
-              <div className="text-sm text-blue-700 dark:text-blue-200">
+              <div className="text-sm text-primary">
                 <p>Check your browser settings to ensure:</p>
                 <ul className="list-disc list-inside space-y-2 mt-2 ml-2">
                   <li>Notification permissions are granted for this website</li>
@@ -126,7 +126,7 @@ export const BrowserNotificationHelp: React.FC = () => {
         <Button
           variant="outline"
           size="sm"
-          className="text-blue-700 dark:text-blue-300 border-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/40"
+          className="text-primary border-primary/30 hover:bg-primary/10 dark:hover:bg-primary/10"
           onClick={() => {
             if (testNotification) {
               testNotification();

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -56,7 +56,7 @@ export default function ConfirmationModal({
       {warningText && (
         <Alert
           variant={isDestructive ? 'destructive' : 'default'}
-          className={`my-2 ${isDestructive ? '' : 'border-yellow-500 text-yellow-700 dark:text-yellow-300'}`}
+          className={`my-2 ${isDestructive ? '' : 'border-caution/30 text-caution'}`}
         >
           <AlertTriangle className="h-4 w-4" />
           <AlertDescription>{warningText}</AlertDescription>

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -122,7 +122,7 @@ export default function ConnectionStatus({ className = '' }: ConnectionStatusPro
           </CardTitle>
           <Badge
             variant={isConnected ? 'default' : 'destructive'}
-            className={`flex items-center gap-1 ${isConnected ? 'bg-green-500 hover:bg-green-600' : ''}`}
+            className={`flex items-center gap-1 ${isConnected ? 'bg-primary hover:bg-primary' : ''}`}
           >
             {isConnected ? (
               <>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -207,15 +207,15 @@ Timestamp: ${new Date().toISOString()}
 
       // Default error UI
       return (
-        <div className="min-h-screen flex items-center justify-center p-4 bg-gray-50 dark:bg-gray-900">
+        <div className="min-h-screen flex items-center justify-center p-4 bg-muted/40 dark:bg-card">
           <Card className="w-full max-w-2xl">
             <CardHeader className="text-center">
               <div className="flex justify-center mb-4">
-                <div className="rounded-full bg-red-100 dark:bg-red-900/30 p-3">
-                  <AlertTriangle className="h-8 w-8 text-red-600 dark:text-red-400" />
+                <div className="rounded-full bg-destructive/10 p-3">
+                  <AlertTriangle className="h-8 w-8 text-destructive" />
                 </div>
               </div>
-              <CardTitle className="text-xl text-red-600 dark:text-red-400">
+              <CardTitle className="text-xl text-destructive">
                 {this.props.isolate ? 'Component Error' : 'Application Error'}
               </CardTitle>
               <CardDescription>
@@ -256,12 +256,12 @@ Timestamp: ${new Date().toISOString()}
               )}
 
               {process.env.NODE_ENV === 'development' && this.state.error && (
-                <Alert className="border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-900/30">
-                  <AlertTriangle className="h-4 w-4 text-orange-600" />
-                  <AlertTitle className="text-orange-800 dark:text-orange-200">
+                <Alert className="border-caution/30 bg-caution/10 dark:border-caution/30 dark:bg-caution/10">
+                  <AlertTriangle className="h-4 w-4 text-caution" />
+                  <AlertTitle className="text-caution">
                     Development Error Details
                   </AlertTitle>
-                  <AlertDescription className="text-orange-700 dark:text-orange-300">
+                  <AlertDescription className="text-caution">
                     <div className="space-y-2 mt-2">
                       <div>
                         <strong>Error:</strong> {this.state.error.message}
@@ -271,7 +271,7 @@ Timestamp: ${new Date().toISOString()}
                           <summary className="cursor-pointer text-sm font-medium">
                             Stack Trace
                           </summary>
-                          <pre className="mt-2 text-xs bg-orange-100 dark:bg-orange-900/50 p-2 rounded overflow-x-auto">
+                          <pre className="mt-2 text-xs bg-caution/10 p-2 rounded overflow-x-auto">
                             {this.state.error.stack}
                           </pre>
                         </details>
@@ -335,7 +335,7 @@ Timestamp: ${new Date().toISOString()}
                     <span>
                       {' '}
                       or report this error with ID:{' '}
-                      <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
+                      <code className="bg-muted/40 dark:bg-card px-1 rounded">
                         {this.state.errorId.slice(0, 8)}
                       </code>
                     </span>

--- a/src/components/InlineLogViewer.tsx
+++ b/src/components/InlineLogViewer.tsx
@@ -431,15 +431,15 @@ export function InlineLogViewer({ className = "" }: InlineLogViewerProps = {}) {
     const getLevelColorClass = (level: string) => {
         switch (level) {
             case 'ERROR':
-                return 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400';
+                return 'bg-destructive/10 text-destructive dark:bg-destructive/10 dark:text-destructive';
             case 'WARN':
-                return 'bg-amber-100 text-amber-800 dark:bg-amber-900/20 dark:text-amber-400';
+                return 'bg-caution/10 text-caution dark:bg-caution/10 dark:text-caution';
             case 'INFO':
-                return 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400';
+                return 'bg-primary/10 text-primary dark:bg-primary/10 dark:text-primary';
             case 'DEBUG':
-                return 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400';
+                return 'bg-muted/40 text-foreground dark:bg-card dark:text-muted-foreground';
             default:
-                return 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400';
+                return 'bg-muted/40 text-foreground dark:bg-card dark:text-muted-foreground';
         }
     };
 
@@ -489,7 +489,7 @@ export function InlineLogViewer({ className = "" }: InlineLogViewerProps = {}) {
                                 onClick={confirmClearLogs}
                                 className={
                                     selectedLoggerName === 'all'
-                                        ? 'bg-red-500 hover:bg-red-600 text-white'
+                                        ? 'bg-destructive hover:bg-destructive text-white'
                                         : ''
                                 }
                             >
@@ -526,7 +526,7 @@ export function InlineLogViewer({ className = "" }: InlineLogViewerProps = {}) {
                                 onClick={confirmClearLogs}
                                 className={
                                     selectedLoggerName === 'all'
-                                        ? 'bg-red-500 hover:bg-red-600 text-white'
+                                        ? 'bg-destructive hover:bg-destructive text-white'
                                         : ''
                                 }
                             >
@@ -684,7 +684,7 @@ export function InlineLogViewer({ className = "" }: InlineLogViewerProps = {}) {
                                 onClick={confirmClearLogs}
                                 className={
                                     selectedLoggerName === 'all'
-                                        ? 'bg-red-500 hover:bg-red-600 text-white'
+                                        ? 'bg-destructive hover:bg-destructive text-white'
                                         : ''
                                 }
                             >
@@ -721,7 +721,7 @@ export function InlineLogViewer({ className = "" }: InlineLogViewerProps = {}) {
                                 onClick={confirmClearLogs}
                                 className={
                                     selectedLoggerName === 'all'
-                                        ? 'bg-red-500 hover:bg-red-600 text-white'
+                                        ? 'bg-destructive hover:bg-destructive text-white'
                                         : ''
                                 }
                             >
@@ -734,7 +734,7 @@ export function InlineLogViewer({ className = "" }: InlineLogViewerProps = {}) {
 
             {/* Header */}
             <div className="p-4 border-b flex items-center gap-2">
-                <Bug className="h-5 w-5 text-amber-500" />
+                <Bug className="h-5 w-5 text-caution" />
                 <h2 className="text-lg font-semibold">Log Viewer</h2>
                 <span className="ml-auto text-sm text-muted-foreground">
                     View and manage application logs
@@ -772,7 +772,7 @@ export function InlineLogViewer({ className = "" }: InlineLogViewerProps = {}) {
                                             <div className="flex items-center justify-between w-full">
                                                 <span className="truncate">{displayName}</span>
                                                 {hasDebugEnabled && (
-                                                    <span className="ml-2 px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 text-xs rounded font-medium shrink-0">
+                                                    <span className="ml-2 px-1.5 py-0.5 bg-caution/10 text-caution text-xs rounded font-medium shrink-0">
                                                         DEBUG
                                                     </span>
                                                 )}
@@ -815,7 +815,7 @@ export function InlineLogViewer({ className = "" }: InlineLogViewerProps = {}) {
                                         <div className="flex items-center justify-between w-full">
                                             <span className="truncate">{displayName}</span>
                                             {hasDebugEnabled && (
-                                                <span className="ml-2 px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 text-xs rounded font-medium shrink-0">
+                                                <span className="ml-2 px-1.5 py-0.5 bg-caution/10 text-caution text-xs rounded font-medium shrink-0">
                                                     DEBUG
                                                 </span>
                                             )}

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -346,15 +346,15 @@ export function LogViewer({ isOpen, onClose }: LogViewerProps) {
   const getLevelColorClass = (level: string) => {
     switch (level) {
       case 'ERROR':
-        return 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400';
+        return 'bg-destructive/10 text-destructive dark:bg-destructive/10 dark:text-destructive';
       case 'WARN':
-        return 'bg-amber-100 text-amber-800 dark:bg-amber-900/20 dark:text-amber-400';
+        return 'bg-caution/10 text-caution dark:bg-caution/10 dark:text-caution';
       case 'INFO':
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400';
+        return 'bg-primary/10 text-primary dark:bg-primary/10 dark:text-primary';
       case 'DEBUG':
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400';
+        return 'bg-muted/40 text-foreground dark:bg-card dark:text-muted-foreground';
       default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400';
+        return 'bg-muted/40 text-foreground dark:bg-card dark:text-muted-foreground';
     }
   };
 
@@ -393,7 +393,7 @@ export function LogViewer({ isOpen, onClose }: LogViewerProps) {
               <Button
                 onClick={confirmClearLogs}
                 className={
-                  selectedLoggerName === 'all' ? 'bg-red-500 hover:bg-red-600 text-white' : ''
+                  selectedLoggerName === 'all' ? 'bg-destructive hover:bg-destructive text-white' : ''
                 }
               >
                 {selectedLoggerName === 'all' ? 'Clear All Loggers' : 'Clear Logs'}
@@ -422,7 +422,7 @@ export function LogViewer({ isOpen, onClose }: LogViewerProps) {
               <AlertDialogAction
                 onClick={confirmClearLogs}
                 className={
-                  selectedLoggerName === 'all' ? 'bg-red-500 hover:bg-red-600 text-white' : ''
+                  selectedLoggerName === 'all' ? 'bg-destructive hover:bg-destructive text-white' : ''
                 }
               >
                 {selectedLoggerName === 'all' ? 'Clear All Loggers' : 'Clear Logs'}
@@ -436,7 +436,7 @@ export function LogViewer({ isOpen, onClose }: LogViewerProps) {
         <DialogContent className="sm:max-w-4xl max-h-[90vh] flex flex-col">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
-              <span className="text-amber-500 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/40 p-1.5 rounded-md">
+              <span className="text-caution bg-caution/10 p-1.5 rounded-md">
                 <Bug className="h-5 w-5" />
               </span>
               Log Viewer
@@ -473,7 +473,7 @@ export function LogViewer({ isOpen, onClose }: LogViewerProps) {
                             <div className="flex items-center justify-between w-full">
                               <span>{displayName}</span>
                               {hasDebugEnabled && (
-                                <span className="ml-2 px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 text-xs rounded font-medium">
+                                <span className="ml-2 px-1.5 py-0.5 bg-caution/10 text-caution text-xs rounded font-medium">
                                   DEBUG
                                 </span>
                               )}
@@ -505,7 +505,7 @@ export function LogViewer({ isOpen, onClose }: LogViewerProps) {
                           <div className="flex items-center justify-between w-full">
                             <span>{displayName}</span>
                             {hasDebugEnabled && (
-                              <span className="ml-2 px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 text-xs rounded font-medium">
+                              <span className="ml-2 px-1.5 py-0.5 bg-caution/10 text-caution text-xs rounded font-medium">
                                 DEBUG
                               </span>
                             )}
@@ -542,10 +542,10 @@ export function LogViewer({ isOpen, onClose }: LogViewerProps) {
                       selectedLoggerName === 'error_boundaries' ||
                       selectedLoggerName === 'security_audit'
                     }
-                    className={isDebugEnabled ? 'data-[state=checked]:bg-amber-500' : ''}
+                    className={isDebugEnabled ? 'data-[state=checked]:bg-caution' : ''}
                   />
                   <Label
-                    className={`text-xs whitespace-nowrap ${isDebugEnabled ? 'font-medium text-amber-500' : 'text-muted-foreground'}`}
+                    className={`text-xs whitespace-nowrap ${isDebugEnabled ? 'font-medium text-caution' : 'text-muted-foreground'}`}
                     title={
                       selectedLoggerName === 'all'
                         ? 'Debug mode can only be set per individual logger'
@@ -660,7 +660,7 @@ export function LogViewer({ isOpen, onClose }: LogViewerProps) {
             <div className="flex-1 text-sm text-muted-foreground">
               {filteredLogs.length} of {logs.length} log entries
               {selectedLoggerName === 'security_audit' && (
-                <div className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                <div className="text-xs text-caution mt-1">
                   Security audit entries can only be cleared from Security Settings
                 </div>
               )}

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -378,11 +378,11 @@ export default function NotificationSettings({ isOpen, onClose }: NotificationSe
                   }}
                   disabled={permissionState === 'denied' || !isEnabled}
                 />
-                <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/20 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
+                <div className="w-11 h-6 bg-muted/40 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/20 rounded-full peer dark:bg-card peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-card after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-border peer-checked:bg-primary"></div>
               </label>
             </div>
             {walletNotifications[activeWalletAddress] === true && (
-              <div className="mt-3 flex items-center gap-2 text-xs text-green-600 dark:text-green-400">
+              <div className="mt-3 flex items-center gap-2 text-xs text-primary">
                 <AlertCircle className="w-3 h-3" />
                 <span>Notifications are enabled for this wallet</span>
               </div>
@@ -585,9 +585,9 @@ export default function NotificationSettings({ isOpen, onClose }: NotificationSe
 
               {/* Add informational text when price alerts are disabled */}
               {preferences.priceAlerts === false && (
-                <div className="flex items-center gap-2 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md">
-                  <AlertCircle className="w-4 h-4 text-amber-600 dark:text-amber-400" />
-                  <p className="text-xs text-amber-600 dark:text-amber-400">
+                <div className="flex items-center gap-2 p-3 bg-caution/10 border border-caution/30 rounded-md">
+                  <AlertCircle className="w-4 h-4 text-caution" />
+                  <p className="text-xs text-caution">
                     Price alerts are currently disabled
                   </p>
                 </div>
@@ -779,7 +779,7 @@ function WalletNotificationsList({
               checked={walletNotifications[wallet.address] === true}
               onChange={(e) => toggleWalletNotifications(wallet.address, e.target.checked)}
             />
-            <div className="w-9 h-5 bg-input peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-ring peer-focus:ring-offset-2 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-background after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
+            <div className="w-9 h-5 bg-input peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-ring peer-focus:ring-offset-2 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-background after:border-border after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-border peer-checked:bg-primary"></div>
           </label>
         </div>
       ))}

--- a/src/components/NotificationToggle.tsx
+++ b/src/components/NotificationToggle.tsx
@@ -62,8 +62,8 @@ export function NotificationToggle() {
       disabled={loading}
       className={`flex items-center gap-2 ${
         notificationsEnabled
-          ? 'bg-green-600 hover:bg-green-700 text-white'
-          : 'text-gray-600 dark:text-gray-300'
+          ? 'bg-primary hover:bg-primary text-white'
+          : 'text-muted-foreground'
       }`}
     >
       {loading ? (

--- a/src/components/QRDisplayModal.tsx
+++ b/src/components/QRDisplayModal.tsx
@@ -91,11 +91,11 @@ export default function QRDisplayModal({ isOpen, onClose, address, label }: QRDi
           )}
 
           {label && (
-            <div className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">{label}</div>
+            <div className="mb-2 text-sm font-medium text-muted-foreground">{label}</div>
           )}
 
-          <div className="mb-4 p-3 bg-gray-100 dark:bg-gray-700 rounded-lg">
-            <div className="text-xs font-mono text-gray-600 dark:text-gray-300 break-all">
+          <div className="mb-4 p-3 bg-muted/40 dark:bg-card rounded-lg">
+            <div className="text-xs font-mono text-muted-foreground break-all">
               {address}
             </div>
           </div>
@@ -103,7 +103,7 @@ export default function QRDisplayModal({ isOpen, onClose, address, label }: QRDi
           <div className="flex gap-2">
             <button
               onClick={copyAddress}
-              className="flex-1 flex items-center justify-center py-2 px-3 text-sm bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition-colors"
+              className="flex-1 flex items-center justify-center py-2 px-3 text-sm bg-muted/40 dark:bg-card hover:bg-muted/40 dark:hover:bg-card text-muted-foreground rounded-lg transition-colors"
             >
               <Copy className="w-4 h-4 mr-1" />
               Copy
@@ -111,7 +111,7 @@ export default function QRDisplayModal({ isOpen, onClose, address, label }: QRDi
             <button
               onClick={downloadQRCode}
               disabled={!qrDataUrl}
-              className="flex-1 flex items-center justify-center py-2 px-3 text-sm bg-avian-600 hover:bg-avian-700 disabled:bg-gray-400 text-white rounded-lg transition-colors"
+              className="flex-1 flex items-center justify-center py-2 px-3 text-sm bg-avian-600 hover:bg-avian-700 disabled:bg-card text-white rounded-lg transition-colors"
             >
               <Download className="w-4 h-4 mr-1" />
               Download

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -73,7 +73,7 @@ export default function RouteGuard({
     // Show loading screen while checking
     if (isChecking) {
         return (
-            <div className="min-h-screen bg-gradient-to-br from-sky-50 via-blue-50 to-cyan-50 dark:from-gray-900 dark:via-blue-950 dark:to-gray-900 flex items-center justify-center relative">
+            <div className="min-h-screen bg-gradient-to-br from-card to-background flex items-center justify-center relative">
                 <GradientBackground>
                     <div className="flex flex-col items-center space-y-4 z-10">
                         <Image src="/avian_spinner.png" alt="Loading..." width={96} height={96} unoptimized />

--- a/src/components/SecuritySettingsPanel.tsx
+++ b/src/components/SecuritySettingsPanel.tsx
@@ -364,7 +364,7 @@ export default function SecuritySettingsPanel({
             {/* Auto-lock Settings Section */}
             <div className="space-y-4">
               <div className="flex items-center">
-                <Clock className="h-5 w-5 text-amber-600 mr-2" />
+                <Clock className="h-5 w-5 text-caution mr-2" />
                 <h3 className="text-lg font-medium">Auto-lock Settings</h3>
               </div>
 
@@ -439,7 +439,7 @@ export default function SecuritySettingsPanel({
             {/* Biometric Authentication Section */}
             <div className="space-y-4">
               <div className="flex items-center">
-                <Fingerprint className="h-5 w-5 text-green-600 mr-2" />
+                <Fingerprint className="h-5 w-5 text-primary mr-2" />
                 <h3 className="text-lg font-medium">Biometric Authentication</h3>
               </div>
 
@@ -497,9 +497,9 @@ export default function SecuritySettingsPanel({
                   )}
                 </div>
               ) : (
-                <Alert className="bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-700">
-                  <Info className="h-4 w-4 text-amber-600" />
-                  <AlertDescription className="text-amber-800 dark:text-amber-200">
+                <Alert className="bg-caution/10 border-caution/30">
+                  <Info className="h-4 w-4 text-caution" />
+                  <AlertDescription className="text-caution">
                     Biometric authentication is not supported on this device or browser.
                   </AlertDescription>
                 </Alert>
@@ -509,7 +509,7 @@ export default function SecuritySettingsPanel({
             {/* Security Audit Log Section */}
             <div className="space-y-4">
               <div className="flex items-center">
-                <FileText className="h-5 w-5 text-red-600 mr-2" />
+                <FileText className="h-5 w-5 text-destructive mr-2" />
                 <h3 className="text-lg font-medium">Security Audit Log</h3>
               </div>
 
@@ -623,7 +623,7 @@ export default function SecuritySettingsPanel({
                   {paginatedEntries.map((entry) => (
                     <Card
                       key={entry.id}
-                      className={`overflow-hidden ${!entry.success ? 'border-red-200 dark:border-red-900' : ''}`}
+                      className={`overflow-hidden ${!entry.success ? 'border-destructive/30' : ''}`}
                     >
                       <div
                         className="p-3 cursor-pointer hover:bg-muted/50"
@@ -806,7 +806,7 @@ export default function SecuritySettingsPanel({
           <DrawerContent>
             <DrawerHeader className="text-center">
               <DrawerTitle className="flex items-center justify-center gap-2">
-                <AlertTriangle className="h-5 w-5 text-red-500" />
+                <AlertTriangle className="h-5 w-5 text-destructive" />
                 Clear Security Audit Log
               </DrawerTitle>
               <DrawerDescription>
@@ -815,7 +815,7 @@ export default function SecuritySettingsPanel({
               </DrawerDescription>
             </DrawerHeader>
             <DrawerFooter className="gap-2">
-              <Button className="bg-red-600 hover:bg-red-700 text-white" onClick={clearAuditLog}>
+              <Button className="bg-destructive hover:bg-destructive text-white" onClick={clearAuditLog}>
                 Clear Log
               </Button>
               <Button variant="outline" onClick={() => setIsClearDialogOpen(false)}>
@@ -826,10 +826,10 @@ export default function SecuritySettingsPanel({
         </Drawer>
       ) : (
         <AlertDialog open={isClearDialogOpen} onOpenChange={setIsClearDialogOpen}>
-          <AlertDialogContent className="dark:bg-gray-800 border dark:border-gray-700">
+          <AlertDialogContent className="dark:bg-card border dark:border-border">
             <AlertDialogHeader>
               <AlertDialogTitle className="flex items-center gap-2">
-                <AlertTriangle className="h-5 w-5 text-red-500" />
+                <AlertTriangle className="h-5 w-5 text-destructive" />
                 Clear Security Audit Log
               </AlertDialogTitle>
               <AlertDialogDescription>
@@ -840,7 +840,7 @@ export default function SecuritySettingsPanel({
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
-                className="bg-red-600 hover:bg-red-700 text-white"
+                className="bg-destructive hover:bg-destructive text-white"
                 onClick={clearAuditLog}
               >
                 Clear Log


### PR DESCRIPTION
**Final chunk of the UI/UX refresh** (PR 7 + PR 8 combined) — brand re-key of every remaining surface. Presentation only.

### Backup / security / notifications / logs
BackupDrawer, BackupExport, BackupRestore, backup/qr page, QRDisplayModal, SecuritySettingsPanel, BiometricSetupButton, NotificationSettings, NotificationToggle, BrowserNotificationHelp, LogViewer, InlineLogViewer.

### Site / shared
terms page, about page, ErrorBoundary, ConnectionStatus, ConfirmationModal, AddressInput, RouteGuard.

### Semantic mapping (held throughout the sweep)
success → teal · danger → `destructive` · warning → `caution` · info → teal · neutrals → `muted`/`border`/`card`. Colour-coding preserved: failed-audit → destructive, connected → teal, input error → destructive.

### Safety
QR codes untouched (hex props); ContactAvatar left alone (identicon contrast logic). No crypto, `requireAuth`, or storage paths touched.

**With this merged, the whole app is re-keyed to the Avian brand.**

### Verification
typecheck ✓ · **542/542 unit ✓** · static build ✓ · **25/25 E2E ✓**