### PR TITLE
feat(ui): unify create-wallet into one guided wizard, two skins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/OnboardingCreateWallet.tsx
+++ b/src/components/OnboardingCreateWallet.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import * as bip39 from 'bip39';
 import { Eye, EyeOff, Copy, RefreshCw, AlertTriangle, ShieldCheck } from 'lucide-react';
-import { toast } from 'sonner';
-import PasswordStrengthChecker, { PasswordStrength } from '@/components/PasswordStrength';
+import PasswordStrengthChecker from '@/components/PasswordStrength';
 import type { WalletCreationData } from '@/components/WalletCreationForm';
-import { generateWalletName } from '@/lib/walletName';
+import { useCreateWalletWizard, WIZARD_STEPS, WizardStep } from '@/hooks/useCreateWalletWizard';
 
 interface OnboardingCreateWalletProps {
     onSubmit: (data: WalletCreationData) => Promise<void>;
@@ -14,169 +11,32 @@ interface OnboardingCreateWalletProps {
     isSubmitting: boolean;
 }
 
-type Step = 'details' | 'backup' | 'confirm' | 'secure';
-const STEPS: Step[] = ['details', 'backup', 'confirm', 'secure'];
-const MIN_PASSWORD_LENGTH = 8;
-const CONFIRM_COUNT = 3;
-
 // Preflight-sequence labels shown in the left rail, one per wizard step.
-const RAIL: Record<Step, { no: string; title: string; sub: string }> = {
+const RAIL: Record<WizardStep, { no: string; title: string; sub: string }> = {
     details: { no: '01', title: 'Identify', sub: 'name & phrase length' },
     backup: { no: '02', title: 'Recovery key', sub: 'write it down' },
     confirm: { no: '03', title: 'Verify', sub: 'confirm the phrase' },
     secure: { no: '04', title: 'Seal', sub: 'set a password' },
 };
 
-// Fisher–Yates shuffle (app runtime; deterministic randomness not required here).
-function shuffle<T>(arr: T[]): T[] {
-    const a = [...arr];
-    for (let i = a.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [a[i], a[j]] = [a[j], a[i]];
-    }
-    return a;
-}
-
-// Pick `count` distinct indices from [0, length).
-function pickPositions(length: number, count: number): number[] {
-    const idx = shuffle(Array.from({ length }, (_, i) => i)).slice(0, count);
-    return idx.sort((a, b) => a - b);
-}
-
+/** Committed-dark "instrument" skin of the guided create-wallet wizard, used in onboarding. */
 export default function OnboardingCreateWallet({
     onSubmit,
     onCancel,
     isSubmitting,
 }: OnboardingCreateWalletProps) {
-    const [step, setStep] = useState<Step>('details');
-
-    // details
-    const [name, setName] = useState('');
-    const [mnemonicLength, setMnemonicLength] = useState<'12' | '24'>('12');
-
-    // backup
-    const [mnemonic, setMnemonic] = useState('');
-    const [revealed, setRevealed] = useState(false);
-    const [writtenDown, setWrittenDown] = useState(false);
-
-    // confirm
-    const [positions, setPositions] = useState<number[]>([]);
-    // slot -> bank entry id (index into `bank`), or null
-    const [assignments, setAssignments] = useState<(number | null)[]>([]);
-
-    // secure
-    const [password, setPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
-    const [showPassword, setShowPassword] = useState(false);
-    const [strength, setStrength] = useState<PasswordStrength>(null);
-
-    const words = useMemo(() => (mnemonic ? mnemonic.trim().split(/\s+/) : []), [mnemonic]);
-
-    // Word bank for the confirm step: every mnemonic word, shuffled, then given an id equal to its
-    // position in the shuffled array — so `bank[id]` resolves to the same entry the button rendered.
-    const bank = useMemo(
-        () => shuffle(words).map((word, id) => ({ id, word })),
-        // Re-shuffle only when the mnemonic itself changes.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [mnemonic],
-    );
-
-    const regenerate = useCallback((length: '12' | '24') => {
-        const entropyBits = length === '24' ? 256 : 128;
-        const next = bip39.generateMnemonic(entropyBits);
-        setMnemonic(next);
-        setRevealed(false);
-        setWrittenDown(false);
-        const wordCount = length === '24' ? 24 : 12;
-        setPositions(pickPositions(wordCount, CONFIRM_COUNT));
-        setAssignments(Array(CONFIRM_COUNT).fill(null));
-    }, []);
-
-    // Generate on mount and whenever the requested length changes.
-    useEffect(() => {
-        regenerate(mnemonicLength);
-    }, [mnemonicLength, regenerate]);
-
-    // Suggest a creative bird-themed name on mount; the user can keep it, edit it, or re-roll.
-    // Guard against the async suggestion landing after the user has already typed something.
-    const nameTouched = useRef(false);
-    useEffect(() => {
-        generateWalletName().then((suggested) => {
-            if (!nameTouched.current) setName(suggested);
-        });
-    }, []);
-
-    const rollName = async () => setName(await generateWalletName());
-
-    const stepIndex = STEPS.indexOf(step);
-
-    // ---- validation --------------------------------------------------------
-    const detailsValid = name.trim().length > 0;
-    const confirmValid = useMemo(
-        () =>
-            assignments.length === positions.length &&
-            assignments.every(
-                (bankId, slot) => bankId !== null && bank[bankId]?.word === words[positions[slot]],
-            ),
-        [assignments, positions, bank, words],
-    );
-    const passwordValid =
-        password.length >= MIN_PASSWORD_LENGTH && password === confirmPassword;
-
-    // ---- confirm interactions ---------------------------------------------
-    const assignedIds = useMemo(() => new Set(assignments.filter((x) => x !== null)), [assignments]);
-
-    const tapWord = (bankId: number) => {
-        if (assignedIds.has(bankId)) return;
-        const nextEmpty = assignments.indexOf(null);
-        if (nextEmpty === -1) return;
-        const next = [...assignments];
-        next[nextEmpty] = bankId;
-        setAssignments(next);
-    };
-
-    const clearSlot = (slot: number) => {
-        if (assignments[slot] === null) return;
-        const next = [...assignments];
-        next[slot] = null;
-        setAssignments(next);
-    };
-
-    const copyPhrase = async () => {
-        try {
-            await navigator.clipboard.writeText(mnemonic);
-            toast.warning('Recovery phrase copied', {
-                description:
-                    'Clear your clipboard afterwards — anything you copy can be read by other apps.',
-            });
-        } catch {
-            toast.error('Could not copy the recovery phrase');
-        }
-    };
-
-    const handleCreate = async () => {
-        if (!passwordValid || !confirmValid) return;
-        await onSubmit({
-            name: name.trim(),
-            password,
-            mnemonic,
-            mnemonicLength,
-        });
-    };
-
-    const goNext = () => setStep(STEPS[Math.min(stepIndex + 1, STEPS.length - 1)]);
-    const goBack = () => {
-        if (stepIndex === 0) return onCancel();
-        setStep(STEPS[stepIndex - 1]);
-    };
+    const w = useCreateWalletWizard({ onSubmit, onCancel });
 
     return (
         <div className="ob-console">
             <aside className="ob-rail">
                 <div className="ob-label">Sequence</div>
                 <ol className="ob-seq">
-                    {STEPS.map((s, i) => (
-                        <li key={s} className={i === stepIndex ? 'active' : i < stepIndex ? 'done' : ''}>
+                    {WIZARD_STEPS.map((s, i) => (
+                        <li
+                            key={s}
+                            className={i === w.stepIndex ? 'active' : i < w.stepIndex ? 'done' : ''}
+                        >
                             <span className="ob-seq__no">{RAIL[s].no}</span>
                             <span className="ob-seq__t">
                                 {RAIL[s].title}
@@ -197,13 +57,13 @@ export default function OnboardingCreateWallet({
 
             <main className="ob-panel">
                 <div className="ob-strip" aria-hidden>
-                    {STEPS.map((s, i) => (
-                        <span key={s} className={i <= stepIndex ? 'on' : ''} />
+                    {WIZARD_STEPS.map((s, i) => (
+                        <span key={s} className={i <= w.stepIndex ? 'on' : ''} />
                     ))}
                 </div>
 
                 {/* STEP 1 — details */}
-                {step === 'details' && (
+                {w.step === 'details' && (
                     <div>
                         <div className="ob-head ob-head--sm">
                             <span className="ob-label">01 · Identify</span>
@@ -212,18 +72,15 @@ export default function OnboardingCreateWallet({
                         <div className="ob-field">
                             <div className="ob-field__row">
                                 <label className="ob-field__lbl" htmlFor="wallet-name">Wallet name</label>
-                                <button type="button" className="ob-mini" onClick={rollName}>
+                                <button type="button" className="ob-mini" onClick={w.rollName}>
                                     <RefreshCw className="h-3.5 w-3.5" /> Suggest
                                 </button>
                             </div>
                             <input
                                 id="wallet-name"
                                 className="ob-input"
-                                value={name}
-                                onChange={(e) => {
-                                    nameTouched.current = true;
-                                    setName(e.target.value);
-                                }}
+                                value={w.name}
+                                onChange={(e) => w.onNameChange(e.target.value)}
                                 placeholder="Main Wallet"
                                 autoFocus
                                 maxLength={50}
@@ -236,8 +93,8 @@ export default function OnboardingCreateWallet({
                                     <button
                                         key={len}
                                         type="button"
-                                        className={mnemonicLength === len ? 'is-on' : ''}
-                                        onClick={() => setMnemonicLength(len)}
+                                        className={w.mnemonicLength === len ? 'is-on' : ''}
+                                        onClick={() => w.setMnemonicLength(len)}
                                     >
                                         {len} words
                                     </button>
@@ -251,7 +108,7 @@ export default function OnboardingCreateWallet({
                 )}
 
                 {/* STEP 2 — backup / reveal */}
-                {step === 'backup' && (
+                {w.step === 'backup' && (
                     <div>
                         <div className="ob-head ob-head--sm">
                             <span className="ob-label">02 · Recovery key</span>
@@ -263,16 +120,16 @@ export default function OnboardingCreateWallet({
                         </p>
 
                         <div className="ob-seedwrap">
-                            <div className={`ob-seed${revealed ? '' : ' blur'}`}>
-                                {words.map((word, i) => (
+                            <div className={`ob-seed${w.revealed ? '' : ' blur'}`}>
+                                {w.words.map((word, i) => (
                                     <div key={i} className="ob-word">
                                         <i>{i + 1}</i>
                                         <b data-testid="seed-word">{word}</b>
                                     </div>
                                 ))}
                             </div>
-                            {!revealed && (
-                                <button type="button" className="ob-reveal" onClick={() => setRevealed(true)}>
+                            {!w.revealed && (
+                                <button type="button" className="ob-reveal" onClick={() => w.setRevealed(true)}>
                                     <Eye className="h-4 w-4" /> Tap to reveal
                                 </button>
                             )}
@@ -284,15 +141,15 @@ export default function OnboardingCreateWallet({
                             them into a website.
                         </div>
 
-                        {revealed && (
+                        {w.revealed && (
                             <div className="ob-seedbar">
-                                <button type="button" className="ob-mini" onClick={copyPhrase}>
+                                <button type="button" className="ob-mini" onClick={w.copyPhrase}>
                                     <Copy className="h-4 w-4" /> Copy
                                 </button>
                                 <button
                                     type="button"
                                     className="ob-mini ob-mini--muted"
-                                    onClick={() => regenerate(mnemonicLength)}
+                                    onClick={() => w.regenerate(w.mnemonicLength)}
                                 >
                                     <RefreshCw className="h-4 w-4" /> Regenerate
                                 </button>
@@ -302,9 +159,9 @@ export default function OnboardingCreateWallet({
                         <label className="ob-arm">
                             <input
                                 type="checkbox"
-                                checked={writtenDown}
-                                disabled={!revealed}
-                                onChange={(e) => setWrittenDown(e.target.checked)}
+                                checked={w.writtenDown}
+                                disabled={!w.revealed}
+                                onChange={(e) => w.setWrittenDown(e.target.checked)}
                             />
                             <span>I&apos;ve written my recovery phrase down and stored it safely.</span>
                         </label>
@@ -312,7 +169,7 @@ export default function OnboardingCreateWallet({
                 )}
 
                 {/* STEP 3 — confirm */}
-                {step === 'confirm' && (
+                {w.step === 'confirm' && (
                     <div>
                         <div className="ob-head ob-head--sm">
                             <span className="ob-label">03 · Verify</span>
@@ -320,36 +177,36 @@ export default function OnboardingCreateWallet({
                         </div>
                         <p className="ob-lede">
                             Tap the words to fill positions{' '}
-                            <b>{positions.map((p) => `#${p + 1}`).join(', ')}</b>, in order.
+                            <b>{w.positions.map((p) => `#${p + 1}`).join(', ')}</b>, in order.
                         </p>
 
                         <div className="ob-slots">
-                            {positions.map((pos, slot) => {
-                                const bankId = assignments[slot];
+                            {w.positions.map((pos, slot) => {
+                                const bankId = w.assignments[slot];
                                 const filled = bankId !== null;
                                 return (
                                     <button
                                         key={slot}
                                         type="button"
                                         className={`ob-slot${filled ? ' filled' : ''}`}
-                                        onClick={() => clearSlot(slot)}
+                                        onClick={() => w.clearSlot(slot)}
                                     >
                                         <small data-testid="confirm-slot-pos">#{pos + 1}</small>
-                                        <b>{filled ? bank[bankId!].word : '·····'}</b>
+                                        <b>{filled ? w.bank[bankId!].word : '·····'}</b>
                                     </button>
                                 );
                             })}
                         </div>
 
                         <div className="ob-bank">
-                            {bank.map((entry) => {
-                                const used = assignedIds.has(entry.id);
+                            {w.bank.map((entry) => {
+                                const used = w.assignedIds.has(entry.id);
                                 return (
                                     <button
                                         key={entry.id}
                                         type="button"
                                         data-testid="bank-word"
-                                        onClick={() => tapWord(entry.id)}
+                                        onClick={() => w.tapWord(entry.id)}
                                         disabled={used}
                                         className={`ob-bankw${used ? ' used' : ''}`}
                                     >
@@ -359,7 +216,7 @@ export default function OnboardingCreateWallet({
                             })}
                         </div>
 
-                        {assignments.every((a) => a !== null) && !confirmValid && (
+                        {w.assignments.every((a) => a !== null) && !w.confirmValid && (
                             <p className="ob-err">
                                 That order doesn&apos;t match. Tap a slot to clear it and try again.
                             </p>
@@ -368,7 +225,7 @@ export default function OnboardingCreateWallet({
                 )}
 
                 {/* STEP 4 — secure */}
-                {step === 'secure' && (
+                {w.step === 'secure' && (
                     <div>
                         <div className="ob-head ob-head--sm">
                             <span className="ob-label">04 · Seal</span>
@@ -385,9 +242,9 @@ export default function OnboardingCreateWallet({
                                     id="new-password"
                                     className="ob-input"
                                     style={{ paddingRight: 40 }}
-                                    type={showPassword ? 'text' : 'password'}
-                                    value={password}
-                                    onChange={(e) => setPassword(e.target.value)}
+                                    type={w.showPassword ? 'text' : 'password'}
+                                    value={w.password}
+                                    onChange={(e) => w.setPassword(e.target.value)}
                                     placeholder="At least 8 characters"
                                     autoComplete="new-password"
                                     autoFocus
@@ -395,16 +252,16 @@ export default function OnboardingCreateWallet({
                                 <button
                                     type="button"
                                     className="ob-eye"
-                                    onClick={() => setShowPassword((v) => !v)}
-                                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                                    onClick={() => w.setShowPassword((v) => !v)}
+                                    aria-label={w.showPassword ? 'Hide password' : 'Show password'}
                                 >
-                                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                                    {w.showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                                 </button>
                             </div>
                             <div className="mt-2">
                                 <PasswordStrengthChecker
-                                    password={password}
-                                    onStrengthChange={(s) => setStrength(s)}
+                                    password={w.password}
+                                    onStrengthChange={(s) => w.setStrength(s)}
                                     showSuggestions={false}
                                 />
                             </div>
@@ -414,20 +271,22 @@ export default function OnboardingCreateWallet({
                             <input
                                 id="confirm-password"
                                 className="ob-input"
-                                type={showPassword ? 'text' : 'password'}
-                                value={confirmPassword}
-                                onChange={(e) => setConfirmPassword(e.target.value)}
+                                type={w.showPassword ? 'text' : 'password'}
+                                value={w.confirmPassword}
+                                onChange={(e) => w.setConfirmPassword(e.target.value)}
                                 autoComplete="new-password"
                             />
-                            {confirmPassword.length > 0 && password !== confirmPassword && (
+                            {w.confirmPassword.length > 0 && w.password !== w.confirmPassword && (
                                 <p className="ob-err">Passwords don&apos;t match.</p>
                             )}
                         </div>
                         <div className="ob-note">
                             <ShieldCheck className="h-4 w-4" />
                             <span>
-                                Encrypted with scrypt + AES-256-GCM. <b>There&apos;s no reset</b> — if
-                                you lose this password, restore from your recovery phrase.
+                                Encrypted locally with AES-256-GCM using a key derived from your
+                                password with scrypt — your password never leaves this device.{' '}
+                                <b>There&apos;s no reset</b>: if you lose it, restore from your
+                                recovery phrase.
                             </span>
                         </div>
                     </div>
@@ -438,32 +297,32 @@ export default function OnboardingCreateWallet({
                     <button
                         type="button"
                         className="ob-btn ob-btn--ghost"
-                        onClick={goBack}
+                        onClick={w.goBack}
                         disabled={isSubmitting}
                     >
-                        ← {stepIndex === 0 ? 'Setup' : 'Back'}
+                        ← {w.stepIndex === 0 ? 'Setup' : 'Back'}
                     </button>
-                    {step === 'details' && (
-                        <button type="button" className="ob-btn ob-btn--go" onClick={goNext} disabled={!detailsValid}>
+                    {w.step === 'details' && (
+                        <button type="button" className="ob-btn ob-btn--go" onClick={w.goNext} disabled={!w.detailsValid}>
                             Continue →
                         </button>
                     )}
-                    {step === 'backup' && (
-                        <button type="button" className="ob-btn ob-btn--go" onClick={goNext} disabled={!writtenDown}>
+                    {w.step === 'backup' && (
+                        <button type="button" className="ob-btn ob-btn--go" onClick={w.goNext} disabled={!w.writtenDown}>
                             Continue →
                         </button>
                     )}
-                    {step === 'confirm' && (
-                        <button type="button" className="ob-btn ob-btn--go" onClick={goNext} disabled={!confirmValid}>
+                    {w.step === 'confirm' && (
+                        <button type="button" className="ob-btn ob-btn--go" onClick={w.goNext} disabled={!w.confirmValid}>
                             Continue →
                         </button>
                     )}
-                    {step === 'secure' && (
+                    {w.step === 'secure' && (
                         <button
                             type="button"
                             className="ob-btn ob-btn--go"
-                            onClick={handleCreate}
-                            disabled={!passwordValid || isSubmitting}
+                            onClick={w.handleCreate}
+                            disabled={!w.passwordValid || isSubmitting}
                         >
                             {isSubmitting ? 'Creating…' : 'Create wallet'}
                         </button>

--- a/src/components/WalletCreationWizard.tsx
+++ b/src/components/WalletCreationWizard.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import {
+    Eye,
+    EyeOff,
+    Copy,
+    RefreshCw,
+    AlertTriangle,
+    ShieldCheck,
+    ArrowLeft,
+    ArrowRight,
+    Lock,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import PasswordStrengthChecker from '@/components/PasswordStrength';
+import type { WalletCreationData } from '@/components/WalletCreationForm';
+import { useCreateWalletWizard, WIZARD_STEPS, WizardStep } from '@/hooks/useCreateWalletWizard';
+
+interface WalletCreationWizardProps {
+    onSubmit: (data: WalletCreationData) => Promise<void>;
+    onCancel: () => void;
+    isSubmitting: boolean;
+}
+
+const TITLES: Record<WizardStep, { title: string; sub: string }> = {
+    details: { title: 'Create a new wallet', sub: 'A fresh HD wallet, generated and encrypted on this device.' },
+    backup: { title: 'Back up your recovery phrase', sub: 'Write it down before continuing — it can’t be recovered for you.' },
+    confirm: { title: 'Confirm your recovery phrase', sub: 'Prove you saved the backup by re-entering the requested words.' },
+    secure: { title: 'Set a password', sub: 'Encrypts this wallet on your device.' },
+};
+
+/**
+ * Theme-aware skin of the guided create-wallet wizard, used inside Settings → Wallet Management.
+ * Shares all logic with the onboarding wizard via useCreateWalletWizard; only the presentation
+ * differs (it follows the app's light/dark theme rather than the committed-dark instrument look).
+ */
+export default function WalletCreationWizard({
+    onSubmit,
+    onCancel,
+    isSubmitting,
+}: WalletCreationWizardProps) {
+    const w = useCreateWalletWizard({ onSubmit, onCancel });
+    const title = TITLES[w.step];
+
+    return (
+        <div>
+            {/* header */}
+            <div className="mb-4 flex items-start justify-between gap-4">
+                <div>
+                    <h3 className="text-xl font-semibold text-foreground">{title.title}</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">{title.sub}</p>
+                </div>
+                <span className="flex-none whitespace-nowrap rounded-full border border-border bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                    Step {w.stepIndex + 1} of 4
+                </span>
+            </div>
+
+            {/* progress */}
+            <div className="mb-6 flex gap-1.5" aria-hidden>
+                {WIZARD_STEPS.map((s, i) => (
+                    <span
+                        key={s}
+                        className={`h-1 flex-1 rounded-full transition-colors ${i <= w.stepIndex ? 'bg-primary' : 'bg-muted'}`}
+                    />
+                ))}
+            </div>
+
+            {/* STEP 1 — details */}
+            {w.step === 'details' && (
+                <div className="space-y-5">
+                    <div>
+                        <div className="mb-2 flex items-center justify-between">
+                            <Label htmlFor="wcw-name">Wallet name</Label>
+                            <button
+                                type="button"
+                                onClick={w.rollName}
+                                className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:opacity-80"
+                            >
+                                <RefreshCw className="h-3.5 w-3.5" /> Suggest
+                            </button>
+                        </div>
+                        <Input
+                            id="wcw-name"
+                            value={w.name}
+                            onChange={(e) => w.onNameChange(e.target.value)}
+                            placeholder="Main Wallet"
+                            maxLength={50}
+                            autoFocus
+                        />
+                        <p className="mt-1.5 text-xs text-muted-foreground">
+                            Creative bird-themed name — keep it or customize your own.
+                        </p>
+                    </div>
+                    <div>
+                        <Label className="mb-2 block">Recovery phrase length</Label>
+                        <div className="flex gap-1.5 rounded-lg border border-input bg-background p-1">
+                            {(['12', '24'] as const).map((len) => (
+                                <button
+                                    key={len}
+                                    type="button"
+                                    onClick={() => w.setMnemonicLength(len)}
+                                    className={`flex-1 rounded-md py-2 text-sm font-medium transition-colors ${
+                                        w.mnemonicLength === len
+                                            ? 'bg-primary/15 text-primary'
+                                            : 'text-muted-foreground hover:text-foreground'
+                                    }`}
+                                >
+                                    {len} words
+                                </button>
+                            ))}
+                        </div>
+                        <p className="mt-1.5 text-xs text-muted-foreground">
+                            Both are secure. 24 words adds margin; 12 is easier to write down.
+                        </p>
+                    </div>
+                </div>
+            )}
+
+            {/* STEP 2 — backup / reveal */}
+            {w.step === 'backup' && (
+                <div className="space-y-4">
+                    <p className="text-sm text-muted-foreground">
+                        Write these {w.words.length} words down in order and keep them offline. This
+                        phrase is the only way to restore the wallet — it can&apos;t be recovered for you.
+                    </p>
+
+                    <div className="relative">
+                        <div
+                            className={`grid grid-cols-2 gap-2 sm:grid-cols-3 ${w.revealed ? '' : 'select-none blur-sm'}`}
+                        >
+                            {w.words.map((word, i) => (
+                                <div
+                                    key={i}
+                                    className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2"
+                                >
+                                    <span className="w-5 text-right font-mono text-xs text-muted-foreground">
+                                        {i + 1}
+                                    </span>
+                                    <span className="font-mono text-sm" data-testid="seed-word">
+                                        {word}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                        {!w.revealed && (
+                            <button
+                                type="button"
+                                onClick={() => w.setRevealed(true)}
+                                className="absolute inset-0 grid place-items-center"
+                            >
+                                <span className="flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium shadow-sm">
+                                    <Eye className="h-4 w-4 text-primary" /> Tap to reveal
+                                </span>
+                            </button>
+                        )}
+                    </div>
+
+                    <div className="flex items-start gap-2.5 rounded-lg border border-caution/30 bg-caution/10 p-3 text-sm">
+                        <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-caution" />
+                        <span>
+                            Anyone with these words owns the funds. Never share them, and never type
+                            them into a website.
+                        </span>
+                    </div>
+
+                    {w.revealed && (
+                        <div className="flex items-center justify-between">
+                            <Button variant="ghost" size="sm" onClick={w.copyPhrase} className="gap-2">
+                                <Copy className="h-4 w-4" /> Copy
+                            </Button>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => w.regenerate(w.mnemonicLength)}
+                                className="gap-2 text-muted-foreground"
+                            >
+                                <RefreshCw className="h-4 w-4" /> Regenerate
+                            </Button>
+                        </div>
+                    )}
+
+                    <label className="flex cursor-pointer items-center gap-2.5 text-sm">
+                        <input
+                            type="checkbox"
+                            checked={w.writtenDown}
+                            disabled={!w.revealed}
+                            onChange={(e) => w.setWrittenDown(e.target.checked)}
+                            className="h-4 w-4 accent-[hsl(var(--primary))] disabled:opacity-50"
+                        />
+                        <span className={w.revealed ? '' : 'text-muted-foreground'}>
+                            I&apos;ve written my recovery phrase down and stored it safely.
+                        </span>
+                    </label>
+                </div>
+            )}
+
+            {/* STEP 3 — confirm */}
+            {w.step === 'confirm' && (
+                <div className="space-y-4">
+                    <p className="text-sm text-muted-foreground">
+                        Tap the words to fill positions{' '}
+                        <span className="font-medium text-foreground">
+                            {w.positions.map((p) => `#${p + 1}`).join(', ')}
+                        </span>{' '}
+                        in order, to confirm your backup.
+                    </p>
+
+                    <div className="flex gap-2">
+                        {w.positions.map((pos, slot) => {
+                            const bankId = w.assignments[slot];
+                            const filled = bankId !== null;
+                            return (
+                                <button
+                                    key={slot}
+                                    type="button"
+                                    onClick={() => w.clearSlot(slot)}
+                                    className={`flex-1 rounded-lg border px-2 py-2.5 text-center transition-colors ${
+                                        filled ? 'border-primary bg-primary/10' : 'border-dashed border-border'
+                                    }`}
+                                >
+                                    <span className="block text-[0.6rem] text-muted-foreground" data-testid="confirm-slot-pos">
+                                        #{pos + 1}
+                                    </span>
+                                    <span className="font-mono text-sm">
+                                        {filled ? w.bank[bankId!].word : '·····'}
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                        {w.bank.map((entry) => {
+                            const used = w.assignedIds.has(entry.id);
+                            return (
+                                <button
+                                    key={entry.id}
+                                    type="button"
+                                    data-testid="bank-word"
+                                    onClick={() => w.tapWord(entry.id)}
+                                    disabled={used}
+                                    className={`rounded-md border px-3 py-1.5 font-mono text-sm transition-colors ${
+                                        used
+                                            ? 'border-border bg-muted/40 text-muted-foreground opacity-50'
+                                            : 'border-border hover:border-primary hover:text-primary'
+                                    }`}
+                                >
+                                    {entry.word}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    {w.assignments.every((a) => a !== null) && !w.confirmValid && (
+                        <p className="text-sm text-destructive">
+                            That order doesn&apos;t match. Tap a slot to clear it and try again.
+                        </p>
+                    )}
+                </div>
+            )}
+
+            {/* STEP 4 — secure */}
+            {w.step === 'secure' && (
+                <div className="space-y-4">
+                    <p className="text-sm text-muted-foreground">
+                        This password encrypts the wallet on this device. You&apos;ll enter it to unlock
+                        and to authorise signatures.
+                    </p>
+                    <div className="space-y-2">
+                        <Label htmlFor="wcw-password">Password</Label>
+                        <div className="relative">
+                            <Input
+                                id="wcw-password"
+                                type={w.showPassword ? 'text' : 'password'}
+                                value={w.password}
+                                onChange={(e) => w.setPassword(e.target.value)}
+                                placeholder="At least 8 characters"
+                                autoComplete="new-password"
+                                className="pr-10"
+                                autoFocus
+                            />
+                            <button
+                                type="button"
+                                onClick={() => w.setShowPassword((v) => !v)}
+                                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                                aria-label={w.showPassword ? 'Hide password' : 'Show password'}
+                            >
+                                {w.showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                            </button>
+                        </div>
+                        <PasswordStrengthChecker
+                            password={w.password}
+                            onStrengthChange={(s) => w.setStrength(s)}
+                            showSuggestions={false}
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="wcw-confirm">Confirm password</Label>
+                        <Input
+                            id="wcw-confirm"
+                            type={w.showPassword ? 'text' : 'password'}
+                            value={w.confirmPassword}
+                            onChange={(e) => w.setConfirmPassword(e.target.value)}
+                            autoComplete="new-password"
+                        />
+                        {w.confirmPassword.length > 0 && w.password !== w.confirmPassword && (
+                            <p className="text-xs text-destructive">Passwords don&apos;t match.</p>
+                        )}
+                    </div>
+                    <div className="flex items-start gap-2.5 rounded-lg border border-primary/25 bg-primary/5 p-3 text-sm">
+                        <ShieldCheck className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
+                        <span>
+                            Encrypted locally with AES-256-GCM using a key derived from your password
+                            with scrypt — your password never leaves this device.{' '}
+                            <b className="text-primary">There&apos;s no reset</b>: if you lose it,
+                            restore from your recovery phrase.
+                        </span>
+                    </div>
+                </div>
+            )}
+
+            {/* nav */}
+            <div className="mt-6 flex gap-2 border-t border-border pt-5">
+                <Button variant="ghost" onClick={w.goBack} disabled={isSubmitting} className="gap-2">
+                    <ArrowLeft className="h-4 w-4" /> {w.stepIndex === 0 ? 'Cancel' : 'Back'}
+                </Button>
+                {w.step === 'details' && (
+                    <Button onClick={w.goNext} disabled={!w.detailsValid} className="ml-auto gap-2">
+                        Continue <ArrowRight className="h-4 w-4" />
+                    </Button>
+                )}
+                {w.step === 'backup' && (
+                    <Button onClick={w.goNext} disabled={!w.writtenDown} className="ml-auto gap-2">
+                        Continue <ArrowRight className="h-4 w-4" />
+                    </Button>
+                )}
+                {w.step === 'confirm' && (
+                    <Button onClick={w.goNext} disabled={!w.confirmValid} className="ml-auto gap-2">
+                        Continue <ArrowRight className="h-4 w-4" />
+                    </Button>
+                )}
+                {w.step === 'secure' && (
+                    <Button
+                        onClick={w.handleCreate}
+                        disabled={!w.passwordValid || isSubmitting}
+                        className="ml-auto gap-2"
+                    >
+                        <Lock className="h-4 w-4" />
+                        {isSubmitting ? 'Creating…' : 'Create wallet'}
+                    </Button>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/WalletManager.tsx
+++ b/src/components/WalletManager.tsx
@@ -21,6 +21,7 @@ import {
   Edit2,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import WalletCreationWizard from '@/components/WalletCreationWizard';
 import WalletCreationForm, {
   WalletCreationMode,
   WalletCreationData,
@@ -816,22 +817,22 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
           </TabsContent>
 
           <TabsContent value="create" className="mt-4">
-            <WalletCreationForm
-              mode="create"
+            <WalletCreationWizard
               onSubmit={async (data) => {
                 try {
                   setIsCreating(true);
 
-                  // Use WalletService to create a proper wallet with real keys
+                  // Use WalletService to create a proper wallet with real keys. The wizard has the
+                  // user confirm their phrase, so create from that exact mnemonic (not a fresh one).
                   const { WalletService } = await import('@/services/wallet/WalletService');
                   const walletService = new WalletService();
 
                   const newWallet = await walletService.createNewWallet({
-                    name: data.name,
+                    name: data.name.trim(),
                     password: data.password,
                     useMnemonic: true,
+                    mnemonic: data.mnemonic,
                     passphrase: data.passphrase, // Pass the optional BIP39 passphrase
-                    mnemonicLength: data.mnemonicLength === '24' ? 256 : 128, // Convert to entropy bits
                     makeActive: true,
                   });
 

--- a/src/hooks/useCreateWalletWizard.ts
+++ b/src/hooks/useCreateWalletWizard.ts
@@ -1,0 +1,227 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import * as bip39 from 'bip39';
+import { toast } from 'sonner';
+import type { WalletCreationData } from '@/components/WalletCreationForm';
+import type { PasswordStrength } from '@/components/PasswordStrength';
+import { generateWalletName } from '@/lib/walletName';
+
+/**
+ * Headless logic for the guided create-wallet wizard, shared by two skins:
+ *  - OnboardingCreateWallet (committed-dark "instrument" look, first-run onboarding), and
+ *  - WalletCreationWizard (theme-aware, inside Settings → Wallet Management).
+ *
+ * The steps and their guarantees — reveal the phrase, then tap-to-confirm it, then set a password —
+ * live here so both surfaces behave identically. A wallet is always created from the exact mnemonic
+ * the user confirmed.
+ */
+
+export type WizardStep = 'details' | 'backup' | 'confirm' | 'secure';
+export const WIZARD_STEPS: WizardStep[] = ['details', 'backup', 'confirm', 'secure'];
+
+const MIN_PASSWORD_LENGTH = 8;
+const CONFIRM_COUNT = 3;
+
+// Fisher–Yates shuffle (app runtime; deterministic randomness not required here).
+function shuffle<T>(arr: T[]): T[] {
+    const a = [...arr];
+    for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+}
+
+// Pick `count` distinct indices from [0, length).
+function pickPositions(length: number, count: number): number[] {
+    const idx = shuffle(Array.from({ length }, (_, i) => i)).slice(0, count);
+    return idx.sort((a, b) => a - b);
+}
+
+interface UseCreateWalletWizardParams {
+    onSubmit: (data: WalletCreationData) => Promise<void>;
+    onCancel: () => void;
+}
+
+export function useCreateWalletWizard({ onSubmit, onCancel }: UseCreateWalletWizardParams) {
+    const [step, setStep] = useState<WizardStep>('details');
+
+    // details
+    const [name, setName] = useState('');
+    const [mnemonicLength, setMnemonicLength] = useState<'12' | '24'>('12');
+
+    // backup
+    const [mnemonic, setMnemonic] = useState('');
+    const [revealed, setRevealed] = useState(false);
+    const [writtenDown, setWrittenDown] = useState(false);
+
+    // confirm
+    const [positions, setPositions] = useState<number[]>([]);
+    // slot -> bank entry id (index into `bank`), or null
+    const [assignments, setAssignments] = useState<(number | null)[]>([]);
+
+    // secure
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
+    const [strength, setStrength] = useState<PasswordStrength>(null);
+
+    const words = useMemo(() => (mnemonic ? mnemonic.trim().split(/\s+/) : []), [mnemonic]);
+
+    // Word bank for the confirm step: every mnemonic word, shuffled, then given an id equal to its
+    // position in the shuffled array — so `bank[id]` resolves to the same entry the button rendered.
+    const bank = useMemo(
+        () => shuffle(words).map((word, id) => ({ id, word })),
+        // Re-shuffle only when the mnemonic itself changes.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [mnemonic],
+    );
+
+    const regenerate = useCallback((length: '12' | '24') => {
+        const entropyBits = length === '24' ? 256 : 128;
+        const next = bip39.generateMnemonic(entropyBits);
+        setMnemonic(next);
+        setRevealed(false);
+        setWrittenDown(false);
+        const wordCount = length === '24' ? 24 : 12;
+        setPositions(pickPositions(wordCount, CONFIRM_COUNT));
+        setAssignments(Array(CONFIRM_COUNT).fill(null));
+    }, []);
+
+    // Generate on mount and whenever the requested length changes.
+    useEffect(() => {
+        regenerate(mnemonicLength);
+    }, [mnemonicLength, regenerate]);
+
+    // Suggest a creative bird-themed name on mount; the user can keep it, edit it, or re-roll.
+    // Guard against the async suggestion landing after the user has already typed something.
+    const nameTouched = useRef(false);
+    useEffect(() => {
+        generateWalletName().then((suggested) => {
+            if (!nameTouched.current) setName(suggested);
+        });
+    }, []);
+
+    const rollName = useCallback(async () => {
+        setName(await generateWalletName());
+    }, []);
+
+    const onNameChange = useCallback((value: string) => {
+        nameTouched.current = true;
+        setName(value);
+    }, []);
+
+    const stepIndex = WIZARD_STEPS.indexOf(step);
+
+    // ---- validation --------------------------------------------------------
+    const detailsValid = name.trim().length > 0;
+    const confirmValid = useMemo(
+        () =>
+            assignments.length === positions.length &&
+            assignments.every(
+                (bankId, slot) => bankId !== null && bank[bankId]?.word === words[positions[slot]],
+            ),
+        [assignments, positions, bank, words],
+    );
+    const passwordValid = password.length >= MIN_PASSWORD_LENGTH && password === confirmPassword;
+
+    // ---- confirm interactions ---------------------------------------------
+    const assignedIds = useMemo(() => new Set(assignments.filter((x) => x !== null)), [assignments]);
+
+    const tapWord = useCallback(
+        (bankId: number) => {
+            if (assignedIds.has(bankId)) return;
+            const nextEmpty = assignments.indexOf(null);
+            if (nextEmpty === -1) return;
+            const next = [...assignments];
+            next[nextEmpty] = bankId;
+            setAssignments(next);
+        },
+        [assignedIds, assignments],
+    );
+
+    const clearSlot = useCallback(
+        (slot: number) => {
+            if (assignments[slot] === null) return;
+            const next = [...assignments];
+            next[slot] = null;
+            setAssignments(next);
+        },
+        [assignments],
+    );
+
+    const copyPhrase = useCallback(async () => {
+        try {
+            await navigator.clipboard.writeText(mnemonic);
+            toast.warning('Recovery phrase copied', {
+                description:
+                    'Clear your clipboard afterwards — anything you copy can be read by other apps.',
+            });
+        } catch {
+            toast.error('Could not copy the recovery phrase');
+        }
+    }, [mnemonic]);
+
+    const handleCreate = useCallback(async () => {
+        if (!passwordValid || !confirmValid) return;
+        await onSubmit({
+            name: name.trim(),
+            password,
+            mnemonic,
+            mnemonicLength,
+        });
+    }, [passwordValid, confirmValid, onSubmit, name, password, mnemonic, mnemonicLength]);
+
+    const goNext = useCallback(
+        () => setStep(WIZARD_STEPS[Math.min(stepIndex + 1, WIZARD_STEPS.length - 1)]),
+        [stepIndex],
+    );
+    const goBack = useCallback(() => {
+        if (stepIndex === 0) return onCancel();
+        setStep(WIZARD_STEPS[stepIndex - 1]);
+    }, [stepIndex, onCancel]);
+
+    return {
+        // step
+        step,
+        stepIndex,
+        // details
+        name,
+        onNameChange,
+        rollName,
+        mnemonicLength,
+        setMnemonicLength,
+        // backup
+        words,
+        revealed,
+        setRevealed,
+        writtenDown,
+        setWrittenDown,
+        regenerate,
+        copyPhrase,
+        // confirm
+        positions,
+        assignments,
+        bank,
+        assignedIds,
+        tapWord,
+        clearSlot,
+        confirmValid,
+        // secure
+        password,
+        setPassword,
+        confirmPassword,
+        setConfirmPassword,
+        showPassword,
+        setShowPassword,
+        strength,
+        setStrength,
+        // validation + nav
+        detailsValid,
+        passwordValid,
+        goNext,
+        goBack,
+        handleCreate,
+    };
+}


### PR DESCRIPTION
Wallet Management's **Create** tab used a separate, simpler form that *showed* the recovery phrase but never made the user confirm it. This unifies both surfaces on one guided wizard, so adding a wallet gets the same **confirm-your-phrase gate** as onboarding — and removes the duplicate create flow.

Approved from a prototype ([light/dark](https://claude.ai/code/artifact/131767b4-ff48-40dd-9149-0b0b052fd05c)).

### Architecture
- **`useCreateWalletWizard`** — a headless hook holding all the logic (steps, mnemonic generation, reveal, tap-to-confirm, password, validation). One source of truth for both surfaces.
- **`OnboardingCreateWallet`** — now a thin **instrument-skinned** (committed-dark) view over the hook.
- **`WalletCreationWizard`** — new **theme-aware** skin (follows the app's light/dark), used in Wallet Management.
- **WalletManager** create tab swapped to the new wizard; it now creates from the **exact confirmed mnemonic** (the old path generated a *fresh* one on submit, so the displayed phrase didn't match the wallet). Import tabs untouched.
- Reworded the password security note to be precise about the mechanism (AES-256-GCM with a scrypt-derived key; password never leaves the device).
- Version **2.4.0 → 2.4.1**.

### Tests
The onboarding E2E drives the shared hook end to end (reveal → confirm → wrong-confirm → create), so the wizard logic is covered through the refactor; the same testids/labels are preserved in both skins.

✅ typecheck · ✅ build (static export) · ✅ 33 E2E