### PR TITLE
fix(ui): address book modal — reach the edit form's Save/Cancel buttons

### DIFF
--- a/src/components/AddressBook.tsx
+++ b/src/components/AddressBook.tsx
@@ -241,7 +241,10 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
   });
 
   return (
-    <div className="space-y-4 mx-2 my-2 flex flex-col min-h-0">
+    // Content flows naturally and the single outer ScrollArea (in AddressBookDrawer) owns scrolling.
+    // Avoid a second, bounded scroll region here: a tall Edit/Add form used to overflow a fixed-
+    // height flex column and clip its Save/Cancel buttons with no way to reach them.
+    <div className="space-y-4 mx-2 my-2">
       {/* Header */}
       <div className="flex items-center justify-between flex-shrink-0">
         <h3 className="text-sm font-medium text-foreground dark:text-white">
@@ -740,10 +743,10 @@ export default function AddressBook({ onSelectAddress, currentAddress }: Address
         </div>
       )}
 
-      {/* Address List */}
-      <div
-        className={`space-y-2 ${isAddingNew || editingId ? 'max-h-64 overflow-y-auto' : 'flex-1 overflow-y-auto'} min-h-0 border-t border-avian-100 dark:border-avian-800 pt-2`}
-      >
+      {/* Address List — no inner scroll; the outer ScrollArea scrolls the whole panel so an open
+          Edit/Add form and its action buttons always stay reachable. */}
+      <div className="space-y-2 border-t border-avian-100 dark:border-avian-800 pt-2">
+
         {filteredAddresses.length === 0 ? (
           searchQuery ? (
             <EmptyState


### PR DESCRIPTION
The **Edit Address** form in the address book modal clipped its Save Changes / Cancel buttons off the bottom with no way to scroll to them.

### Cause
`AddressBookDrawer` wraps `AddressBook` in a `ScrollArea`, but `AddressBook` also made itself a bounded flex column (`flex flex-col min-h-0`) with the list scrolling internally and the Edit/Add forms pinned `flex-shrink-0`. The two scroll systems fought: a tall form overflowed the column, and the outer ScrollArea couldn't scroll it, so the action buttons were unreachable.

### Fix
Let the single outer ScrollArea own scrolling — drop the inner flex-height and the list's internal scroll so the whole panel scrolls and an open form's buttons stay reachable.

### Verification
- ✅ typecheck · ✅ build (static export)
- No E2E covers this modal — **please visually confirm** the Edit form now scrolls to Save/Cancel on a short window (both the desktop dialog and the mobile drawer).