### PR TITLE
feat(security): optional lock screen — load-then-authenticate

### DIFF
--- a/docs/proposals/optional-lock-screen.md
+++ b/docs/proposals/optional-lock-screen.md
@@ -1,7 +1,15 @@
 # Proposal: optional lock screen, load-then-authenticate
 
-**Status:** proposed, not yet implemented
+**Status:** implemented (2026-08-12)
 **Scope:** its own PR, after the reconnect/balance fixes land
+
+> **Implementation note.** Built as specified, with one deliberate simplification: rather than an
+> overlay over always-mounted children, the wall renders *in place of* the wallet subtree while the
+> `SecurityContext.Provider` stays mounted. The user-facing behaviour is identical (default no-wall
+> loads read-only; opt-in wall shows on start), `requireAuth` works in both modes and still fails
+> closed, and it sidesteps a z-index/stacking fight the sibling-overlay hit. Open questions 1
+> (session-password timeout) and 2 (biometric-only unlock) remain follow-ups; a lock now clears the
+> in-memory password (the credential half), but there is no standalone key-timeout without the wall.
 
 ## Summary
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -33,7 +33,7 @@ interface SeedRecord {
 }
 
 /** Accepts the terms so the app does not bounce us to /terms on first load. */
-async function acceptTerms(page: Page) {
+export async function acceptTerms(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem('terms-accepted', 'true');
     localStorage.setItem('terms-accepted-date', new Date().toISOString());
@@ -44,7 +44,7 @@ async function acceptTerms(page: Page) {
  * Puts a wallet into the app's database. The app has to boot once first so that IndexedDB exists
  * with the current schema — creating it ourselves would risk drifting from StorageService.
  */
-async function seedWallet(page: Page) {
+export async function seedWallet(page: Page) {
   const record: SeedRecord = {
     name: WALLET_NAME,
     address: WALLET_ADDRESS,
@@ -94,6 +94,87 @@ async function seedWallet(page: Page) {
 }
 
 /**
+ * Sets the opt-in screen-lock wall on or off. It updates the settings record the app already
+ * created on boot (updating the existing record avoids the unique `key` index conflict a fresh
+ * insert would hit) and reloads so it takes effect. Call after seedWallet.
+ */
+export async function setScreenLock(page: Page, enabled: boolean) {
+  // Wait until the app has written its settings record.
+  await page.waitForFunction(
+    (dbName) =>
+      new Promise<boolean>((resolve) => {
+        const req = indexedDB.open(dbName);
+        req.onsuccess = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains('preferences')) {
+            db.close();
+            resolve(false);
+            return;
+          }
+          const g = db
+            .transaction('preferences', 'readonly')
+            .objectStore('preferences')
+            .index('key')
+            .get('settings');
+          g.onsuccess = () => {
+            db.close();
+            resolve(!!g.result);
+          };
+          g.onerror = () => {
+            db.close();
+            resolve(false);
+          };
+        };
+        req.onerror = () => resolve(false);
+      }),
+    DB_NAME,
+    { timeout: 30_000 },
+  );
+
+  await page.evaluate(
+    ({ dbName, enabled }) =>
+      new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open(dbName);
+        req.onerror = () => reject(req.error ?? new Error('open failed'));
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction('preferences', 'readwrite');
+          const store = tx.objectStore('preferences');
+          const g = store.index('key').get('settings');
+          g.onsuccess = () => {
+            const rec = g.result;
+            if (!rec) {
+              reject(new Error('settings record missing'));
+              return;
+            }
+            let parsed: Record<string, any> = {};
+            try {
+              parsed = typeof rec.value === 'string' ? JSON.parse(rec.value) : rec.value || {};
+            } catch {
+              parsed = {};
+            }
+            parsed.security_settings = parsed.security_settings || {};
+            parsed.security_settings.autoLock = parsed.security_settings.autoLock || {};
+            parsed.security_settings.autoLock.screenLockEnabled = enabled;
+            rec.value = JSON.stringify(parsed);
+            rec.updatedAt = new Date();
+            store.put(rec);
+          };
+          g.onerror = () => reject(g.error ?? new Error('read failed'));
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error ?? new Error('write failed'));
+        };
+      }),
+    { dbName: DB_NAME, enabled },
+  );
+
+  await page.reload();
+}
+
+/**
  * An encrypted wallet starts locked, so the app shows its lock screen until the password is
  * entered. Unlocking marks the session active, and that flag is inherited by popups opened from
  * this window, so it only has to be done once.
@@ -120,6 +201,9 @@ export const test = base.extend<{ walletPage: Page }>({
 
     await acceptTerms(page);
     await seedWallet(page);
+    // These specs exercise the wallet behind the password wall, so opt into it explicitly (the
+    // app default is now no wall). unlockWallet then drives the wall as before.
+    await setScreenLock(page, true);
     await unlockWallet(page);
     await use(page);
   },

--- a/e2e/optional-lock.spec.ts
+++ b/e2e/optional-lock.spec.ts
@@ -1,0 +1,56 @@
+import {
+  test,
+  expect,
+  acceptTerms,
+  seedWallet,
+  setScreenLock,
+  WALLET_ADDRESS,
+  WALLET_PASSWORD,
+} from './fixtures';
+
+/**
+ * The optional lock screen (docs/proposals/optional-lock-screen.md). Two modes:
+ *  - default (screen lock off): the wallet loads read-only with no password wall;
+ *  - screen lock on: the full password wall shows on start and unlock reveals the wallet.
+ * Both seed a wallet directly; the difference is the `screenLockEnabled` setting.
+ */
+
+test.describe('optional lock screen', () => {
+  test('screen lock OFF: wallet loads read-only without a password', async ({ page }) => {
+    await page.routeWebSocket(/.*/, (ws) => ws.close());
+    await acceptTerms(page);
+    await seedWallet(page);
+    await setScreenLock(page, false); // no wall
+
+    // No password wall.
+    await expect(page.getByRole('button', { name: 'Unlock Wallet' })).toHaveCount(0);
+    await expect(page.getByText('Wallet Locked')).toHaveCount(0);
+
+    // Read-only content is visible without authenticating: the address is shown, and the balance
+    // reads "unavailable" (the socket is blocked) rather than a misleading zero. The responsive
+    // layout renders a mobile and a desktop copy; assert on the visible one.
+    await expect(
+      page.getByText(WALLET_ADDRESS).filter({ visible: true }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId('balance-unavailable').filter({ visible: true })).toBeVisible();
+  });
+
+  test('screen lock ON: the wall shows on start and unlock reveals the wallet', async ({ page }) => {
+    await page.routeWebSocket(/.*/, (ws) => ws.close());
+    await acceptTerms(page);
+    await seedWallet(page);
+    await setScreenLock(page, true); // wall on
+
+    const unlockButton = page.getByRole('button', { name: 'Unlock Wallet' });
+    await expect(unlockButton).toBeVisible({ timeout: 30_000 });
+
+    await page.getByPlaceholder('Enter your wallet password').fill(WALLET_PASSWORD);
+    await unlockButton.click();
+
+    // The wall goes away and the wallet is revealed.
+    await expect(page.getByText('Wallet Locked')).toBeHidden({ timeout: 60_000 });
+    await expect(
+      page.getByText(WALLET_ADDRESS).filter({ visible: true }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/src/components/SecurityLockScreen.tsx
+++ b/src/components/SecurityLockScreen.tsx
@@ -20,7 +20,7 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 interface SecurityLockScreenProps {
-  onUnlock: () => void;
+  onUnlock: (password?: string) => void;
   lockReason?: 'timeout' | 'manual' | 'failed_auth';
 }
 
@@ -223,7 +223,7 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
     try {
       const success = await securityService.unlockWallet(password, false);
       if (success) {
-        handleUnlockSuccess('Welcome back!');
+        handleUnlockSuccess('Welcome back!', password);
       } else {
         setError('Invalid password');
         // Check lockout status after failed attempt
@@ -245,11 +245,13 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
     }
   };
 
-  const handleUnlockSuccess = (message: string) => {
+  const handleUnlockSuccess = (message: string, password?: string) => {
     toast.success('Wallet unlocked', {
       description: message,
     });
-    onUnlock();
+    // Hand the password back so the key is available for silent re-auth this session (password
+    // unlocks only; biometric/no-password unlocks pass nothing and re-prompt on demand).
+    onUnlock(password);
   };
 
   const handleBiometricUnlock = async () => {

--- a/src/components/SecuritySettingsPanel.tsx
+++ b/src/components/SecuritySettingsPanel.tsx
@@ -372,6 +372,27 @@ export default function SecuritySettingsPanel({
               <Separator />
 
               <div className="space-y-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <Label htmlFor="screen-lock-enabled">Require password to open the wallet</Label>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      When off, the wallet opens read-only (balance, address, history) and only asks
+                      for your password to send, export, or sign.
+                    </p>
+                  </div>
+                  <Switch
+                    id="screen-lock-enabled"
+                    checked={settings.autoLock.screenLockEnabled === true}
+                    onCheckedChange={(checked) =>
+                      handleSettingsUpdate({
+                        autoLock: { ...settings.autoLock, screenLockEnabled: checked },
+                      })
+                    }
+                  />
+                </div>
+
+                <Separator />
+
                 <div className="flex items-center justify-between">
                   <Label htmlFor="auto-lock-enabled" className="flex-1">
                     Enable auto-lock

--- a/src/contexts/SecurityContext.tsx
+++ b/src/contexts/SecurityContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useRef,
   ReactNode,
   useCallback,
 } from 'react';
@@ -17,6 +18,16 @@ import Image from 'next/image';
 import GradientBackground from '@/components/GradientBackground';
 
 interface SecurityContextType {
+  /** The opt-in full-screen password wall is showing. */
+  screenLocked: boolean;
+  /** The wallet password is held in memory for silent re-auth this session. */
+  keyUnlocked: boolean;
+  /** Whether the screen-lock wall is enabled (opt-in; from settings). */
+  screenLockEnabled: boolean;
+  /**
+   * @deprecated Use `screenLocked` (the UI wall) or `keyUnlocked` (credential availability).
+   * Kept as an alias of `screenLocked` for existing consumers (the lock button).
+   */
   isLocked: boolean;
   lockWallet: () => Promise<void>;
   unlockWallet: (password?: string, useBiometric?: boolean) => Promise<boolean>;
@@ -47,7 +58,10 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
   }
 
   const [isInitializing, setIsInitializing] = useState(true); // Add initializing state
-  const [isLocked, setIsLocked] = useState(false);
+  // The opt-in full-screen wall (was `isLocked`). Split from credential availability so the wallet
+  // can load read-only without a password by default; see docs/proposals/optional-lock-screen.md.
+  const [screenLocked, setScreenLocked] = useState(false);
+  const [screenLockEnabled, setScreenLockEnabled] = useState(false);
   const [lockReason, setLockReason] = useState<'timeout' | 'manual' | 'failed_auth'>('manual');
   const [wasBiometricAuth, setWasBiometricAuth] = useState(false);
   const [storedWalletPassword, setStoredWalletPassword] = useState<string | undefined>();
@@ -60,34 +74,51 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
     ((value: { success: boolean; password?: string }) => void) | null
   >(null);
 
+  // Credential availability: the password is in memory, so requireAuth can silently re-auth.
+  const keyUnlocked = storedWalletPassword !== undefined;
+
+  // Read in event callbacks that outlive the render they were created in.
+  const screenLockEnabledRef = useRef(false);
+  const screenLockedRef = useRef(false);
   useEffect(() => {
-    // Initialize security service and check if wallet should be locked
+    screenLockEnabledRef.current = screenLockEnabled;
+  }, [screenLockEnabled]);
+  useEffect(() => {
+    screenLockedRef.current = screenLocked;
+  }, [screenLocked]);
+
+  useEffect(() => {
+    // Initialize security service and check if the wall should be shown
     const initSecurity = async () => {
       try {
         // Check terms acceptance FIRST - security requires terms acceptance
         const termsAccepted = localStorage.getItem('terms-accepted');
 
         if (!termsAccepted) {
-          // Terms not accepted, stay unlocked regardless of wallet state
-          setIsLocked(false);
+          // Terms not accepted, no wall regardless of wallet state
+          setScreenLocked(false);
           setIsInitializing(false);
           return;
         }
 
-        // Terms accepted, proceed with normal security checks
+        // Whether the opt-in wall is enabled for this install.
+        const settings = await securityService.getSecuritySettings();
+        const wallEnabled = settings.autoLock?.screenLockEnabled === true;
+        setScreenLockEnabled(wallEnabled);
+        screenLockEnabledRef.current = wallEnabled;
+
         const activeWallet = await StorageService.getActiveWallet();
 
-        // Check if there's an active wallet
-        if (activeWallet) {
-          const isCurrentlyLocked = await securityService.isLocked();
-          setIsLocked(isCurrentlyLocked);
+        // Only ever raise the wall on start when the user opted in AND a wallet exists. Otherwise
+        // the wallet loads read-only and sensitive actions prompt on demand.
+        if (activeWallet && wallEnabled) {
+          setScreenLocked(await securityService.isLocked());
         } else {
-          // If no active wallet, ensure we're unlocked
-          setIsLocked(false);
+          setScreenLocked(false);
         }
       } catch (error) {
-        // Default to unlocked state if there's an error
-        setIsLocked(false);
+        // Default to no wall if there's an error
+        setScreenLocked(false);
       } finally {
         // Mark initialization as complete
         setIsInitializing(false);
@@ -126,12 +157,22 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
     window.addEventListener('focus', handleFocus);
     window.addEventListener('terms-accepted', handleTermsAccepted as EventListener);
 
-    // Listen for lock state changes
+    // Listen for lock state changes from the service (auto-lock timeout, failed-auth, manual).
+    // The wall is only raised for a timeout/failed-auth lock when the user enabled it; a manual
+    // lock always raises it (the user explicitly asked to lock).
     const unsubscribe = securityService.onLockStateChange(
       (locked: boolean, reason?: 'timeout' | 'manual' | 'failed_auth') => {
-        setIsLocked(locked);
+        const raiseWall =
+          locked && (reason === 'manual' || screenLockEnabledRef.current);
+        setScreenLocked(raiseWall);
         if (reason) {
           setLockReason(reason);
+        }
+        // A lock (from any source) forgets the in-memory password, so the next sensitive action
+        // must re-authenticate — this is the credential half of "locking".
+        if (locked) {
+          setStoredWalletPassword(undefined);
+          setWasBiometricAuth(false);
         }
       },
     );
@@ -147,8 +188,8 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
     ];
 
     const handleUserActivity = () => {
-      // Only reset auto-lock if wallet is unlocked
-      if (!isLocked) {
+      // Only reset auto-lock while the wall is not showing
+      if (!screenLockedRef.current) {
         securityService.resetAutoLock();
       }
     };
@@ -168,12 +209,17 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
         window.removeEventListener(eventType, handleUserActivity);
       });
     };
-  }, [isLocked]);
+    // Intentionally run once: the callbacks read the live values through refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const lockWallet = async () => {
-    await securityService.lockWallet();
-    setIsLocked(true);
+    // A manual lock raises the wall and forgets the session password.
+    await securityService.lockWallet('manual');
+    setScreenLocked(true);
     setLockReason('manual');
+    setWasBiometricAuth(false);
+    setStoredWalletPassword(undefined);
   };
 
   const unlockWallet = async (password?: string, useBiometric?: boolean) => {
@@ -185,7 +231,7 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
         if (biometricResult.success) {
           setWasBiometricAuth(true);
           setStoredWalletPassword(biometricResult.walletPassword);
-          setIsLocked(false);
+          setScreenLocked(false);
           return true;
         }
         return false;
@@ -194,7 +240,7 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
     } else {
       const success = await securityService.unlockWallet(password, false);
       if (success) {
-        setIsLocked(false);
+        setScreenLocked(false);
         setWasBiometricAuth(false);
         // Store the password if provided
         if (password) {
@@ -232,12 +278,12 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
     message?: string,
     autoLogin: boolean = false,
   ): Promise<{ success: boolean; password?: string }> => {
-    if (isLocked) {
-      return { success: false };
-    }
-
+    // NOTE: this intentionally no longer early-returns on the UI wall. Authentication is gated on
+    // whether the KEY is available, not on whether the wall is showing — so it works in both the
+    // load-then-authenticate (no wall) and screen-lock (wall) modes. It must still FAIL CLOSED:
+    // the only path that succeeds without prompting requires a password already in memory.
     try {
-      // If password is already stored from previous authentication
+      // If password is already stored from a previous authentication this session
       if (storedWalletPassword && autoLogin) {
         return {
           success: true,
@@ -287,14 +333,21 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
 
   const manualLock = async () => {
     await securityService.lockWallet('manual');
-    setIsLocked(true);
+    setScreenLocked(true);
     setLockReason('manual');
     setWasBiometricAuth(false);
     setStoredWalletPassword(undefined);
   };
 
-  const handleUnlock = () => {
-    setIsLocked(false);
+  // Called by the lock screen when the user unlocks it. A password unlock hands the password back
+  // so the key is available for the rest of the session; a biometric unlock does not (the next
+  // sensitive action re-runs the quick biometric prompt).
+  const handleUnlock = (password?: string) => {
+    setScreenLocked(false);
+    if (password) {
+      setStoredWalletPassword(password);
+      setWasBiometricAuth(false);
+    }
   };
 
   // Show nothing while initializing to prevent flicker
@@ -313,14 +366,13 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
     );
   }
 
-  if (isLocked) {
-    return <SecurityLockScreen onUnlock={handleUnlock} lockReason={lockReason} />;
-  }
-
   return (
     <SecurityContext.Provider
       value={{
-        isLocked,
+        screenLocked,
+        keyUnlocked,
+        screenLockEnabled,
+        isLocked: screenLocked,
         lockWallet,
         unlockWallet,
         requireAuth,
@@ -329,7 +381,14 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
         storedWalletPassword,
       }}
     >
-      {children}
+      {/* The provider is always mounted (so requireAuth works and the default no-wall mode loads
+          the wallet read-only). When the opt-in wall is up we render it in place of the wallet
+          subtree — there is no read-only view to show behind a full-screen wall anyway. */}
+      {screenLocked ? (
+        <SecurityLockScreen onUnlock={handleUnlock} lockReason={lockReason} />
+      ) : (
+        children
+      )}
       <AuthenticationDialog
         isOpen={showAuthDialog}
         onClose={handleAuthCancel}

--- a/src/services/core/SecurityService.ts
+++ b/src/services/core/SecurityService.ts
@@ -995,15 +995,24 @@ export class SecurityService {
     try {
       const allSettings = await StorageService.getSettings();
       const settings = allSettings?.security_settings;
-      if (settings) return settings;
+      if (settings) {
+        // Migrate pre-existing installs that predate the screen-lock toggle: they have been
+        // living with the full password wall, so keep it on rather than silently dropping it.
+        if (settings.autoLock && settings.autoLock.screenLockEnabled === undefined) {
+          settings.autoLock.screenLockEnabled = true;
+          await this.updateSecuritySettings(settings);
+        }
+        return settings;
+      }
 
-      // Default settings
+      // Default settings — new installs load read-only with no wall (screenLockEnabled: false).
       const defaultSettings: SecuritySettings = {
         autoLock: {
           enabled: true,
           timeout: 300000, // 5 minutes
           biometricUnlock: false,
           requirePasswordAfterTimeout: true,
+          screenLockEnabled: false,
         },
         biometric: {
           enabled: false,
@@ -1027,6 +1036,7 @@ export class SecurityService {
           timeout: 300000,
           biometricUnlock: false,
           requirePasswordAfterTimeout: true,
+          screenLockEnabled: false,
         },
         biometric: {
           enabled: false,
@@ -1050,6 +1060,7 @@ export class SecurityService {
           timeout: 300000, // 5 minutes
           biometricUnlock: false,
           requirePasswordAfterTimeout: true,
+          screenLockEnabled: false,
         },
         biometric: {
           enabled: false,

--- a/src/types/security.ts
+++ b/src/types/security.ts
@@ -54,6 +54,10 @@ export interface AutoLockSettings {
   timeout: number; // in milliseconds
   biometricUnlock: boolean;
   requirePasswordAfterTimeout: boolean;
+  // Opt-in full-screen password wall shown when opening the wallet. Default false (the wallet
+  // loads read-only and only key-using actions prompt). `undefined` in stored settings means a
+  // pre-existing install that predates this toggle — migrated to `true` to preserve its wall.
+  screenLockEnabled?: boolean;
 }
 
 export interface SecuritySettings {


### PR DESCRIPTION
Implements `docs/proposals/optional-lock-screen.md`. Splits the single `isLocked` flag — which conflated the **UI wall** with **credential availability** — into two independent ideas:

- **`screenLocked`** — the opt-in full-screen password wall
- **`keyUnlocked`** — the password is held in memory for silent re-auth

### Behaviour
- **Default (wall off):** the wallet loads **read-only** (balance, address, history — all public, address-keyed data) with no password wall; only key-using actions (send, export, sign, connect-approval) prompt via `requireAuth`.
- **Wall on (opt-in, or existing installs on migration):** the full password wall shows on start, exactly as before.
- One settings toggle: **"Require password to open the wallet."** New installs default off; **existing installs migrate to on** so nobody is silently dropped to no-wall.

### Safety (this is security-critical, so spelled out)
- **No change to key encryption at rest.** Keys/mnemonics stay encrypted (scrypt + AES-GCM); only the password sits in memory after the first authenticated action, exactly as today.
- **Every signature still requires `requireAuth`.** It no longer early-returns on the wall — it gates on key availability — and it still **fails closed**: the only path that succeeds without prompting requires a password *already in memory*. Verified: the connect signing E2E (which authenticates on every sign) passes unchanged.
- A lock (from any source) **forgets the in-memory password**.

### Implementation note
Rather than a sibling-overlay over always-mounted children, the wall renders **in place of** the wallet subtree while the provider stays mounted — identical UX, `requireAuth` works in both modes, and it sidesteps a z-index/stacking fight. Open questions 1 (standalone session-key timeout) and 2 (biometric-only) remain follow-ups.

### Files
`SecurityContext` (state split + provider), `SecurityService` (setting + migration), `SecurityLockScreen` (hands password back on unlock), `SecuritySettingsPanel` (toggle), `types/security` (field), E2E fixture (seeds the setting; the 27 existing specs opt into the wall and are unchanged) + new `optional-lock.spec` covering both modes.

### Verification
typecheck ✓ · **542/542 unit ✓** · static build ✓ · **30/30 E2E ✓** (28 + 2 new)