### PR TITLE
feat(send): review step before authorising a transaction

### DIFF
--- a/src/components/SendForm.tsx
+++ b/src/components/SendForm.tsx
@@ -24,6 +24,7 @@ import { QRScanResult } from '@/types/addressBook';
 import { UTXOSelectionSettings } from './UTXOSelectionSettings';
 import { UTXOOverview } from './UTXOOverview';
 import { UTXOSelector } from './UTXOSelector';
+import SendReviewDialog from './SendReviewDialog';
 
 // Import Shadcn UI components
 import { Button } from '@/components/ui/button';
@@ -82,6 +83,7 @@ export default function SendForm() {
   });
   const [isConsolidatingToSelf, setIsConsolidatingToSelf] = useState(false);
   const [showUTXOSelector, setShowUTXOSelector] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
   const [manuallySelectedUTXOs, setManuallySelectedUTXOs] = useState<EnhancedUTXO[]>([]);
   const [subtractFeeFromAmount, setSubtractFeeFromAmount] = useState(false);
   const [customChangeAddress, setCustomChangeAddress] = useState('');
@@ -189,17 +191,23 @@ export default function SendForm() {
       return;
     }
 
+    // All checks passed — show the review. Nothing is authorised or signed until the user
+    // confirms there; the actual auth + send path (proceedToAuthAndSend) is unchanged.
+    setReviewOpen(true);
+  };
+
+  // Runs after the user confirms the review: authenticate, then send. Extracted verbatim from the
+  // old inline handleSubmit path so the money-moving flow is untouched — only gated by the review.
+  const proceedToAuthAndSend = async () => {
     try {
-      // Always require authentication for transactions, regardless of stored password
       let authPassword = '';
 
       if (isEncrypted) {
-        // Always request authentication using the SecurityContext's requireAuth method
         const authResult = await requireAuth('Authenticate to send transaction');
 
         if (!authResult.success || !authResult.password) {
-          // User canceled authentication or it failed
           setError('Authentication required to send transaction');
+          setReviewOpen(false);
           return;
         }
 
@@ -207,10 +215,11 @@ export default function SendForm() {
         setUsingBiometricAuth(wasBiometricAuth);
       }
 
-      // Proceed with sending the transaction using the acquired password
       await sendTransactionWithAuth(authPassword);
+      setReviewOpen(false);
     } catch (error: any) {
       setError('Authentication failed: ' + (error.message || 'Unknown error'));
+      setReviewOpen(false);
     }
   };
 
@@ -1411,6 +1420,46 @@ export default function SendForm() {
           feeRate={utxoOptions.feeRate || 10000}
           maxInputs={utxoOptions.maxInputs || 100}
         />
+
+        {(() => {
+          const amountSats = Math.floor(parseFloat(amount || '0') * 100000000);
+          const feeSats = 10000;
+          const totalSats = subtractFeeFromAmount ? amountSats : amountSats + feeSats;
+          const recipientSats = subtractFeeFromAmount
+            ? Math.max(0, amountSats - feeSats)
+            : amountSats;
+          const fmt = (s: number) => (s / 100000000).toFixed(8);
+          const manualCount = manuallySelectedUTXOs.length;
+          const inputsLabel =
+            utxoOptions.strategy === CoinSelectionStrategy.MANUAL
+              ? `${manualCount} UTXO${manualCount === 1 ? '' : 's'} · manual`
+              : 'Automatic · best-fit';
+          return (
+            <SendReviewDialog
+              open={reviewOpen}
+              onOpenChange={setReviewOpen}
+              onConfirm={proceedToAuthAndSend}
+              onEditInputs={() => {
+                setReviewOpen(false);
+                setShowUTXOSelector(true);
+              }}
+              isSending={isSending}
+              amount={amount}
+              toAddress={toAddress}
+              feeAVN={fmt(feeSats)}
+              totalAVN={fmt(totalSats)}
+              recipientReceivesAVN={fmt(recipientSats)}
+              subtractFee={subtractFeeFromAmount}
+              inputsLabel={inputsLabel}
+              changeAddress={customChangeAddress || undefined}
+              fromLabel={
+                fromDerivedAddress
+                  ? `Derived · ${fromDerivedAddress.slice(0, 10)}…${fromDerivedAddress.slice(-6)}`
+                  : undefined
+              }
+            />
+          );
+        })()}
 
         {/* Manual UTXO Selection Notice */}
         {utxoOptions.strategy === CoinSelectionStrategy.MANUAL && (

--- a/src/components/SendReviewDialog.tsx
+++ b/src/components/SendReviewDialog.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import React from 'react';
+import { ArrowRight, Lock, ShieldCheck, SlidersHorizontal } from 'lucide-react';
+import { useMediaQuery } from '@/hooks/use-media-query';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    Drawer,
+    DrawerContent,
+    DrawerDescription,
+    DrawerHeader,
+    DrawerTitle,
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+
+interface SendReviewDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onConfirm: () => void;
+    onEditInputs: () => void;
+    isSending: boolean;
+    amount: string;
+    toAddress: string;
+    feeAVN: string;
+    totalAVN: string;
+    recipientReceivesAVN: string;
+    subtractFee: boolean;
+    inputsLabel: string;
+    changeAddress?: string;
+    fromLabel?: string;
+}
+
+const shorten = (a: string) => (a.length > 24 ? `${a.slice(0, 12)}…${a.slice(-10)}` : a);
+
+export default function SendReviewDialog({
+    open,
+    onOpenChange,
+    onConfirm,
+    onEditInputs,
+    isSending,
+    amount,
+    toAddress,
+    feeAVN,
+    totalAVN,
+    recipientReceivesAVN,
+    subtractFee,
+    inputsLabel,
+    changeAddress,
+    fromLabel,
+}: SendReviewDialogProps) {
+    const isMobile = useMediaQuery('(max-width: 768px)');
+
+    const body = (
+        <div className="space-y-4">
+            {/* hero */}
+            <div className="rounded-xl border border-border bg-muted/40 p-5 text-center">
+                <span className="fd-label block text-muted-foreground">You&apos;re sending</span>
+                <div className="fd-readout mt-2 text-3xl font-semibold text-primary">
+                    {amount} <span className="text-lg text-muted-foreground">AVN</span>
+                </div>
+            </div>
+
+            {/* to */}
+            <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+                <ArrowRight className="h-3.5 w-3.5 text-primary" /> To recipient
+            </div>
+            <div className="break-all rounded-md border border-border bg-muted/20 p-3 font-mono text-sm">
+                {toAddress}
+            </div>
+
+            {/* breakdown */}
+            <div className="rounded-lg border border-border">
+                <Row k="Amount" v={`${amount} AVN`} />
+                <Row k="Network fee" v={`≈ ${feeAVN} AVN`} />
+                <div className="flex items-center justify-between gap-3 border-t border-border px-3 py-2.5 text-sm">
+                    <span className="text-muted-foreground">Inputs</span>
+                    <span className="flex items-center gap-2">
+                        <span className="font-mono">{inputsLabel}</span>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 gap-1 px-2 text-xs text-primary"
+                            onClick={onEditInputs}
+                        >
+                            <SlidersHorizontal className="h-3 w-3" /> Change
+                        </Button>
+                    </span>
+                </div>
+                {changeAddress && <Row k="Change address" v={shorten(changeAddress)} mono />}
+                {fromLabel && <Row k="From" v={fromLabel} />}
+                <div className="flex items-center justify-between gap-3 border-t border-border px-3 py-3 text-sm">
+                    <span className="font-medium">Total</span>
+                    <span className="font-mono text-base font-semibold">{totalAVN} AVN</span>
+                </div>
+            </div>
+
+            {subtractFee && (
+                <p className="text-xs text-muted-foreground">
+                    The network fee is taken from the amount — the recipient receives{' '}
+                    <span className="font-mono text-foreground">{recipientReceivesAVN} AVN</span>.
+                </p>
+            )}
+
+            {/* reassurance */}
+            <div className="flex items-start gap-2.5 rounded-lg border border-primary/25 bg-primary/5 p-3 text-sm">
+                <ShieldCheck className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
+                <span>
+                    Confirming opens authentication — nothing is signed or broadcast until you authorise.
+                </span>
+            </div>
+
+            {/* actions */}
+            <div className="flex gap-2 pt-1">
+                <Button
+                    type="button"
+                    variant="outline"
+                    className="flex-1"
+                    onClick={() => onOpenChange(false)}
+                    disabled={isSending}
+                >
+                    Back
+                </Button>
+                <Button type="button" className="flex-1 gap-2" onClick={onConfirm} disabled={isSending}>
+                    <Lock className="h-4 w-4" />
+                    {isSending ? 'Sending…' : 'Confirm & authorise'}
+                </Button>
+            </div>
+        </div>
+    );
+
+    const title = 'Review transaction';
+    const description = 'Check the details before you authorise the send.';
+
+    if (isMobile) {
+        return (
+            <Drawer open={open} onOpenChange={onOpenChange}>
+                <DrawerContent className="max-h-[95vh]">
+                    <DrawerHeader className="text-left">
+                        <DrawerTitle>{title}</DrawerTitle>
+                        <DrawerDescription>{description}</DrawerDescription>
+                    </DrawerHeader>
+                    <div className="overflow-y-auto px-4 pb-6">{body}</div>
+                </DrawerContent>
+            </Drawer>
+        );
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogDescription>{description}</DialogDescription>
+                </DialogHeader>
+                {body}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function Row({ k, v, mono }: { k: string; v: string; mono?: boolean }) {
+    return (
+        <div className="flex items-center justify-between gap-3 border-t border-border px-3 py-2.5 text-sm first:border-t-0">
+            <span className="text-muted-foreground">{k}</span>
+            <span className={mono ? 'font-mono' : ''}>{v}</span>
+        </div>
+    );
+}


### PR DESCRIPTION
**Second deep-flow redesign.** Inserts a **review gate between the send form's validation and authentication**, so a transaction is never one tap away from leaving the wallet.

### Safety-first structure
The actual money path (`sendTransactionWithAuth`) is **byte-for-byte unchanged**. The auth + send logic was extracted *verbatim* into `proceedToAuthAndSend`, now called only after the user confirms the review. `requireAuth` still fires on confirm, so the per-send auth guarantee is intact.

### What changed
- **`SendReviewDialog`** (Dialog / Drawer) — amount, recipient, network-fee estimate, **inputs summary** (Automatic best-fit vs. *N* UTXOs manual, with a **Change** affordance that opens the coin-control picker), optional change address, and the total debited. States plainly that confirming opens authentication and nothing is signed until then.
- **`SendForm`** — `handleSubmit` runs all existing validation, then opens the review instead of going straight to `requireAuth`. **Every** send path (standard, manual-UTXO, derived-address, consolidation) is gated identically.

Coin-control keeps the existing `UTXOSelector`, now reachable from the review. No crypto, auth, or storage changes.

### Verification note
The send flow early-returns when disconnected, and the test env has no ElectrumX — so, like the rest of the send path, the review isn't E2E-reachable offline. Verified the surrounding suite is unaffected: typecheck ✓ · **542/542 unit ✓** · static build ✓ · **27/27 E2E ✓**. Worth an eyeball live once merged.