### PR TITLE
perf(tx): incremental transaction refresh instead of full reprocess

### DIFF
--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -146,12 +146,7 @@ interface TransactionHistoryProps {
 }
 
 export function TransactionHistory({ className }: TransactionHistoryProps) {
-  const {
-    address,
-    refreshTransactionHistory,
-    processingProgress,
-    reprocessTransactionHistoryProgressive,
-  } = useWallet();
+  const { address, refreshTransactionHistory, processingProgress } = useWallet();
   const [transactions, setTransactions] = useState<EnhancedTransactionData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -164,8 +159,10 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
     try {
       setIsRefreshing(true);
 
-      // Use the progressive method that updates UI in real-time
-      await reprocessTransactionHistoryProgressive();
+      // Incremental refresh: pull only new transactions rather than re-fetching the entire
+      // history. A full re-sync (reclassify everything) is still available via the balance
+      // card's long-press.
+      await refreshTransactionHistory();
 
       // Final reload after processing is complete
       const finalTxHistory = await StorageService.getTransactionHistory(address);
@@ -181,7 +178,7 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
     } finally {
       setIsRefreshing(false);
     }
-  }, [address, reprocessTransactionHistoryProgressive]);
+  }, [address, refreshTransactionHistory]);
 
   const loadTransactions = useCallback(async () => {
     if (!address) return;

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -461,27 +461,16 @@ export class WalletService {
                 walletLogger.warn('Error fixing transactions without wallet address:', fixError);
             }
 
-            // Process initial transaction history only if needed
+            // Pull transaction history on load. This is incremental: after the first sync it only
+            // fetches transactions we haven't stored yet, so opening the wallet is fast even with a
+            // large history. Previously this did a FULL reprocess (re-fetching every transaction)
+            // on first login and every 24h thereafter, which is very slow for big wallets — a full
+            // reclassification is rarely needed and remains available on demand (balance card
+            // long-press -> reprocessTransactionHistory).
             try {
-                // Check if we need to process transactions by checking if this is first login
                 const lastProcessedKey = `${address}_last_processed_time`;
-                const lastProcessedTime = localStorage.getItem(lastProcessedKey);
-                const currentTime = Date.now();
-
-                // Only process if:
-                // 1. Never processed before, or
-                // 2. It's been more than 24 hours since last processing
-                const shouldProcess =
-                    !lastProcessedTime || currentTime - parseInt(lastProcessedTime) > 24 * 60 * 60 * 1000;
-
-                if (shouldProcess) {
-                    await this.processTransactionHistory(address, onProgress);
-                    // Save the processing time
-                    localStorage.setItem(lastProcessedKey, currentTime.toString());
-                } else {
-                    // Still check for new transactions since last login without full reprocessing
-                    await this.refreshTransactionHistory(address, onProgress);
-                }
+                await this.refreshTransactionHistory(address, onProgress);
+                localStorage.setItem(lastProcessedKey, Date.now().toString());
             } catch (error) {
                 walletLogger.error('Error processing initial transaction history:', error);
             }


### PR DESCRIPTION
Fixes the slow "Processing N/5247" that appeared on wallet load.

### Root cause
`initializeWallet` did a **full reprocess** — one `getTransaction` per transaction — on first login **and every 24 hours after**. For a large wallet that's thousands of sequential Electrum round-trips just to open the wallet.

### Fix (2 files)
- **`WalletService.initializeWallet`** — on load, call the incremental `refreshTransactionHistory` (only-new) instead of a 24h/first-login full `processTransactionHistory`. The first sync still fetches everything once; every open after that is fast.
- **`TransactionHistory`** — the panel's Refresh button switches from a full progressive reprocess to the same incremental refresh.

A full re-fetch + reclassification is **still available on demand** via the balance card's long-press (`reprocessTransactionHistory`) — unchanged, as is `processTransactionHistory`'s reclassification contract.

### Note
A first attempt (skipping already-confirmed txs inside `processTransactionHistory`) was reverted because a unit test correctly caught that it would stop reclassifying stored transactions. The fix lives in the load path instead; the shared method is untouched.

### Safety
No crypto, signing, or storage-format changes.

### Verification
typecheck ✓ · **542/542 unit ✓** · static build ✓ · **27/27 E2E ✓**