### PR TITLE
fix(security): manual lock survives a refresh with the open-time wall off

### DIFF
--- a/e2e/optional-lock.spec.ts
+++ b/e2e/optional-lock.spec.ts
@@ -53,4 +53,38 @@ test.describe('optional lock screen', () => {
       page.getByText(WALLET_ADDRESS).filter({ visible: true }).first(),
     ).toBeVisible({ timeout: 30_000 });
   });
+
+  test('manual lock survives a refresh even when the open-time wall is off', async ({ page }) => {
+    await page.routeWebSocket(/.*/, (ws) => ws.close());
+    await acceptTerms(page);
+    await seedWallet(page);
+    await setScreenLock(page, false); // no open-time wall
+
+    // The dashboard loads read-only (no wall). Lock manually via the nav button.
+    const lockButton = page.getByRole('button', { name: 'Lock wallet' });
+    await expect(lockButton).toBeVisible({ timeout: 30_000 });
+    await lockButton.click();
+
+    // The wall appears.
+    await expect(page.getByRole('button', { name: 'Unlock', exact: true })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // A refresh keeps the wall up — the manual lock is remembered for the session.
+    await page.reload();
+    await expect(page.getByRole('button', { name: 'Unlock', exact: true })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Unlocking clears the remembered lock; the wall goes and does not return on the next refresh.
+    await page.getByPlaceholder('Password').fill(WALLET_PASSWORD);
+    await page.getByRole('button', { name: 'Unlock', exact: true }).click();
+    await expect(page.getByText('Wallet locked')).toBeHidden({ timeout: 60_000 });
+
+    await page.reload();
+    await expect(
+      page.getByText(WALLET_ADDRESS).filter({ visible: true }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText('Wallet locked')).toHaveCount(0);
+  });
 });

--- a/src/contexts/SecurityContext.tsx
+++ b/src/contexts/SecurityContext.tsx
@@ -42,6 +42,34 @@ interface SecurityContextType {
 
 const SecurityContext = createContext<SecurityContextType | undefined>(undefined);
 
+// A manual "lock now" is remembered here so it survives a page refresh even when the opt-in
+// open-time wall is disabled. sessionStorage (not localStorage) is deliberate: the lock holds
+// across reloads of the same tab, but closing the tab clears it — reopening then honours the
+// user's open-time setting (no wall if they turned it off).
+const MANUAL_LOCK_KEY = 'avian-manual-lock';
+
+function setManualLockFlag(on: boolean) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (on) {
+      sessionStorage.setItem(MANUAL_LOCK_KEY, '1');
+    } else {
+      sessionStorage.removeItem(MANUAL_LOCK_KEY);
+    }
+  } catch {
+    // sessionStorage can throw in locked-down privacy modes; a non-durable lock is acceptable then.
+  }
+}
+
+function isManuallyLocked(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return sessionStorage.getItem(MANUAL_LOCK_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
 interface SecurityProviderProps {
   children: ReactNode;
 }
@@ -109,10 +137,16 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
 
         const activeWallet = await StorageService.getActiveWallet();
 
-        // Only ever raise the wall on start when the user opted in AND a wallet exists. Otherwise
+        // Raise the wall on start when a wallet exists AND either the user opted into the open-time
+        // wall, or they manually locked earlier this session (which persists across refresh). A
+        // manual lock always wins; otherwise fall back to the service's locked state. With neither,
         // the wallet loads read-only and sensitive actions prompt on demand.
-        if (activeWallet && wallEnabled) {
-          setScreenLocked(await securityService.isLocked());
+        const manuallyLocked = isManuallyLocked();
+        if (activeWallet && (wallEnabled || manuallyLocked)) {
+          setScreenLocked(manuallyLocked || (await securityService.isLocked()));
+          if (manuallyLocked) {
+            setLockReason('manual');
+          }
         } else {
           setScreenLocked(false);
         }
@@ -214,7 +248,9 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
   }, []);
 
   const lockWallet = async () => {
-    // A manual lock raises the wall and forgets the session password.
+    // A manual lock raises the wall and forgets the session password. Remember it so a refresh
+    // keeps the wall up even when the open-time wall is disabled.
+    setManualLockFlag(true);
     await securityService.lockWallet('manual');
     setScreenLocked(true);
     setLockReason('manual');
@@ -229,6 +265,7 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
       if (biometricAvailable) {
         const biometricResult = await securityService.authenticateWithBiometric();
         if (biometricResult.success) {
+          setManualLockFlag(false);
           setWasBiometricAuth(true);
           setStoredWalletPassword(biometricResult.walletPassword);
           setScreenLocked(false);
@@ -240,6 +277,7 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
     } else {
       const success = await securityService.unlockWallet(password, false);
       if (success) {
+        setManualLockFlag(false);
         setScreenLocked(false);
         setWasBiometricAuth(false);
         // Store the password if provided
@@ -332,6 +370,7 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
   };
 
   const manualLock = async () => {
+    setManualLockFlag(true);
     await securityService.lockWallet('manual');
     setScreenLocked(true);
     setLockReason('manual');
@@ -343,6 +382,8 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
   // so the key is available for the rest of the session; a biometric unlock does not (the next
   // sensitive action re-runs the quick biometric prompt).
   const handleUnlock = (password?: string) => {
+    // A successful unlock clears any remembered manual lock, so a later refresh does not re-lock.
+    setManualLockFlag(false);
     setScreenLocked(false);
     if (password) {
       setStoredWalletPassword(password);


### PR DESCRIPTION
Follow-up to the optional lock screen (#24). With **Require password to open the wallet** turned off, the nav **Lock** button raised the wall only in memory — a refresh dropped you straight back to the dashboard, so the lock didn't really hold.

### Fix
Treat the open-time setting and the manual Lock button as independent:
- A manual lock is remembered in `sessionStorage`, so it **survives a refresh** of the same tab.
- `initSecurity` raises the wall whenever that flag is set, regardless of the open-time setting; a manual lock always wins, otherwise it falls back to the service's locked state.
- Closing the tab clears the flag — reopening still honours the open-time preference (no wall if you disabled it).
- A successful unlock (password **or** biometric) clears the flag.

This keeps the Lock button meaningful without forcing a wall on every open.

### Tests
- New E2E: manual lock persists across a refresh and clears on unlock.
- ✅ typecheck · ✅ build (static export) · ✅ 32 E2E