### PR TITLE
feat(ui): landing page is the public entry — terms gate moves to wallet creation

### DIFF
--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -23,3 +23,25 @@ test('a visitor with no wallet sees the landing page and can start onboarding', 
   await create.click();
   await expect(page).toHaveURL(/\/onboarding/);
 });
+
+/**
+ * The landing page is the public entry point: a brand-new visitor who has not accepted the license
+ * still lands here, not on the terms wall. The license is instead accepted when they choose to
+ * create a wallet — onboarding routes them through /terms and back.
+ */
+test('a visitor who has not accepted terms still sees the landing, and Create routes via /terms', async ({
+  page,
+}) => {
+  await page.routeWebSocket(/.*/, (ws) => ws.close());
+  // Deliberately seed no terms-accepted flag.
+
+  await page.goto('/');
+
+  // The landing hero shows without a license wall in front of it.
+  await expect(page.getByRole('heading', { name: /Your funds/i })).toBeVisible({ timeout: 30_000 });
+
+  // Starting onboarding now passes through the license gate first.
+  await page.getByRole('button', { name: /Create a wallet/i }).click();
+  await expect(page).toHaveURL(/\/terms/);
+  await expect(page.getByText('License Agreement').first()).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -35,16 +35,24 @@ export default function OnboardingPage() {
     const [showBackupPassword, setShowBackupPassword] = useState(false);
     const [needsPassword, setNeedsPassword] = useState(false);
 
-    // Check if wallet exists and redirect if so
+    // Gate access: terms must be accepted before a wallet can be created, and an existing wallet
+    // means onboarding is already done.
     useEffect(() => {
-        const checkWallet = async () => {
+        const checkAccess = async () => {
+            // Accepting the license is a precondition for creating or importing a wallet. Send the
+            // user to /terms and bring them straight back here once they accept.
+            if (typeof window !== 'undefined' && !localStorage.getItem('terms-accepted')) {
+                router.push('/terms?next=/onboarding');
+                return;
+            }
+
             const walletExists = await StorageService.hasWallet();
             if (walletExists) {
                 router.push('/');
             }
         };
 
-        checkWallet();
+        checkAccess();
     }, [router]);
 
     // Handle wallet creation/import form submission

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,23 +55,21 @@ export default function Home() {
 
     const fullRefreshRequestedRef = useRef(false);
 
-    // Check for terms acceptance on initial load
+    // Read terms acceptance on initial load. We do NOT bounce a brand-new visitor to /terms here:
+    // the landing page is the public entry point, and terms are accepted when they choose to create
+    // or import a wallet (the /onboarding route enforces it). A returning user who has a wallet but
+    // no recorded acceptance is still sent to /terms below, before the dashboard renders.
     useEffect(() => {
         if (typeof window !== 'undefined') {
-            const termsAcceptedValue = localStorage.getItem('terms-accepted');
-            if (!termsAcceptedValue) {
-                router.push('/terms');
-                return;
-            }
-            setTermsAccepted(true);
+            setTermsAccepted(!!localStorage.getItem('terms-accepted'));
         }
-    }, [router]);
+    }, []);
 
     // Decide whether to show the wallet dashboard or, for a first-time visitor with no wallet on
-    // the device, the landing page. Only runs after terms are accepted.
+    // the device, the landing page. Runs once the terms state is known.
     useEffect(() => {
         const checkWalletExists = async () => {
-            if (!termsAccepted || typeof window === 'undefined') return;
+            if (termsAccepted === null || typeof window === 'undefined') return;
 
             // A loaded address means we already have a wallet — go straight to the dashboard.
             if (address) {
@@ -97,6 +95,14 @@ export default function Home() {
 
         checkWalletExists();
     }, [termsAccepted, address, isLoading]);
+
+    // A returning user who already has a wallet but no recorded terms acceptance must accept before
+    // the dashboard renders. (New visitors with no wallet see the landing page instead.)
+    useEffect(() => {
+        if (walletExists === true && termsAccepted === false) {
+            router.push('/terms');
+        }
+    }, [walletExists, termsAccepted, router]);
 
     const formatBalance = (balance: number) => {
         const avnBalance = (balance / 100000000).toFixed(8); // Convert satoshis to AVN
@@ -194,6 +200,19 @@ export default function Home() {
     // (empty) dashboard. Returning users with a wallet fall through to the dashboard below.
     if (walletExists === false) {
         return <LandingPage />;
+    }
+
+    // Wallet exists but terms were never accepted — hold on the loader while the effect above
+    // redirects to /terms, rather than flashing the dashboard.
+    if (termsAccepted === false) {
+        return (
+            <div className="min-h-screen bg-background flex items-center justify-center">
+                <div className="flex items-center space-x-2">
+                    <Loader className="h-6 w-6 animate-spin text-avian-600" />
+                    <span className="text-muted-foreground">Loading...</span>
+                </div>
+            </div>
+        );
     }
 
     return (

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -38,6 +38,12 @@ export default function TermsPage() {
     // Reference to scroll content to check initial scroll position
     const scrollContentRef = useRef<HTMLDivElement>(null);
 
+    // Where to go after acceptance. Only same-origin absolute paths are honoured (guard against an
+    // open redirect via a crafted ?next=); anything else falls back to the main app.
+    const nextParam = searchParams.get('next');
+    const nextPath =
+        nextParam && nextParam.startsWith('/') && !nextParam.startsWith('//') ? nextParam : '/';
+
     // Check if terms are already accepted and redirect to main page (unless viewing)
     useEffect(() => {
         if (typeof window !== 'undefined') {
@@ -53,13 +59,13 @@ export default function TermsPage() {
             }
 
             if (termsAccepted && !isViewMode) {
-                router.push('/');
+                router.push(nextPath);
                 return;
             }
             // Terms not accepted or in view mode, show the page
             setIsCheckingTerms(false);
         }
-    }, [router, searchParams]);
+    }, [router, searchParams, nextPath]);
 
     // Check initial scroll position when content loads
     useEffect(() => {
@@ -124,8 +130,8 @@ export default function TermsPage() {
             // Dispatch custom event to notify SecurityContext
             window.dispatchEvent(new CustomEvent('terms-accepted', { detail: { accepted: true } }));
 
-            // Navigate to main app
-            router.push('/');
+            // Navigate onward — back to whatever sent us here (e.g. /onboarding), else the main app.
+            router.push(nextPath);
         } else if (acceptanceChoice === 'decline') {
             // Show the AlertDialog for declining terms
             setShowDeclineDialog(true);


### PR DESCRIPTION
Follow-up to the landing page (#25). Right now a brand-new visitor is bounced straight to the license wall, so the landing page never gets to be the first impression. This makes the landing the public entry point and moves license acceptance to the moment they create a wallet.

### What changed
- **page.tsx**: read terms without redirecting; show the landing for a no-wallet visitor regardless of terms. A returning user who has a wallet but no recorded acceptance is still sent to `/terms` before the dashboard renders.
- **onboarding**: gate on terms acceptance — routes to `/terms?next=/onboarding` and back.
- **terms**: honor a same-origin `?next=` redirect target after acceptance (guarded against open redirects).
- **Version bump 2.3.0 → 2.4.0** (shown on the About page) — covers the whole UI-refresh sweep.

### Flow
`/` → landing (no wall) → **Create a wallet** → `/terms` → accept → `/onboarding` → wallet.

### Tests
- New E2E: a visitor without accepted terms still sees the landing, and Create routes via `/terms`.
- ✅ typecheck · ✅ build (static export) · ✅ 32 E2E