### PR TITLE
feat(ui): branded empty + skeleton loading states

### DIFF
--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from './fixtures';
+
+/**
+ * The seeded wallet has no transaction history and the fixture blocks the socket, so the history
+ * panel has nothing to show — exactly the empty-state case. This guards that it renders the
+ * friendly "No transactions yet" state rather than a blank panel or a stuck spinner.
+ */
+test('transaction history shows a friendly empty state with no transactions', async ({
+  walletPage,
+}) => {
+  await walletPage.goto('/');
+
+  // Desktop layout renders the history panel directly; the empty state settles after loading.
+  await expect(walletPage.getByText('No transactions yet').first()).toBeVisible({
+    timeout: 30_000,
+  });
+});

--- a/src/components/AddressBook.tsx
+++ b/src/components/AddressBook.tsx
@@ -14,7 +14,9 @@ import {
   QrCode,
   Camera,
   Share2,
+  BookUser,
 } from 'lucide-react';
+import { EmptyState } from '@/components/EmptyState';
 import { StorageService } from '@/services/core/StorageService';
 import { SavedAddress, DEFAULT_CATEGORIES, QRScanResult } from '@/types/addressBook';
 import { toast } from 'sonner';
@@ -743,9 +745,19 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
         className={`space-y-2 ${isAddingNew || editingId ? 'max-h-64 overflow-y-auto' : 'flex-1 overflow-y-auto'} min-h-0 border-t border-avian-100 dark:border-avian-800 pt-2`}
       >
         {filteredAddresses.length === 0 ? (
-          <div className="text-center py-8 text-muted-foreground">
-            {searchQuery ? 'No addresses match your search' : 'No saved addresses'}
-          </div>
+          searchQuery ? (
+            <EmptyState
+              icon={Search}
+              title="No matches"
+              description="No saved addresses match your search."
+            />
+          ) : (
+            <EmptyState
+              icon={BookUser}
+              title="No saved addresses"
+              description="Save the people and services you send to, so you don't have to paste addresses each time."
+            />
+          )
         ) : (
           filteredAddresses.map((address) => (
             <div

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+
+interface EmptyStateProps {
+    /** A lucide (or compatible) icon component. */
+    icon?: React.ComponentType<{ className?: string }>;
+    title: string;
+    description?: string;
+    /** Optional call-to-action, e.g. a Button. */
+    action?: React.ReactNode;
+    className?: string;
+}
+
+/**
+ * A calm, branded empty state: an icon in a soft tile, a title, an optional line of guidance, and
+ * an optional action. Used wherever a list or panel has nothing to show yet, so "nothing here"
+ * reads as an invitation rather than a dead end.
+ */
+export function EmptyState({ icon: Icon, title, description, action, className = '' }: EmptyStateProps) {
+    return (
+        <div
+            className={`flex flex-col items-center justify-center px-6 py-12 text-center ${className}`}
+        >
+            {Icon && (
+                <div className="mb-4 grid h-14 w-14 place-items-center rounded-2xl border border-border bg-muted/50 text-muted-foreground">
+                    <Icon className="h-7 w-7" />
+                </div>
+            )}
+            <p className="text-base font-medium">{title}</p>
+            {description && (
+                <p className="mt-1 max-w-xs text-sm text-muted-foreground">{description}</p>
+            )}
+            {action && <div className="mt-5">{action}</div>}
+        </div>
+    );
+}

--- a/src/components/SecuritySettingsPanel.tsx
+++ b/src/components/SecuritySettingsPanel.tsx
@@ -15,6 +15,7 @@ import {
   Info,
   AlertTriangle,
 } from 'lucide-react';
+import { EmptyState } from '@/components/EmptyState';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { cn } from '@/lib/utils';
 
@@ -612,11 +613,11 @@ export default function SecuritySettingsPanel({
             </div>
 
             {filteredAuditLog.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground">
-                <FileText className="h-10 w-10 mx-auto mb-2 opacity-50" />
-                <p>No audit log entries found</p>
-                <p className="text-sm">Security events will appear here when they occur</p>
-              </div>
+              <EmptyState
+                icon={FileText}
+                title="No audit log entries"
+                description="Security events like unlocks and setting changes will appear here as they happen."
+              />
             ) : (
               <>
                 <div className="space-y-3">

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -14,6 +14,7 @@ import {
   ChevronLeft,
   ChevronRight,
   RefreshCw,
+  Inbox,
 } from 'lucide-react';
 
 import {
@@ -27,7 +28,29 @@ import {
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/EmptyState';
 import { toast } from 'sonner';
+
+// Loading placeholder that mirrors the transaction-row layout, so the list settles into place
+// rather than flashing a bare spinner.
+function TxRowSkeleton() {
+  return (
+    <div className="p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <Skeleton className="h-10 w-10 flex-shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-2 py-1">
+            <Skeleton className="h-3.5 w-24" />
+            <Skeleton className="h-3 w-44" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+        </div>
+        <Skeleton className="h-4 w-20 flex-shrink-0" />
+      </div>
+    </div>
+  );
+}
 
 interface TransactionData {
   id?: number;
@@ -441,34 +464,21 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
       <CardContent className="p-0">
         <div className="max-h-[500px] overflow-y-auto">
           {isLoading ? (
-            <div className="flex items-center justify-center p-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-              <span className="ml-2 text-muted-foreground">Loading transactions...</span>
+            <div className="divide-y divide-border" aria-busy="true" aria-label="Loading transactions">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <TxRowSkeleton key={i} />
+              ))}
             </div>
           ) : paginatedTransactions.length === 0 ? (
-            <div className="text-center py-12">
-              <div className="text-muted-foreground mb-2">
-                <svg
-                  className="w-16 h-16 mx-auto"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1}
-                    d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"
-                  />
-                </svg>
-              </div>
-              <p className="text-muted-foreground text-lg">
-                {filter === 'all' ? 'No transactions found' : `No ${filter} transactions found`}
-              </p>
-              <p className="text-muted-foreground text-sm mt-1">
-                Transactions will appear here once you start using your wallet
-              </p>
-            </div>
+            <EmptyState
+              icon={Inbox}
+              title={filter === 'all' ? 'No transactions yet' : `No ${filter} transactions`}
+              description={
+                filter === 'all'
+                  ? 'When you receive or send AVN, it shows up here with live confirmations.'
+                  : `Nothing matches the ${filter} filter yet.`
+              }
+            />
           ) : (
             <div className="divide-y divide-border">
               {paginatedTransactions.map((tx) => (

--- a/src/components/WatchAddressesPanel.tsx
+++ b/src/components/WatchAddressesPanel.tsx
@@ -5,6 +5,7 @@ import { useWallet } from '@/contexts/WalletContext';
 import { useNotifications } from '@/contexts/NotificationContext';
 import WatchAddressService, { WatchAddress } from '@/services/wallet/WatchAddressService';
 import { RefreshCw, Clipboard, Trash2, Eye, Save, BellRing, Minus, Plus } from 'lucide-react';
+import { EmptyState } from '@/components/EmptyState';
 import { StorageService } from '@/services/core/StorageService';
 
 // Shadcn UI components
@@ -441,11 +442,11 @@ export default function WatchAddressesPanel() {
           </div>
 
           {watchedAddresses.length === 0 ? (
-            <div className="text-center py-8">
-              <p className="text-muted-foreground">
-                No addresses being watched yet.
-              </p>
-            </div>
+            <EmptyState
+              icon={Eye}
+              title="No watched addresses"
+              description="Watch any Avian address to follow its balance and activity without importing keys."
+            />
           ) : (
             <div className="space-y-4">
               {watchedAddresses.map((item) => (


### PR DESCRIPTION
**Third deep-flow redesign** (last on the list). Replaces generic "nothing here" panels and bare spinners with a calm, consistent treatment.

### What changed
- **`EmptyState`** (new, reusable) — icon tile + title + guidance + optional action.
- **TransactionHistory** — loading now renders **skeleton rows** that mirror the real row layout instead of a centered spinner; the empty state uses `EmptyState` ("No transactions yet" — an invitation, with a per-filter message).
- **AddressBook**, **SecuritySettingsPanel** (audit log), **WatchAddressesPanel** — empty states unified onto `EmptyState` with helpful guidance copy.

### Tests
Adds `e2e/empty-states.spec.ts` asserting the history empty state renders for a wallet with no transactions — this one **is** reachable in the offline harness.

### Safety
No crypto, auth, or storage changes.

### Verification
typecheck ✓ · **542/542 unit ✓** · static build ✓ · **28/28 E2E ✓** (27 + 1 new)