### PR TITLE
feat(ui): flight-deck onboarding — instrument reskin

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -21,8 +21,7 @@ test.describe('onboarding — guided create wallet', () => {
 
     await page.goto('/onboarding');
 
-    // Welcome → method selection → Create.
-    await page.getByRole('button', { name: 'Get Started' }).click();
+    // Onboarding opens on method selection → Create.
     await page.getByText('Create New Wallet').click();
 
     // Step 1 — details.
@@ -56,7 +55,7 @@ test.describe('onboarding — guided create wallet', () => {
     await page.getByRole('button', { name: /Create wallet/ }).click();
 
     // Creation runs scrypt, so allow time; success proves the wallet was written.
-    await expect(page.getByText('Setup Complete!')).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByText('Wallet armed')).toBeVisible({ timeout: 60_000 });
   });
 
   test('a wrong confirmation is rejected and cannot proceed', async ({ page }) => {
@@ -67,7 +66,6 @@ test.describe('onboarding — guided create wallet', () => {
     });
 
     await page.goto('/onboarding');
-    await page.getByRole('button', { name: 'Get Started' }).click();
     await page.getByText('Create New Wallet').click();
     await page.getByLabel('Wallet name').fill('Careless Wallet');
     await page.getByRole('button', { name: 'Continue' }).click();

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -3,30 +3,40 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useWallet } from '@/contexts/WalletContext';
-import { Wallet, Import, FileKey, ArrowLeft, Upload, QrCode, AlertTriangle, ArrowRight, Eye, EyeOff, ScrollText } from 'lucide-react';
+import { ArrowLeft, Upload, QrCode, Eye, EyeOff } from 'lucide-react';
 import { StorageService } from '@/services/core/StorageService';
 import WalletCreationForm, {
     WalletCreationMode,
     WalletCreationData,
 } from '@/components/WalletCreationForm';
 import OnboardingCreateWallet from '@/components/OnboardingCreateWallet';
-import { useMediaQuery } from '@/hooks/use-media-query';
 import { BackupService } from '@/services/core/BackupService';
 import { BackupQRModal } from '@/components/BackupQRModal';
+import { ONBOARDING_CSS } from '@/components/onboarding/instrument';
 
-// Import Shadcn UI components
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { toast } from 'sonner';
+
+/** Instrument-styled brand mark used across the onboarding shell (matches the landing page glyph). */
+function BrandMark() {
+    return (
+        <svg className="ob-brand__mark" viewBox="0 0 32 32" aria-hidden>
+            <path
+                d="M16 3 L28 26 L16 20 L4 26 Z"
+                fill="none"
+                stroke="#34F5C6"
+                strokeWidth="1.8"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
 
 export default function OnboardingPage() {
     const router = useRouter();
     const { reloadActiveWallet } = useWallet();
-    const isMobile = useMediaQuery('(max-width: 768px)');
-    const [step, setStep] = useState<'welcome' | 'method' | 'form' | 'backup-file' | 'success'>('welcome');
+    const [step, setStep] = useState<'method' | 'form' | 'backup-file' | 'success'>('method');
     const [formMode, setFormMode] = useState<WalletCreationMode>('create');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [showBackupQRModal, setShowBackupQRModal] = useState(false);
@@ -193,243 +203,157 @@ export default function OnboardingPage() {
         }, 2000);
     };
 
-    const renderWelcome = () => (
-        <Card className="max-w-md mx-auto">
-            <CardHeader className="text-center">
-                <div className="flex justify-center mb-4">
-                    <div className="w-20 h-20 bg-primary/10 rounded-full flex items-center justify-center">
-                        <Wallet className="w-10 h-10 text-primary" />
-                    </div>
-                </div>
-                <CardTitle className="text-2xl">Welcome to Avian Wallet</CardTitle>
-                <p className="text-muted-foreground">
-                    Your secure, privacy-focused wallet for Avian Network
+    const pickImport = (mode: WalletCreationMode) => {
+        setFormMode(mode);
+        setStep('form');
+    };
+
+    // ---- screens -----------------------------------------------------------
+    const methodScreen = (
+        <div className="ob-panel ob-solo">
+            <div className="ob-head">
+                <span className="ob-label">Bring a wallet online</span>
+                <h1>Create a new wallet, or bring your own keys</h1>
+                <p>
+                    Everything runs on this device. Start fresh and we&apos;ll generate a recovery
+                    phrase, or import one you already hold.
                 </p>
-            </CardHeader>
-            <CardContent>
-                <Button
-                    onClick={() => setStep('method')}
-                    className="w-full"
-                    size="lg"
+            </div>
+
+            <div className="ob-methods">
+                <button
+                    className="ob-tile ob-tile--go"
+                    onClick={() => {
+                        setFormMode('create');
+                        setStep('form');
+                    }}
                 >
-                    Get Started <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-            </CardContent>
-        </Card>
-    );
-
-    const renderMethodSelection = () => (
-        <div className="max-w-2xl mx-auto space-y-6">
-            <div className="text-center mb-8">
-                <h1 className="text-3xl font-bold mb-2">Choose Setup Method</h1>
-                <p className="text-muted-foreground">
-                    How would you like to set up your wallet?
-                </p>
+                    <span className="ob-tile__ic ob-tile__ic--go">
+                        <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden>
+                            <path d="M12 5 v14 M5 12 h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                        </svg>
+                    </span>
+                    <span className="ob-tile__body">
+                        <b>Create New Wallet</b>
+                        <small>Generate a fresh HD wallet and back up its recovery phrase.</small>
+                    </span>
+                    <span className="ob-tile__go" aria-hidden>→</span>
+                </button>
             </div>
 
-            <div className="grid gap-6 md:grid-cols-2">
-                {/* Create New Wallet */}
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={() => {
-                    setFormMode('create');
-                    setStep('form');
-                }}>
-                    <CardHeader>
-                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
-                            <Wallet className="w-6 h-6 text-primary" />
-                        </div>
-                        <CardTitle className="text-xl">Create New Wallet</CardTitle>
-                        <p className="text-muted-foreground">
-                            Generate a new wallet with a secure mnemonic phrase
-                        </p>
-                    </CardHeader>
-                </Card>
-
-                {/* Import from Mnemonic */}
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={() => {
-                    setFormMode('importMnemonic');
-                    setStep('form');
-                }}>
-                    <CardHeader>
-                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
-                            <FileKey className="w-6 h-6 text-primary" />
-                        </div>
-                        <CardTitle className="text-xl">Import from Mnemonic</CardTitle>
-                        <p className="text-muted-foreground">
-                            Restore your wallet using a 12 or 24-word phrase
-                        </p>
-                    </CardHeader>
-                </Card>
-
-                {/* Import from Private Key */}
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={() => {
-                    setFormMode('importWIF');
-                    setStep('form');
-                }}>
-                    <CardHeader>
-                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
-                            <Import className="w-6 h-6 text-primary" />
-                        </div>
-                        <CardTitle className="text-xl">Import Private Key</CardTitle>
-                        <p className="text-muted-foreground">
-                            Import a wallet using a WIF private key
-                        </p>
-                    </CardHeader>
-                </Card>
-
-                {/* Restore from Backup */}
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={() => setStep('backup-file')}>
-                    <CardHeader>
-                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
-                            <Upload className="w-6 h-6 text-primary" />
-                        </div>
-                        <CardTitle className="text-xl">Restore from Backup</CardTitle>
-                        <p className="text-muted-foreground">
-                            Import wallet from a backup file or QR codes
-                        </p>
-                    </CardHeader>
-                </Card>
-
-                {/* Import from Descriptor */}
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={() => {
-                    setFormMode('importDescriptor');
-                    setStep('form');
-                }}>
-                    <CardHeader>
-                        <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
-                            <ScrollText className="w-6 h-6 text-primary" />
-                        </div>
-                        <CardTitle className="text-xl">Import from Descriptor</CardTitle>
-                        <p className="text-muted-foreground">
-                            Import from an Avian Core v5 output script descriptor
-                        </p>
-                    </CardHeader>
-                </Card>
-            </div>
-
-            <div className="text-center">
-                <Button variant="ghost" onClick={() => setStep('welcome')}>
-                    <ArrowLeft className="w-4 h-4 mr-2" /> Back
-                </Button>
+            <div className="ob-methods__sub">
+                <div className="ob-label" style={{ marginBottom: 12 }}>Import an existing wallet</div>
+                <div className="ob-imports">
+                    <button className="ob-irow" onClick={() => pickImport('importMnemonic')}>
+                        <span className="ob-lamp ob-lamp--turq" />
+                        <span className="ob-irow__t"><b>Recovery phrase</b><small>Restore from a 12 or 24-word phrase</small></span>
+                        <span className="ob-irow__go" aria-hidden>→</span>
+                    </button>
+                    <button className="ob-irow" onClick={() => pickImport('importWIF')}>
+                        <span className="ob-lamp ob-lamp--turq" />
+                        <span className="ob-irow__t"><b>Private key (WIF)</b><small>Import a single-key wallet</small></span>
+                        <span className="ob-irow__go" aria-hidden>→</span>
+                    </button>
+                    <button className="ob-irow" onClick={() => pickImport('importDescriptor')}>
+                        <span className="ob-lamp ob-lamp--indigo" />
+                        <span className="ob-irow__t"><b>Output descriptor</b><small>Avian Core v5 script descriptor</small></span>
+                        <span className="ob-irow__go" aria-hidden>→</span>
+                    </button>
+                    <button className="ob-irow" onClick={() => setStep('backup-file')}>
+                        <span className="ob-lamp ob-lamp--indigo" />
+                        <span className="ob-irow__t"><b>Encrypted backup / QR</b><small>Restore a backup file or scan QR codes</small></span>
+                        <span className="ob-irow__go" aria-hidden>→</span>
+                    </button>
+                </div>
             </div>
         </div>
     );
 
-    const renderForm = () => {
-        // Create gets the guided, confirm-your-backup wizard; imports keep the direct form.
-        if (formMode === 'create') {
-            return (
-                <div className="max-w-lg mx-auto">
-                    <OnboardingCreateWallet
-                        onSubmit={handleFormSubmit}
-                        onCancel={() => setStep('method')}
-                        isSubmitting={isSubmitting}
-                    />
-                </div>
-            );
-        }
-
-        return (
-            <div className="max-w-lg mx-auto">
-                <div className="text-center mb-8">
-                    <Button variant="ghost" onClick={() => setStep('method')} className="mb-4">
-                        <ArrowLeft className="w-4 h-4 mr-2" /> Back
-                    </Button>
-                    <h1 className="text-3xl font-bold mb-2">
-                        {formMode === 'importMnemonic' && 'Import from Mnemonic'}
-                        {formMode === 'importWIF' && 'Import Private Key'}
-                        {formMode === 'importDescriptor' && 'Import from Descriptor'}
-                    </h1>
-                </div>
-
-                <WalletCreationForm
-                    mode={formMode}
-                    onSubmit={handleFormSubmit}
-                    onCancel={() => setStep('method')}
-                    isSubmitting={isSubmitting}
-                />
-            </div>
-        );
+    const importTitles: Partial<Record<WalletCreationMode, string>> = {
+        importMnemonic: 'Import from recovery phrase',
+        importWIF: 'Import a private key',
+        importDescriptor: 'Import from descriptor',
     };
 
-    const renderBackupFile = () => (
-        <div className="max-w-lg mx-auto space-y-6">
-            <div className="text-center">
-                <Button variant="ghost" onClick={() => setStep('method')} className="mb-4">
-                    <ArrowLeft className="w-4 h-4 mr-2" /> Back
-                </Button>
-                <h1 className="text-3xl font-bold mb-2">Restore from Backup</h1>
-                <p className="text-muted-foreground">
-                    Upload a backup file or scan QR codes to restore your wallet
-                </p>
+    const importScreen = (
+        <div className="ob-panel ob-solo">
+            <button className="ob-mini ob-mini--muted ob-back" onClick={() => setStep('method')}>
+                <ArrowLeft className="h-4 w-4" /> Back
+            </button>
+            <div className="ob-head ob-head--sm">
+                <span className="ob-label">Import</span>
+                <h2>{importTitles[formMode]}</h2>
+            </div>
+            <WalletCreationForm
+                mode={formMode}
+                onSubmit={handleFormSubmit}
+                onCancel={() => setStep('method')}
+                isSubmitting={isSubmitting}
+            />
+        </div>
+    );
+
+    const restoreScreen = (
+        <div className="ob-panel ob-solo">
+            <button className="ob-mini ob-mini--muted ob-back" onClick={() => setStep('method')}>
+                <ArrowLeft className="h-4 w-4" /> Back
+            </button>
+            <div className="ob-head ob-head--sm">
+                <span className="ob-label">Restore</span>
+                <h2>Restore from a backup</h2>
+                <p>Upload an encrypted backup file, or scan a set of QR codes.</p>
             </div>
 
-            <div className="grid gap-4">
-                {/* File Upload */}
-                <Card>
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-2">
-                            <Upload className="w-5 h-5" />
-                            Upload Backup File
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <Input
-                            type="file"
-                            accept=".json"
-                            onChange={handleFileSelect}
-                            disabled={isSubmitting}
-                        />
+            <div className="ob-restore">
+                <div className="ob-restore__file">
+                    <div className="ob-field__lbl">
+                        <Upload className="inline h-4 w-4 mr-2 -mt-0.5" /> Backup file
+                    </div>
+                    <Input
+                        type="file"
+                        accept=".json"
+                        onChange={handleFileSelect}
+                        disabled={isSubmitting}
+                        className="ob-file"
+                    />
 
-                        {needsPassword && (
-                            <div className="mt-4 space-y-3">
-                                <Label htmlFor="backupPassword">Backup Password</Label>
-                                <div className="relative">
-                                    <Input
-                                        id="backupPassword"
-                                        type={showBackupPassword ? "text" : "password"}
-                                        value={backupPassword}
-                                        onChange={(e) => setBackupPassword(e.target.value)}
-                                        placeholder="Enter backup password"
-                                        className="pr-10"
-                                    />
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="sm"
-                                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                                        onClick={() => setShowBackupPassword(!showBackupPassword)}
-                                    >
-                                        {showBackupPassword ? (
-                                            <EyeOff className="h-4 w-4 text-muted-foreground" />
-                                        ) : (
-                                            <Eye className="h-4 w-4 text-muted-foreground" />
-                                        )}
-                                    </Button>
-                                </div>
-                                <Button
-                                    onClick={handlePasswordRestore}
-                                    disabled={!backupPassword || isSubmitting}
-                                    className="w-full"
+                    {needsPassword && (
+                        <div className="mt-4 space-y-3">
+                            <Label htmlFor="backupPassword" className="ob-field__lbl">Backup password</Label>
+                            <div className="ob-inwrap">
+                                <Input
+                                    id="backupPassword"
+                                    type={showBackupPassword ? 'text' : 'password'}
+                                    value={backupPassword}
+                                    onChange={(e) => setBackupPassword(e.target.value)}
+                                    placeholder="Enter backup password"
+                                    className="ob-input pr-10"
+                                />
+                                <button
+                                    type="button"
+                                    className="ob-eye"
+                                    onClick={() => setShowBackupPassword(!showBackupPassword)}
+                                    aria-label={showBackupPassword ? 'Hide password' : 'Show password'}
                                 >
-                                    {isSubmitting ? 'Restoring...' : 'Restore Backup'}
-                                </Button>
+                                    {showBackupPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                                </button>
                             </div>
-                        )}
-                    </CardContent>
-                </Card>
+                            <button
+                                className="ob-btn ob-btn--go w-full"
+                                onClick={handlePasswordRestore}
+                                disabled={!backupPassword || isSubmitting}
+                            >
+                                {isSubmitting ? 'Restoring…' : 'Restore backup'}
+                            </button>
+                        </div>
+                    )}
+                </div>
 
-                {/* QR Code Import */}
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow" onClick={() => setShowBackupQRModal(true)}>
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-2">
-                            <QrCode className="w-5 h-5" />
-                            Scan QR Codes
-                        </CardTitle>
-                        <p className="text-muted-foreground">
-                            Restore from QR code backup
-                        </p>
-                    </CardHeader>
-                </Card>
+                <button className="ob-irow" onClick={() => setShowBackupQRModal(true)}>
+                    <span className="ob-tile__ic"><QrCode className="h-5 w-5" /></span>
+                    <span className="ob-irow__t"><b>Scan QR codes</b><small>Restore from a QR code backup</small></span>
+                    <span className="ob-irow__go" aria-hidden>→</span>
+                </button>
             </div>
 
             <BackupQRModal
@@ -440,49 +364,50 @@ export default function OnboardingPage() {
         </div>
     );
 
-    const renderSuccess = () => (
-        <Card className="max-w-md mx-auto text-center">
-            <CardContent className="pt-6">
-                <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <Wallet className="w-8 h-8 text-primary" />
-                </div>
-                <h2 className="text-2xl font-bold mb-2">Setup Complete!</h2>
-                <p className="text-muted-foreground mb-6">
-                    Your wallet has been successfully set up. Redirecting to your wallet...
-                </p>
-                <Button onClick={() => router.push('/')} className="w-full">
-                    Continue to Wallet
-                </Button>
-            </CardContent>
-        </Card>
+    const successScreen = (
+        <div className="ob-panel ob-solo ob-done">
+            <div className="ob-done__badge">
+                <svg width="34" height="34" viewBox="0 0 24 24" aria-hidden>
+                    <path d="M4 12.5 l5 5 L20 6" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+            </div>
+            <h2>Wallet armed</h2>
+            <p className="ob-lede ob-done__lede">
+                Your keys are generated, encrypted, and stored on this device. You have control.
+            </p>
+            <div className="ob-done__sign"><span className="ob-lamp" /> SYSTEMS NOMINAL</div>
+            <button className="ob-btn ob-btn--go" onClick={() => router.push('/')}>
+                Enter FlightDeck →
+            </button>
+        </div>
     );
 
     return (
-        <div className="min-h-screen bg-background">
-            {/* Header */}
-            <div className="border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-                <div className="container max-w-4xl mx-auto px-4 py-4">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                            <Wallet className="h-6 w-6 text-primary" />
-                            <span className="text-xl font-bold">Avian Wallet</span>
-                        </div>
-                        {step !== 'welcome' && (
-                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                Step {step === 'method' ? 1 : step === 'form' || step === 'backup-file' ? 2 : 3} of 3
-                            </div>
-                        )}
+        <div className="ob dark">
+            <style>{ONBOARDING_CSS}</style>
+
+            <div className="ob-top">
+                <div className="ob-wrap ob-top__row">
+                    <div className="ob-brand">
+                        <BrandMark />
+                        <span className="ob-brand__name">AVIAN <b>FLIGHTDECK</b></span>
                     </div>
+                    <div className="ob-top__tag"><span className="ob-lamp" /> PREFLIGHT SEQUENCE</div>
                 </div>
             </div>
 
-            {/* Main Content */}
-            <div className="container max-w-4xl mx-auto px-4 py-8">
-                {step === 'welcome' && renderWelcome()}
-                {step === 'method' && renderMethodSelection()}
-                {step === 'form' && renderForm()}
-                {step === 'backup-file' && renderBackupFile()}
-                {step === 'success' && renderSuccess()}
+            <div className="ob-wrap ob-stage">
+                {step === 'method' && methodScreen}
+                {step === 'form' && formMode === 'create' && (
+                    <OnboardingCreateWallet
+                        onSubmit={handleFormSubmit}
+                        onCancel={() => setStep('method')}
+                        isSubmitting={isSubmitting}
+                    />
+                )}
+                {step === 'form' && formMode !== 'create' && importScreen}
+                {step === 'backup-file' && restoreScreen}
+                {step === 'success' && successScreen}
             </div>
         </div>
     );

--- a/src/components/OnboardingCreateWallet.tsx
+++ b/src/components/OnboardingCreateWallet.tsx
@@ -2,23 +2,8 @@
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import * as bip39 from 'bip39';
-import {
-    ArrowLeft,
-    ArrowRight,
-    Eye,
-    EyeOff,
-    Copy,
-    Check,
-    RefreshCw,
-    ShieldCheck,
-    AlertTriangle,
-    Lock,
-} from 'lucide-react';
+import { Eye, EyeOff, Copy, RefreshCw, AlertTriangle, ShieldCheck } from 'lucide-react';
 import { toast } from 'sonner';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import PasswordStrengthChecker, { PasswordStrength } from '@/components/PasswordStrength';
 import type { WalletCreationData } from '@/components/WalletCreationForm';
 
@@ -32,6 +17,14 @@ type Step = 'details' | 'backup' | 'confirm' | 'secure';
 const STEPS: Step[] = ['details', 'backup', 'confirm', 'secure'];
 const MIN_PASSWORD_LENGTH = 8;
 const CONFIRM_COUNT = 3;
+
+// Preflight-sequence labels shown in the left rail, one per wizard step.
+const RAIL: Record<Step, { no: string; title: string; sub: string }> = {
+    details: { no: '01', title: 'Identify', sub: 'name & phrase length' },
+    backup: { no: '02', title: 'Recovery key', sub: 'write it down' },
+    confirm: { no: '03', title: 'Verify', sub: 'confirm the phrase' },
+    secure: { no: '04', title: 'Seal', sub: 'set a password' },
+};
 
 // Fisher–Yates shuffle (app runtime; deterministic randomness not required here).
 function shuffle<T>(arr: T[]): T[] {
@@ -165,37 +158,50 @@ export default function OnboardingCreateWallet({
         setStep(STEPS[stepIndex - 1]);
     };
 
-    // ---- render helpers ----------------------------------------------------
-    const titles: Record<Step, string> = {
-        details: 'Name your wallet',
-        backup: 'Back up your recovery phrase',
-        confirm: 'Confirm your recovery phrase',
-        secure: 'Set a password',
-    };
-
     return (
-        <Card className="max-w-lg mx-auto">
-            <CardHeader className="space-y-3">
-                {/* progress */}
-                <div className="flex items-center gap-1.5" aria-hidden>
+        <div className="ob-console">
+            <aside className="ob-rail">
+                <div className="ob-label">Sequence</div>
+                <ol className="ob-seq">
                     {STEPS.map((s, i) => (
-                        <span
-                            key={s}
-                            className={`h-1 flex-1 rounded-full transition-colors ${i <= stepIndex ? 'bg-primary' : 'bg-muted'}`}
-                        />
+                        <li key={s} className={i === stepIndex ? 'active' : i < stepIndex ? 'done' : ''}>
+                            <span className="ob-seq__no">{RAIL[s].no}</span>
+                            <span className="ob-seq__t">
+                                {RAIL[s].title}
+                                <small>{RAIL[s].sub}</small>
+                            </span>
+                            <span className="ob-seq__dot" />
+                        </li>
+                    ))}
+                </ol>
+                <div className="ob-rail__note">
+                    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
+                        <path d="M7 1.5 L13 12 H1 Z" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+                        <path d="M7 6 v3 M7 10.3 v0.3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    </svg>
+                    Keys are generated on this device. Nothing here is sent to a server.
+                </div>
+            </aside>
+
+            <main className="ob-panel">
+                <div className="ob-strip" aria-hidden>
+                    {STEPS.map((s, i) => (
+                        <span key={s} className={i <= stepIndex ? 'on' : ''} />
                     ))}
                 </div>
-                <CardTitle className="text-xl">{titles[step]}</CardTitle>
-            </CardHeader>
 
-            <CardContent className="space-y-5">
                 {/* STEP 1 — details */}
                 {step === 'details' && (
-                    <div className="space-y-5">
-                        <div className="space-y-2">
-                            <Label htmlFor="wallet-name">Wallet name</Label>
-                            <Input
+                    <div>
+                        <div className="ob-head ob-head--sm">
+                            <span className="ob-label">01 · Identify</span>
+                            <h2>Name your wallet</h2>
+                        </div>
+                        <div className="ob-field">
+                            <label className="ob-field__lbl" htmlFor="wallet-name">Wallet name</label>
+                            <input
                                 id="wallet-name"
+                                className="ob-input"
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
                                 placeholder="Main Wallet"
@@ -203,121 +209,101 @@ export default function OnboardingCreateWallet({
                                 maxLength={50}
                             />
                         </div>
-                        <div className="space-y-2">
-                            <Label>Recovery phrase length</Label>
-                            <div className="flex gap-2 rounded-lg border border-input bg-background p-1">
+                        <div className="ob-field">
+                            <span className="ob-field__lbl">Recovery phrase length</span>
+                            <div className="ob-seg">
                                 {(['12', '24'] as const).map((len) => (
                                     <button
                                         key={len}
                                         type="button"
+                                        className={mnemonicLength === len ? 'is-on' : ''}
                                         onClick={() => setMnemonicLength(len)}
-                                        className={`flex-1 rounded-md py-2 text-sm font-medium transition-colors ${
-                                            mnemonicLength === len
-                                                ? 'bg-primary/15 text-primary'
-                                                : 'text-muted-foreground hover:text-foreground'
-                                        }`}
                                     >
                                         {len} words
                                     </button>
                                 ))}
                             </div>
-                            <p className="text-xs text-muted-foreground">
-                                Both are secure. 24 words offers extra margin; 12 is easier to write down.
-                            </p>
+                            <span className="ob-hint">
+                                Both are secure. 24 words adds margin; 12 is easier to write down.
+                            </span>
                         </div>
                     </div>
                 )}
 
                 {/* STEP 2 — backup / reveal */}
                 {step === 'backup' && (
-                    <div className="space-y-4">
-                        <p className="text-sm text-muted-foreground">
-                            Write these {words.length} words down in order and keep them offline. They are
-                            the only way to restore this wallet — FlightDeck can&apos;t recover them for you.
+                    <div>
+                        <div className="ob-head ob-head--sm">
+                            <span className="ob-label">02 · Recovery key</span>
+                            <h2>Write these words down, in order</h2>
+                        </div>
+                        <p className="ob-lede">
+                            This phrase is the only way to restore the wallet — FlightDeck can&apos;t
+                            recover it for you. Keep it offline.
                         </p>
 
-                        <div className="relative">
-                            <div
-                                className={`grid grid-cols-2 gap-2 sm:grid-cols-3 ${revealed ? '' : 'select-none blur-sm'}`}
-                            >
+                        <div className="ob-seedwrap">
+                            <div className={`ob-seed${revealed ? '' : ' blur'}`}>
                                 {words.map((word, i) => (
-                                    <div
-                                        key={i}
-                                        className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2"
-                                    >
-                                        <span className="w-5 text-right font-mono text-xs text-muted-foreground">
-                                            {i + 1}
-                                        </span>
-                                        <span className="font-mono text-sm" data-testid="seed-word">
-                                            {word}
-                                        </span>
+                                    <div key={i} className="ob-word">
+                                        <i>{i + 1}</i>
+                                        <b data-testid="seed-word">{word}</b>
                                     </div>
                                 ))}
                             </div>
                             {!revealed && (
-                                <button
-                                    type="button"
-                                    onClick={() => setRevealed(true)}
-                                    className="absolute inset-0 grid place-items-center"
-                                >
-                                    <span className="flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium shadow-sm">
-                                        <Eye className="h-4 w-4 text-primary" /> Tap to reveal
-                                    </span>
+                                <button type="button" className="ob-reveal" onClick={() => setRevealed(true)}>
+                                    <Eye className="h-4 w-4" /> Tap to reveal
                                 </button>
                             )}
                         </div>
 
-                        <div className="flex items-start gap-2.5 rounded-lg border border-caution/30 bg-caution/10 p-3 text-sm">
-                            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-caution" />
-                            <span>
-                                Anyone with these words owns the funds. Never share them, and never type them
-                                into a website.
-                            </span>
+                        <div className="ob-warn">
+                            <AlertTriangle className="h-4 w-4" />
+                            Anyone with these words owns the funds. Never share them, and never type
+                            them into a website.
                         </div>
 
                         {revealed && (
-                            <div className="flex items-center justify-between">
-                                <Button variant="ghost" size="sm" onClick={copyPhrase} className="gap-2">
+                            <div className="ob-seedbar">
+                                <button type="button" className="ob-mini" onClick={copyPhrase}>
                                     <Copy className="h-4 w-4" /> Copy
-                                </Button>
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
+                                </button>
+                                <button
+                                    type="button"
+                                    className="ob-mini ob-mini--muted"
                                     onClick={() => regenerate(mnemonicLength)}
-                                    className="gap-2 text-muted-foreground"
                                 >
                                     <RefreshCw className="h-4 w-4" /> Regenerate
-                                </Button>
+                                </button>
                             </div>
                         )}
 
-                        <label className="flex cursor-pointer items-center gap-2.5 text-sm">
+                        <label className="ob-arm">
                             <input
                                 type="checkbox"
                                 checked={writtenDown}
                                 disabled={!revealed}
                                 onChange={(e) => setWrittenDown(e.target.checked)}
-                                className="h-4 w-4 accent-[hsl(var(--primary))] disabled:opacity-50"
                             />
-                            <span className={revealed ? '' : 'text-muted-foreground'}>
-                                I&apos;ve written my recovery phrase down and stored it safely.
-                            </span>
+                            <span>I&apos;ve written my recovery phrase down and stored it safely.</span>
                         </label>
                     </div>
                 )}
 
                 {/* STEP 3 — confirm */}
                 {step === 'confirm' && (
-                    <div className="space-y-4">
-                        <p className="text-sm text-muted-foreground">
+                    <div>
+                        <div className="ob-head ob-head--sm">
+                            <span className="ob-label">03 · Verify</span>
+                            <h2>Confirm your recovery phrase</h2>
+                        </div>
+                        <p className="ob-lede">
                             Tap the words to fill positions{' '}
-                            <span className="font-medium text-foreground">
-                                {positions.map((p) => `#${p + 1}`).join(', ')}
-                            </span>{' '}
-                            in order, to confirm your backup.
+                            <b>{positions.map((p) => `#${p + 1}`).join(', ')}</b>, in order.
                         </p>
 
-                        <div className="flex gap-2">
+                        <div className="ob-slots">
                             {positions.map((pos, slot) => {
                                 const bankId = assignments[slot];
                                 const filled = bankId !== null;
@@ -325,28 +311,17 @@ export default function OnboardingCreateWallet({
                                     <button
                                         key={slot}
                                         type="button"
+                                        className={`ob-slot${filled ? ' filled' : ''}`}
                                         onClick={() => clearSlot(slot)}
-                                        className={`flex-1 rounded-lg border px-2 py-2.5 text-center transition-colors ${
-                                            filled
-                                                ? 'border-primary bg-primary/10'
-                                                : 'border-dashed border-border'
-                                        }`}
                                     >
-                                        <span
-                                            className="block text-[0.6rem] text-muted-foreground"
-                                            data-testid="confirm-slot-pos"
-                                        >
-                                            #{pos + 1}
-                                        </span>
-                                        <span className="font-mono text-sm">
-                                            {filled ? bank[bankId!].word : '·····'}
-                                        </span>
+                                        <small data-testid="confirm-slot-pos">#{pos + 1}</small>
+                                        <b>{filled ? bank[bankId!].word : '·····'}</b>
                                     </button>
                                 );
                             })}
                         </div>
 
-                        <div className="flex flex-wrap gap-2">
+                        <div className="ob-bank">
                             {bank.map((entry) => {
                                 const used = assignedIds.has(entry.id);
                                 return (
@@ -356,11 +331,7 @@ export default function OnboardingCreateWallet({
                                         data-testid="bank-word"
                                         onClick={() => tapWord(entry.id)}
                                         disabled={used}
-                                        className={`rounded-md border px-3 py-1.5 font-mono text-sm transition-colors ${
-                                            used
-                                                ? 'border-border bg-muted/40 text-muted-foreground opacity-50'
-                                                : 'border-border hover:border-primary hover:text-primary'
-                                        }`}
+                                        className={`ob-bankw${used ? ' used' : ''}`}
                                     >
                                         {entry.word}
                                     </button>
@@ -369,7 +340,7 @@ export default function OnboardingCreateWallet({
                         </div>
 
                         {assignments.every((a) => a !== null) && !confirmValid && (
-                            <p className="text-sm text-destructive">
+                            <p className="ob-err">
                                 That order doesn&apos;t match. Tap a slot to clear it and try again.
                             </p>
                         )}
@@ -378,95 +349,107 @@ export default function OnboardingCreateWallet({
 
                 {/* STEP 4 — secure */}
                 {step === 'secure' && (
-                    <div className="space-y-4">
-                        <p className="text-sm text-muted-foreground">
-                            This password encrypts the wallet on this device. You&apos;ll enter it to unlock
-                            and to authorise signatures.
+                    <div>
+                        <div className="ob-head ob-head--sm">
+                            <span className="ob-label">04 · Seal</span>
+                            <h2>Set a password</h2>
+                        </div>
+                        <p className="ob-lede">
+                            This password encrypts the wallet on this device. You&apos;ll enter it to
+                            unlock and to authorise signatures.
                         </p>
-                        <div className="space-y-2">
-                            <Label htmlFor="new-password">Password</Label>
-                            <div className="relative">
-                                <Input
+                        <div className="ob-field">
+                            <label className="ob-field__lbl" htmlFor="new-password">Password</label>
+                            <div className="ob-inwrap">
+                                <input
                                     id="new-password"
+                                    className="ob-input"
+                                    style={{ paddingRight: 40 }}
                                     type={showPassword ? 'text' : 'password'}
                                     value={password}
                                     onChange={(e) => setPassword(e.target.value)}
                                     placeholder="At least 8 characters"
                                     autoComplete="new-password"
-                                    className="pr-10"
                                     autoFocus
                                 />
                                 <button
                                     type="button"
+                                    className="ob-eye"
                                     onClick={() => setShowPassword((v) => !v)}
-                                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                                     aria-label={showPassword ? 'Hide password' : 'Show password'}
                                 >
                                     {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                                 </button>
                             </div>
-                            <PasswordStrengthChecker
-                                password={password}
-                                onStrengthChange={(s) => setStrength(s)}
-                                showSuggestions={false}
-                            />
+                            <div className="mt-2">
+                                <PasswordStrengthChecker
+                                    password={password}
+                                    onStrengthChange={(s) => setStrength(s)}
+                                    showSuggestions={false}
+                                />
+                            </div>
                         </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="confirm-password">Confirm password</Label>
-                            <Input
+                        <div className="ob-field">
+                            <label className="ob-field__lbl" htmlFor="confirm-password">Confirm password</label>
+                            <input
                                 id="confirm-password"
+                                className="ob-input"
                                 type={showPassword ? 'text' : 'password'}
                                 value={confirmPassword}
                                 onChange={(e) => setConfirmPassword(e.target.value)}
                                 autoComplete="new-password"
                             />
                             {confirmPassword.length > 0 && password !== confirmPassword && (
-                                <p className="text-xs text-destructive">Passwords don&apos;t match.</p>
+                                <p className="ob-err">Passwords don&apos;t match.</p>
                             )}
                         </div>
-                        <div className="flex items-start gap-2.5 rounded-lg border border-primary/25 bg-primary/5 p-3 text-sm">
-                            <ShieldCheck className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
+                        <div className="ob-note">
+                            <ShieldCheck className="h-4 w-4" />
                             <span>
-                                Encrypted with scrypt + AES-256-GCM.{' '}
-                                <b className="text-primary">There&apos;s no reset</b> — if you lose this
-                                password, restore from your recovery phrase.
+                                Encrypted with scrypt + AES-256-GCM. <b>There&apos;s no reset</b> — if
+                                you lose this password, restore from your recovery phrase.
                             </span>
                         </div>
                     </div>
                 )}
 
                 {/* nav */}
-                <div className="flex gap-2 pt-1">
-                    <Button variant="ghost" onClick={goBack} disabled={isSubmitting} className="gap-2">
-                        <ArrowLeft className="h-4 w-4" /> Back
-                    </Button>
+                <div className="ob-nav">
+                    <button
+                        type="button"
+                        className="ob-btn ob-btn--ghost"
+                        onClick={goBack}
+                        disabled={isSubmitting}
+                    >
+                        ← {stepIndex === 0 ? 'Setup' : 'Back'}
+                    </button>
                     {step === 'details' && (
-                        <Button onClick={goNext} disabled={!detailsValid} className="ml-auto gap-2">
-                            Continue <ArrowRight className="h-4 w-4" />
-                        </Button>
+                        <button type="button" className="ob-btn ob-btn--go" onClick={goNext} disabled={!detailsValid}>
+                            Continue →
+                        </button>
                     )}
                     {step === 'backup' && (
-                        <Button onClick={goNext} disabled={!writtenDown} className="ml-auto gap-2">
-                            Continue <ArrowRight className="h-4 w-4" />
-                        </Button>
+                        <button type="button" className="ob-btn ob-btn--go" onClick={goNext} disabled={!writtenDown}>
+                            Continue →
+                        </button>
                     )}
                     {step === 'confirm' && (
-                        <Button onClick={goNext} disabled={!confirmValid} className="ml-auto gap-2">
-                            Continue <ArrowRight className="h-4 w-4" />
-                        </Button>
+                        <button type="button" className="ob-btn ob-btn--go" onClick={goNext} disabled={!confirmValid}>
+                            Continue →
+                        </button>
                     )}
                     {step === 'secure' && (
-                        <Button
+                        <button
+                            type="button"
+                            className="ob-btn ob-btn--go"
                             onClick={handleCreate}
                             disabled={!passwordValid || isSubmitting}
-                            className="ml-auto gap-2"
                         >
-                            <Lock className="h-4 w-4" />
                             {isSubmitting ? 'Creating…' : 'Create wallet'}
-                        </Button>
+                        </button>
                     )}
                 </div>
-            </CardContent>
-        </Card>
+            </main>
+        </div>
     );
 }

--- a/src/components/onboarding/instrument.ts
+++ b/src/components/onboarding/instrument.ts
@@ -1,0 +1,160 @@
+/**
+ * Shared "flight-deck instrument" styles for the onboarding surface (the method screen, the create
+ * wizard, import, restore, and the armed/success state). Injected once by the onboarding page via a
+ * <style> tag — the same self-contained, committed-dark approach the landing page uses — and keyed
+ * to the app's already-loaded Inter / Roboto Mono via the CSS variables layout.tsx sets. Scoped
+ * under `.ob` so nothing leaks into the rest of the app.
+ */
+export const ONBOARDING_CSS = `
+.ob{
+  --night:#0D1B21;--panel:#0F2027;--panel-2:#122730;--panel-3:#163139;--line:#24404A;--line-soft:#1A333B;
+  --ink:#E6F0F2;--muted:#9DB4BC;--faint:#4D5E68;--mint:#34F5C6;--turq:#34E2D5;--cyan:#17A7B6;--indigo:#6B8FF0;--violet:#8A8FF2;--amber:#F2C46B;--rose:#F0768A;
+  --grad:linear-gradient(135deg,#34F5C6,#17A7B6);
+  --sans:var(--font-inter),-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;--mono:var(--font-roboto-mono),ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+  min-height:100vh;background:radial-gradient(1100px 640px at 82% -10%,rgba(52,245,198,0.06),transparent 60%),var(--night);
+  color:var(--ink);font-family:var(--sans);line-height:1.6;-webkit-font-smoothing:antialiased;
+}
+.ob *{box-sizing:border-box;}
+.ob-wrap{max-width:1060px;margin:0 auto;padding:0 24px;}
+.ob-stage{padding:38px 24px 56px;}
+.ob-label{font-family:var(--mono);font-size:0.66rem;letter-spacing:0.16em;text-transform:uppercase;color:var(--muted);}
+.ob-lamp{display:inline-block;width:7px;height:7px;border-radius:50%;background:var(--mint);box-shadow:0 0 0 2px rgba(52,245,198,0.15),0 0 10px 1px rgba(52,245,198,0.85);flex:none;}
+.ob-lamp--turq{background:var(--turq);box-shadow:0 0 0 2px rgba(52,226,213,0.15),0 0 10px 1px rgba(52,226,213,0.8);}
+.ob-lamp--indigo{background:var(--indigo);box-shadow:0 0 0 2px rgba(107,143,240,0.15),0 0 10px 1px rgba(107,143,240,0.8);}
+
+.ob-top{border-bottom:1px solid var(--line-soft);position:sticky;top:0;z-index:5;background:color-mix(in srgb,var(--night) 88%,transparent);backdrop-filter:blur(8px);}
+.ob-top__row{display:flex;align-items:center;justify-content:space-between;height:62px;}
+.ob-brand{display:flex;align-items:center;gap:11px;}
+.ob-brand__mark{width:28px;height:28px;}
+.ob-brand__name{font-family:var(--mono);font-weight:600;letter-spacing:0.02em;font-size:0.88rem;}
+.ob-brand__name b{color:var(--mint);}
+.ob-top__tag{display:inline-flex;align-items:center;gap:8px;font-family:var(--mono);font-size:0.64rem;letter-spacing:0.12em;color:var(--muted);}
+
+.ob-console{display:grid;grid-template-columns:250px 1fr;gap:26px;align-items:start;}
+.ob-rail{position:sticky;top:90px;border:1px solid var(--line-soft);background:var(--panel);border-radius:16px;padding:20px 18px;}
+.ob-seq{list-style:none;margin:14px 0 0;padding:0;display:grid;gap:4px;}
+.ob-seq li{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px;padding:11px 12px;border-radius:10px;border:1px solid transparent;color:var(--muted);}
+.ob-seq__no{font-family:var(--mono);font-size:0.7rem;color:var(--faint);}
+.ob-seq__t{font-size:0.86rem;font-weight:600;color:inherit;line-height:1.25;}
+.ob-seq__t small{display:block;font-weight:400;font-size:0.72rem;color:var(--faint);margin-top:2px;}
+.ob-seq__dot{width:8px;height:8px;border-radius:50%;background:var(--line);}
+.ob-seq li.done{color:var(--ink);}
+.ob-seq li.done .ob-seq__dot{background:var(--mint);box-shadow:0 0 8px rgba(52,245,198,0.7);}
+.ob-seq li.done .ob-seq__no{color:var(--mint);}
+.ob-seq li.active{color:var(--ink);background:var(--panel-2);border-color:var(--line);}
+.ob-seq li.active .ob-seq__dot{background:var(--turq);box-shadow:0 0 10px rgba(52,226,213,0.9);}
+.ob-seq li.active .ob-seq__no{color:var(--turq);}
+.ob-rail__note{display:flex;gap:9px;margin-top:16px;padding-top:16px;border-top:1px solid var(--line-soft);color:var(--muted);font-size:0.74rem;line-height:1.5;}
+.ob-rail__note svg{color:var(--amber);flex:none;margin-top:2px;}
+
+.ob-panel{border:1px solid var(--line);background:linear-gradient(180deg,var(--panel-3),var(--panel-2));border-radius:18px;padding:30px 30px 26px;box-shadow:0 40px 80px -55px rgba(0,0,0,0.9);}
+.ob-solo{max-width:600px;margin:0 auto;}
+.ob-head{margin-bottom:24px;}
+.ob-head h1{font-size:clamp(1.5rem,3vw,2rem);letter-spacing:-0.01em;font-weight:800;margin:11px 0 10px;text-wrap:balance;}
+.ob-head h2{font-size:1.4rem;letter-spacing:-0.01em;font-weight:700;margin:9px 0 0;}
+.ob-head p{color:var(--muted);margin:8px 0 0;max-width:52ch;}
+.ob-head--sm{margin-bottom:18px;}
+.ob-lede{color:var(--muted);font-size:0.92rem;margin:0 0 18px;max-width:56ch;}
+.ob-lede b{color:var(--ink);}
+
+.ob-methods{display:grid;gap:12px;}
+.ob-tile{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:16px;text-align:left;width:100%;padding:18px;border-radius:14px;border:1px solid var(--line);background:var(--panel-2);cursor:pointer;transition:border-color .15s,transform .14s,background .15s;color:var(--ink);font-family:inherit;}
+.ob-tile:hover{transform:translateY(-1px);border-color:var(--mint);}
+.ob-tile--go{border-color:rgba(52,245,198,0.35);background:linear-gradient(180deg,rgba(52,245,198,0.06),var(--panel-2));}
+.ob-tile__ic{width:46px;height:46px;border-radius:12px;display:grid;place-items:center;background:var(--panel-3);border:1px solid var(--line);flex:none;color:var(--turq);}
+.ob-tile__ic--go{color:#0D1B21;background:linear-gradient(135deg,var(--mint),var(--cyan));border-color:transparent;}
+.ob-tile__body b{display:block;font-size:1.02rem;margin-bottom:3px;}
+.ob-tile__body small{color:var(--muted);font-size:0.85rem;line-height:1.5;}
+.ob-tile__go{font-family:var(--mono);color:var(--mint);font-size:1.1rem;}
+.ob-methods__sub{margin-top:26px;padding-top:22px;border-top:1px solid var(--line-soft);}
+.ob-imports{display:grid;gap:9px;}
+.ob-irow{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:14px;text-align:left;width:100%;padding:14px 16px;border-radius:12px;border:1px solid var(--line-soft);background:var(--panel-2);cursor:pointer;color:var(--ink);font-family:inherit;transition:border-color .15s,transform .14s;}
+.ob-irow:hover{border-color:var(--mint);transform:translateY(-1px);}
+.ob-irow__t b{display:block;font-size:0.94rem;margin-bottom:2px;}
+.ob-irow__t small{color:var(--muted);font-size:0.8rem;}
+.ob-irow__go{font-family:var(--mono);color:var(--muted);}
+.ob-irow:hover .ob-irow__go{color:var(--mint);}
+
+.ob-strip{display:flex;gap:6px;margin-bottom:24px;}
+.ob-strip span{height:3px;flex:1;border-radius:3px;background:var(--line);transition:background .2s;}
+.ob-strip span.on{background:var(--grad);}
+
+.ob-field{display:block;margin-bottom:18px;}
+.ob-field__lbl{display:block;font-size:0.82rem;font-weight:600;color:var(--ink);margin-bottom:8px;}
+.ob-input{width:100%;padding:12px 14px;border-radius:10px;border:1px solid var(--line);background:rgba(4,18,26,0.55);color:var(--ink);font-family:var(--mono);font-size:0.92rem;transition:border-color .15s;}
+.ob-input::placeholder{color:var(--faint);}
+.ob-input:focus{outline:none;border-color:var(--mint);}
+.ob-inwrap{position:relative;}
+.ob-eye{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--muted);cursor:pointer;padding:4px;}
+.ob-eye:hover{color:var(--ink);}
+.ob-hint{display:block;color:var(--faint);font-size:0.76rem;margin-top:8px;}
+.ob-err{color:var(--rose);font-size:0.78rem;margin:8px 0 0;}
+
+.ob-seg{display:flex;gap:4px;padding:4px;border-radius:11px;border:1px solid var(--line);background:rgba(4,18,26,0.5);}
+.ob-seg button{flex:1;padding:10px;border-radius:8px;border:none;background:none;color:var(--muted);font-family:var(--mono);font-size:0.82rem;font-weight:600;cursor:pointer;transition:all .15s;}
+.ob-seg button.is-on{background:rgba(52,245,198,0.14);color:var(--mint);box-shadow:inset 0 0 0 1px rgba(52,245,198,0.3);}
+
+.ob-seedwrap{position:relative;margin-bottom:14px;}
+.ob-seed{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;transition:filter .2s;}
+.ob-seed.blur{filter:blur(7px);user-select:none;pointer-events:none;}
+.ob-word{display:flex;align-items:center;gap:9px;padding:9px 11px;border-radius:8px;border:1px solid var(--line-soft);background:rgba(4,18,26,0.4);}
+.ob-word i{width:18px;text-align:right;font-family:var(--mono);font-size:0.7rem;color:var(--faint);font-style:normal;}
+.ob-word b{font-family:var(--mono);font-size:0.86rem;font-weight:500;}
+.ob-reveal{position:absolute;inset:0;margin:auto;height:44px;width:max-content;padding:0 18px;display:inline-flex;align-items:center;gap:9px;border-radius:10px;border:1px solid var(--line);background:var(--panel-3);color:var(--ink);font-family:var(--mono);font-size:0.82rem;font-weight:600;cursor:pointer;}
+.ob-reveal svg{color:var(--mint);}
+.ob-reveal:hover{border-color:var(--mint);}
+.ob-warn{display:flex;gap:10px;align-items:flex-start;padding:12px 14px;border-radius:10px;border:1px solid rgba(242,196,107,0.3);background:rgba(242,196,107,0.09);color:var(--ink);font-size:0.83rem;line-height:1.5;margin-bottom:14px;}
+.ob-warn svg{color:var(--amber);flex:none;margin-top:2px;}
+.ob-seedbar{display:flex;justify-content:space-between;margin-bottom:14px;}
+.ob-mini{display:inline-flex;align-items:center;gap:7px;background:none;border:none;color:var(--mint);font-family:var(--mono);font-size:0.76rem;font-weight:600;cursor:pointer;padding:6px 4px;}
+.ob-mini--muted{color:var(--muted);}
+.ob-mini:hover{filter:brightness(1.15);}
+.ob-back{margin-bottom:16px;}
+.ob-arm{display:flex;align-items:center;gap:11px;cursor:pointer;font-size:0.87rem;padding:12px 14px;border-radius:10px;border:1px solid var(--line-soft);background:var(--panel-2);}
+.ob-arm input{width:17px;height:17px;accent-color:#34F5C6;flex:none;}
+.ob-arm input:disabled{opacity:0.4;}
+
+.ob-slots{display:flex;gap:10px;margin-bottom:16px;}
+.ob-slot{flex:1;border-radius:10px;border:1px dashed var(--line);background:rgba(4,18,26,0.4);padding:11px 6px;text-align:center;cursor:pointer;transition:all .14s;color:var(--ink);font-family:inherit;}
+.ob-slot.filled{border-style:solid;border-color:var(--mint);background:rgba(52,245,198,0.08);}
+.ob-slot small{display:block;font-family:var(--mono);font-size:0.6rem;color:var(--faint);margin-bottom:4px;}
+.ob-slot b{font-family:var(--mono);font-size:0.9rem;font-weight:500;color:var(--ink);}
+.ob-bank{display:flex;flex-wrap:wrap;gap:8px;}
+.ob-bankw{border-radius:8px;border:1px solid var(--line-soft);background:var(--panel-2);color:var(--ink);font-family:var(--mono);font-size:0.85rem;padding:8px 13px;cursor:pointer;transition:all .14s;}
+.ob-bankw:hover:not(:disabled){border-color:var(--mint);color:var(--mint);}
+.ob-bankw:disabled{opacity:0.35;cursor:default;}
+
+.ob-meter{height:5px;border-radius:3px;background:var(--line);overflow:hidden;margin-top:10px;}
+.ob-meter i{display:block;height:100%;width:0;border-radius:3px;background:var(--rose);transition:width .2s,background .2s;}
+.ob-note{display:flex;gap:10px;align-items:flex-start;padding:12px 14px;border-radius:10px;border:1px solid rgba(52,245,198,0.22);background:rgba(52,245,198,0.06);color:var(--ink);font-size:0.83rem;line-height:1.5;}
+.ob-note svg{color:var(--mint);flex:none;margin-top:2px;}
+.ob-note b{color:var(--mint);}
+
+.ob-restore{display:grid;gap:14px;}
+.ob-restore__file{border:1px solid var(--line-soft);background:var(--panel-2);border-radius:12px;padding:16px;}
+.ob-file{background:rgba(4,18,26,0.5);border-color:var(--line);color:var(--ink);}
+
+.ob-nav{display:flex;gap:12px;margin-top:26px;padding-top:22px;border-top:1px solid var(--line-soft);}
+.ob-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 22px;border-radius:10px;font-family:var(--mono);font-size:0.8rem;letter-spacing:0.04em;font-weight:600;border:1px solid transparent;cursor:pointer;transition:transform .14s,box-shadow .2s,background .15s,opacity .15s;}
+.ob-btn--go{background:var(--grad);color:#06232A;box-shadow:0 8px 24px -10px rgba(52,245,198,0.5);margin-left:auto;}
+.ob-btn--go:hover{transform:translateY(-1px);box-shadow:0 12px 30px -10px rgba(52,245,198,0.7);}
+.ob-btn--go:disabled{opacity:0.4;cursor:not-allowed;transform:none;box-shadow:none;}
+.ob-btn--ghost{background:var(--panel-2);color:var(--ink);border-color:var(--line);}
+.ob-btn--ghost:hover{border-color:var(--mint);color:var(--mint);}
+
+.ob-done{display:flex;flex-direction:column;align-items:center;text-align:center;gap:14px;padding:44px 30px;}
+.ob-done__badge{width:76px;height:76px;border-radius:20px;display:grid;place-items:center;color:var(--mint);background:rgba(52,245,198,0.1);border:1px solid rgba(52,245,198,0.3);box-shadow:0 0 40px -8px rgba(52,245,198,0.4);}
+.ob-done h2{font-size:1.7rem;font-weight:800;margin:6px 0 0;}
+.ob-done__lede{text-align:center;max-width:44ch;margin-inline:auto;}
+.ob-done__sign{font-family:var(--mono);font-size:0.72rem;letter-spacing:0.1em;color:var(--muted);display:inline-flex;align-items:center;gap:8px;}
+
+.ob :focus-visible{outline:2px solid var(--mint);outline-offset:2px;border-radius:6px;}
+
+@media (max-width:820px){
+  .ob-console{grid-template-columns:1fr;}
+  .ob-rail{display:none;}
+  .ob-panel{padding:24px 20px;}
+  .ob-seed{grid-template-columns:repeat(2,1fr);}
+}
+@media (prefers-reduced-motion:reduce){.ob *{transition:none!important;}}
+`;


### PR DESCRIPTION
Reskins the onboarding surface — the last screen still on generic shadcn cards — into the same flight-deck instrument language as the landing page, so `Create a wallet` → onboarding feels like one continuous cockpit. Approved from an interactive prototype.

Steps and validation are **unchanged** — this is visual/structural only.

### What changed
- **Method screen** — "Create New Wallet" as the primary instrument tile; the four import methods (recovery phrase / private key / descriptor / encrypted backup) as rows beneath.
- **Create wizard** — reframed as a **preflight sequence** with a left rail that lights up per step (Identify → Recovery key → Verify → Seal). The panel keeps the blurred reveal grid, tap-to-confirm, and password strength meter.
- **Import & restore** — wrapped in the same shell. The shared `WalletCreationForm` (also used by `WalletManager`) is **untouched** and rendered inside a forced-`dark` context so it stays coherent without affecting the themed in-app use.
- **Armed** success state replaces "Setup Complete!".
- Shared styles live in `components/onboarding/instrument.ts`, injected once (same self-contained approach as the landing page); keyed to the app's Inter / Roboto Mono.

### Flow note
The redundant welcome step is dropped — the landing page already welcomes new visitors, so onboarding opens straight on method selection.

### Tests
- E2E updated for the dropped welcome click and the new success copy. Every behavior-critical hook is preserved: `seed-word` / `bank-word` / `confirm-slot-pos` testids, the `Wallet name` / `Password` / `Confirm password` labels, and the `Continue` / `Tap to reveal` / `Create wallet` buttons.
- ✅ typecheck · ✅ build (static export) · ✅ 31 E2E (both onboarding specs drive the reskinned wizard)