### PR TITLE
feat(security): harden scrypt KDF with a versioned, self-describing format

### DIFF
--- a/docs/proposals/scrypt-kdf-hardening.md
+++ b/docs/proposals/scrypt-kdf-hardening.md
@@ -1,0 +1,108 @@
+# Proposal: scrypt KDF hardening + versioned encryption format
+
+- **Status:** proposed (2026-08-12)
+- **Area:** `src/services/wallet/encryption.ts` and its call sites (WalletService, SecurityService, StorageService, BackupService)
+- **Risk:** high — touches at-rest encryption of every private key, mnemonic, and the biometric-stored password. Must never lock an existing user out.
+
+## Problem
+
+At-rest encryption derives its key with scrypt using hardcoded work factors:
+
+```ts
+// src/services/wallet/encryption.ts
+const SCRYPT = { N: 16384, r: 8, p: 1, dkLen: 32 } as const;
+```
+
+`N=16384, r=8` needs ~16 MB and derives in well under 100 ms on a normal desktop. That is the low/interactive setting. For a wallet whose ciphertext an attacker can steal (it lives in IndexedDB and in exported backups), it makes offline brute-forcing of weak passwords far cheaper than it should be.
+
+Two things make this more than a one-line change:
+
+1. **The parameters are not stored with the ciphertext.** The blob is `salt(64) ‖ iv(16) ‖ tag(16) ‖ ciphertext`, hex-encoded, and `SCRYPT` is a single constant shared by `secureEncrypt` and `secureDecrypt`. Raising `N` in place makes every existing wallet undecryptable — decryption would derive a different key than the one the data was sealed with.
+2. **There are three coexisting formats already.** Current (scrypt + AES-256-GCM, authenticated), legacy (CryptoJS AES-CBC, unauthenticated — see `decryptData`), and now we want a fourth: hardened scrypt. Whatever we add has to slot into `decryptData`'s existing fallback chain without weakening the authentication guarantees.
+
+## Goals
+
+- Tune scrypt so a normal unlock takes **~250–750 ms** on typical desktop and mobile hardware, benchmarked (not guessed) — the memory requirement is expected to be the limiting factor, especially on mobile and under `scrypt-js`.
+- **Never break an existing wallet.** Old ciphertext (N=16384 and legacy CryptoJS) must keep decrypting forever.
+- **Transparent upgrade.** A wallet sealed with the old factors is re-sealed with the new profile the next time it is unlocked, with no user action.
+- No new dependency; keep AES-256-GCM (authenticated) as the cipher.
+
+## Non-goals
+
+- Changing the cipher, the HD derivation, or the signing path.
+- Migrating backups in place (a backup is sealed with a password at export time; new exports simply use the new profile — see below).
+- Argon2 or a WASM KDF. Worth a look later, but out of scope; this proposal stays on `scrypt-js` to avoid a new binary in the bundle.
+
+## Design
+
+### 1. Self-describing, versioned blob
+
+New ciphertext records the KDF profile it was sealed with, so decryption never has to guess. Sketch:
+
+```
+v2.<base64url(json header)>.<base64url(salt ‖ iv ‖ tag ‖ ciphertext)>
+```
+
+where the header is `{ "kdf": "scrypt", "N": <n>, "r": <r>, "p": <p>, "dkLen": 32 }` (or a short `profile` id that maps to a table — TBD in "Open questions").
+
+The `v2.` prefix and the `.` separators make the new format **unambiguously distinguishable** from the two existing ones: the current format is pure lowercase hex (even length, `[0-9a-f]` only) and the legacy CryptoJS format is its own base64 blob that does not start with `v2.`. So detection is a cheap string check, not a decrypt-and-see.
+
+### 2. Decrypt dispatch
+
+`decryptData` gains one branch at the front of its existing chain:
+
+1. **`v2.` prefix** → parse header, derive with the header's params, AES-GCM decrypt. Authenticated: wrong password throws.
+2. **all-hex** → current v1 path (`N=16384`). Authenticated.
+3. **otherwise** → legacy CryptoJS path. **Unauthenticated** — the existing `wasLegacy: true` contract still applies (callers must validate against `isValidWIF` / `bip39.validateMnemonic`).
+
+`secureEncrypt` always writes v2 with the chosen profile. `secureDecrypt` stays as the v1 primitive used internally where the format is known.
+
+### 3. Choosing the parameters (benchmark, don't guess)
+
+scrypt memory ≈ `128 · N · r` bytes:
+
+| N | r | memory | note |
+|---|---|--------|------|
+| 16384 (2¹⁴) | 8 | 16 MB | today — too weak |
+| 65536 (2¹⁶) | 8 | 64 MB | likely candidate |
+| 131072 (2¹⁷) | 8 | 128 MB | risks OOM on mobile / scrypt-js |
+
+Plan: add a small benchmark harness (dev-only script) that times derivation for a few `(N, r)` pairs and pick the highest that stays under ~750 ms **and** within a safe mobile memory budget on real devices (desktop Chrome, a mid-range Android, iOS Safari). The chosen profile is recorded as a constant `SCRYPT_V2` and written into every new blob's header, so a *future* bump is just another profile — the format won't need to change again.
+
+### 4. Transparent migration
+
+There is already a re-encrypt-on-unlock path for the legacy→modern upgrade (e.g. `SecurityService` ~L796: after `decryptData` returns `wasLegacy`, it calls `secureEncrypt` and persists). Extend the same idea:
+
+- `decryptData` also reports the format it read (e.g. `format: 'v2' | 'v1' | 'legacy'`).
+- On a successful unlock, if the stored blob is `v1` **or** `legacy`, re-`secureEncrypt` (now v2) and persist — for the wallet's `privateKey`, its `mnemonic`, and the biometric-stored password (`StorageService` ~L2054).
+- Idempotent: a `v2` blob is left alone.
+
+Backups: `BackupService.exportBackup` uses `secureEncrypt`, so new exports are v2 automatically; `parseBackupFile` uses `decryptData`, so it still imports v1 and legacy backups. No in-place backup migration needed.
+
+## Testing
+
+- **Golden vectors:** keep the existing v1 and legacy decrypt vectors (they prove backward compatibility) and add v2 encrypt/decrypt vectors. The unit suite pins fixed ciphertext — the v1/legacy vectors must continue to pass unchanged.
+- **Round-trip + migration tests:** seal with v1 → `decryptData` reports `v1` → re-seal → now `v2` and still decrypts to the same plaintext.
+- **Benchmark harness:** dev-only, not in CI (timing is machine-dependent), but recorded results justify the chosen profile in the PR.
+- E2E is unaffected (it drives the UI, not the KDF), though create/unlock will be measurably slower — the fixtures already allow generous timeouts for scrypt.
+
+## Risks
+
+- **Mobile memory ceiling.** The main risk. `scrypt-js` allocates the full `128·N·r` buffer in JS; too large and low-end phones OOM or jank. Mitigated by benchmarking and picking a conservative profile; `p` stays 1.
+- **Unlock latency.** 250–750 ms is intentional and applies to every unlock and every sign that needs the key. Acceptable for a wallet; the UI already shows a spinner.
+- **Partial migration.** A wallet re-encrypts only when unlocked; a wallet that is never opened stays v1 (still fully decryptable). That is fine — no data is stranded.
+- **The biometric password blob** must be migrated too, or biometric unlock keeps a v1 blob around indefinitely. Included above.
+
+## Rollout
+
+1. Land the versioned format + dispatch + v1/legacy back-compat (no behaviour change yet — new writes are v2, old reads still work).
+2. Benchmark and set `SCRYPT_V2`.
+3. Turn on re-encrypt-on-unlock for v1/legacy blobs.
+4. Ship; wallets upgrade themselves as people open them.
+
+## Open questions
+
+1. **Header: explicit params vs. profile id.** Storing `{N,r,p}` is self-contained and future-proof; a `profile` id is smaller but needs a lookup table shipped with the app. Lean explicit params.
+2. **Encoding.** `v2.<b64url>.<b64url>` vs. a binary header with a magic byte then hex. The string form is easy to eyeball and unambiguous; the binary form is more compact. Lean the string form.
+3. **Target profile.** Pending the benchmark, but `N=65536, r=8` (64 MB) is the leading candidate for a desktop+mobile PWA.
+4. **Should exported backups force v2 immediately, or offer the old profile for interop with older app versions?** Lean force-v2 (a backup is only ever restored by this app, which will understand all formats).

--- a/e2e/avian-connect-permissions.spec.ts
+++ b/e2e/avian-connect-permissions.spec.ts
@@ -98,7 +98,11 @@ test.describe('acceptance: the signature verifies in Message Utilities', () => {
     await walletPage.getByRole('button', { name: 'signMessage()', exact: true }).click();
     await approvalDialog(popup).getByRole('button', { name: 'Sign', exact: true }).click();
     await authenticate(popup);
-    await expect(walletPage.getByTestId('demo-verification')).toHaveAttribute('data-valid', 'true');
+    // Signing decrypts the key with scrypt (hardened to ~64 MB), which is deliberately slow and
+    // slower still under parallel e2e workers — give it headroom beyond the default expect timeout.
+    await expect(walletPage.getByTestId('demo-verification')).toHaveAttribute('data-valid', 'true', {
+      timeout: 30_000,
+    });
 
     // Take the full signature from the demo's own session, the way a user would copy it.
     const signature = await walletPage.evaluate(
@@ -128,7 +132,11 @@ test.describe('acceptance: the signature verifies in Message Utilities', () => {
     await walletPage.getByRole('button', { name: 'signMessage()', exact: true }).click();
     await approvalDialog(popup).getByRole('button', { name: 'Sign', exact: true }).click();
     await authenticate(popup);
-    await expect(walletPage.getByTestId('demo-verification')).toHaveAttribute('data-valid', 'true');
+    // Signing decrypts the key with scrypt (hardened to ~64 MB), which is deliberately slow and
+    // slower still under parallel e2e workers — give it headroom beyond the default expect timeout.
+    await expect(walletPage.getByTestId('demo-verification')).toHaveAttribute('data-valid', 'true', {
+      timeout: 30_000,
+    });
 
     const signature = await walletPage.evaluate(
       () => JSON.parse(sessionStorage.getItem('avian-connect-demo') || '{}').signature as string,

--- a/scripts/bench-scrypt.cjs
+++ b/scripts/bench-scrypt.cjs
@@ -1,0 +1,69 @@
+/**
+ * Dev-only benchmark for choosing the scrypt work factors used by at-rest encryption
+ * (see docs/proposals/scrypt-kdf-hardening.md and src/services/wallet/encryption.ts).
+ *
+ * Times key derivation for a few candidate (N, r) profiles and prints the wall-clock time and the
+ * memory each needs (≈ 128 · N · r bytes). Pick the highest profile that stays roughly in the
+ * 250–750 ms band AND within a safe memory budget on your *slowest* target device.
+ *
+ * This measures only the machine it runs on. Desktop Node is a rough upper bound on speed; a
+ * phone will be slower and its memory ceiling is the real constraint — validate there too (e.g. by
+ * temporarily logging derivation time from the running PWA on a real handset).
+ *
+ *   node scripts/bench-scrypt.cjs            # default password length
+ *   node scripts/bench-scrypt.cjs "some password"
+ */
+
+const { scrypt } = require('scrypt-js');
+const { randomBytes } = require('crypto');
+
+const PROFILES = [
+  { N: 16384, r: 8, p: 1 }, // current v1 — too weak, shown for reference
+  { N: 32768, r: 8, p: 1 },
+  { N: 65536, r: 8, p: 1 }, // current v2 candidate
+  { N: 131072, r: 8, p: 1 },
+];
+
+const DK_LEN = 32;
+const RUNS = 5;
+
+function memoryMB(N, r) {
+  return (128 * N * r) / (1024 * 1024);
+}
+
+async function timeOne(password, N, r, p) {
+  const salt = randomBytes(64);
+  const pw = Buffer.from(password, 'utf-8');
+  const start = process.hrtime.bigint();
+  await scrypt(pw, salt, N, r, p, DK_LEN);
+  const end = process.hrtime.bigint();
+  return Number(end - start) / 1e6; // ms
+}
+
+async function main() {
+  const password = process.argv[2] || 'a-fairly-typical-user-password-123';
+  console.log(`\nscrypt derivation benchmark — password length ${password.length}, ${RUNS} runs each\n`);
+  console.log('  N        r   p   memory     median      min      max');
+  console.log('  ' + '-'.repeat(58));
+
+  for (const { N, r, p } of PROFILES) {
+    const times = [];
+    for (let i = 0; i < RUNS; i++) {
+      times.push(await timeOne(password, N, r, p));
+    }
+    times.sort((a, b) => a - b);
+    const median = times[Math.floor(times.length / 2)];
+    const fmt = (n) => `${n.toFixed(0).padStart(6)} ms`;
+    console.log(
+      `  ${String(N).padStart(7)}  ${r}   ${p}   ${memoryMB(N, r).toFixed(0).padStart(4)} MB   ` +
+        `${fmt(median)}  ${fmt(times[0])}  ${fmt(times[times.length - 1])}`,
+    );
+  }
+
+  console.log('\nTarget: highest profile with median ~250–750 ms and memory your slowest device tolerates.\n');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/services/core/SecurityService.test.ts
+++ b/src/services/core/SecurityService.test.ts
@@ -190,8 +190,8 @@ describe('unlocking a wallet still on the legacy encryption format', () => {
     expect(await securityService.unlockWallet(TEST_PASSWORD)).toBe(true);
 
     const stored = await StorageService.getWalletById(created.id!);
-    // Upgraded blobs are scrypt/AES-GCM hex, not CryptoJS base64.
-    expect(stored?.privateKey).toMatch(/^[0-9a-f]+$/);
+    // Upgraded blobs are the current versioned scrypt/AES-GCM format, not CryptoJS base64.
+    expect(stored?.privateKey).toMatch(/^v2\./);
     expect((await decryptData(stored!.privateKey, TEST_PASSWORD)).decrypted).toBe(WIF);
   });
 

--- a/src/services/core/SecurityService.ts
+++ b/src/services/core/SecurityService.ts
@@ -13,7 +13,7 @@ import { StorageService } from './StorageService';
 // lock screen — does not pull the secp256k1 build. The elliptic-curve validation it needs on the
 // legacy-upgrade path is loaded lazily via initializeCrypto() below, and bip39 lazily at its one
 // use site, so neither is in the initial bundle.
-import { secureEncrypt, decryptData, legacyDecrypt } from '../wallet/encryption';
+import { secureEncrypt, decryptData } from '../wallet/encryption';
 import { securityLogger } from '@/lib/Logger';
 import { isBrowser } from '@/lib/utils';
 
@@ -765,7 +765,7 @@ export class SecurityService {
 
         try {
           // Validate password by attempting to decrypt the private key
-          const { decrypted, wasLegacy } = await decryptData(activeWallet.privateKey, password);
+          const { decrypted, format } = await decryptData(activeWallet.privateKey, password);
 
           // The legacy format carries no authentication tag, so a wrong password does not
           // reliably fail — it can decrypt to plausible-looking rubbish. Checking that the
@@ -790,8 +790,10 @@ export class SecurityService {
             throw new Error('Decrypted value is not a valid private key, password incorrect.');
           }
 
-          // If the key was using legacy encryption, upgrade it now.
-          if (wasLegacy) {
+          // Upgrade the stored ciphertext to the current (v2) KDF profile if it isn't already —
+          // this covers both the old interactive-scrypt (v1) format and the unauthenticated legacy
+          // format. The key was just validated as a real WIF, so re-encrypting it is safe.
+          if (format !== 'v2') {
             securityLogger.info(`Upgrading encryption for wallet: ${activeWallet.name}`);
             const newEncryptedKey = await secureEncrypt(decrypted, password);
 
@@ -799,8 +801,11 @@ export class SecurityService {
             // Also upgrade the mnemonic if it exists
             if (activeWallet.mnemonic) {
               try {
-                // We can use the legacy decrypt directly since we know it's an old format
-                const decryptedMnemonic = legacyDecrypt(activeWallet.mnemonic, password);
+                // Decrypt in whatever format it is stored (v1/legacy), then re-seal as v2.
+                const { decrypted: decryptedMnemonic } = await decryptData(
+                  activeWallet.mnemonic,
+                  password,
+                );
                 // Same reasoning as the key above: only store something that is demonstrably
                 // a real mnemonic, or the user's recovery phrase is lost. bip39 is loaded lazily
                 // so it stays out of the initial bundle.

--- a/src/services/wallet/crypto.test.ts
+++ b/src/services/wallet/crypto.test.ts
@@ -104,18 +104,33 @@ describe('purposeForAddressType', () => {
 describe('secureEncrypt / decryptData', () => {
   const password = 'a-sufficiently-long-password';
 
-  it('round-trips a secret', async () => {
+  it('round-trips a secret and writes the current v2 format', async () => {
     const encrypted = await secureEncrypt('super secret mnemonic words', password);
-    const { decrypted, wasLegacy } = await decryptData(encrypted, password);
+    const { decrypted, wasLegacy, format } = await decryptData(encrypted, password);
 
     expect(decrypted).toBe('super secret mnemonic words');
     expect(wasLegacy).toBe(false);
+    expect(format).toBe('v2');
+  });
+
+  it('still decrypts a pre-hardening v1 ciphertext, so existing wallets keep opening', async () => {
+    // A real blob produced by the original N=16384 (v1) format. Generated once with the old
+    // parameters; existing wallets are sealed exactly like this and must never be stranded.
+    const v1Blob =
+      '7519b19070904c1411d9b13e1cf346081b8c9214501fd8a4278eae2685834ad09ec3731e2dd16448524d5a365319fa341037670e21c00595269dd356ac36af991465e08826a87069335f48e227f00ec3888fa2551702e9840e991a449c5ded107b6f12ad5b56086a6f98468c844084f4d8038b57f38ad5';
+    const { decrypted, wasLegacy, format } = await decryptData(v1Blob, 'golden-test-password');
+
+    expect(decrypted).toBe('golden v1 secret phrase');
+    expect(wasLegacy).toBe(false);
+    expect(format).toBe('v1');
   });
 
   it('never emits the plaintext', async () => {
-    const encrypted = await secureEncrypt('L1aW4aubDFB7yfras2S1mN3bqg9nwySY8nkoLmJebSLD5BWv3ENZ', password);
-    expect(encrypted).not.toContain('L1aW4aubDFB7yfras2S1mN3bqg9nwySY8nkoLmJebSLD5BWv3ENZ');
-    expect(encrypted).toMatch(/^[0-9a-f]+$/);
+    const secret = 'L1aW4aubDFB7yfras2S1mN3bqg9nwySY8nkoLmJebSLD5BWv3ENZ';
+    const encrypted = await secureEncrypt(secret, password);
+    expect(encrypted).not.toContain(secret);
+    // The current format is versioned and self-describing: v2.<base64 header>.<base64 body>.
+    expect(encrypted).toMatch(/^v2\.[A-Za-z0-9+/=]+\.[A-Za-z0-9+/=]+$/);
   });
 
   it('produces a different ciphertext every time, so salt and IV are not reused', async () => {
@@ -123,8 +138,9 @@ describe('secureEncrypt / decryptData', () => {
     const second = await secureEncrypt('same input', password);
 
     expect(first).not.toBe(second);
-    // Salt is the leading 16 bytes; identical salts would mean a broken RNG.
-    expect(first.slice(0, 32)).not.toBe(second.slice(0, 32));
+    // The v2 header is deterministic (same KDF params); the salt and IV live in the body, which
+    // must differ every time or the RNG is broken.
+    expect(first.split('.')[2]).not.toBe(second.split('.')[2]);
   });
 
   it('refuses the wrong password', async () => {
@@ -136,10 +152,12 @@ describe('secureEncrypt / decryptData', () => {
 
   it('refuses tampered ciphertext, because the payload is authenticated', async () => {
     const encrypted = await secureEncrypt('secret', password);
-    // Flip a byte in the ciphertext body, past salt, IV and tag.
+    // Corrupt a character in the base64 body (past the `v2.` prefix and the header).
+    const dot = encrypted.lastIndexOf('.');
+    const body = encrypted.slice(dot + 1);
+    const at = Math.floor(body.length / 2);
     const tampered =
-      encrypted.slice(0, encrypted.length - 2) +
-      (encrypted.slice(-2) === 'ff' ? '00' : 'ff');
+      encrypted.slice(0, dot + 1) + body.slice(0, at) + (body[at] === 'A' ? 'B' : 'A') + body.slice(at + 1);
 
     await expect(decryptData(tampered, password)).rejects.toThrow(
       /Invalid password or corrupted data/,

--- a/src/services/wallet/encryption.ts
+++ b/src/services/wallet/encryption.ts
@@ -63,44 +63,102 @@ const IV_LENGTH = 16;
 const SALT_LENGTH = 64;
 const TAG_LENGTH = 16;
 
-/** Scrypt work factors, shared by encrypt and decrypt so a value round-trips. */
-const SCRYPT = { N: 16384, r: 8, p: 1, dkLen: 32 } as const;
+type ScryptParams = { N: number; r: number; p: number; dkLen: number };
+
+/**
+ * Scrypt work factors. V1 is the original interactive setting (~16 MB) — kept only so ciphertext
+ * written before the hardening still decrypts. V2 is the hardened profile (~64 MB) used for every
+ * new value; it is recorded in each v2 blob's header so decryption never has to guess, and a future
+ * bump is just another profile without a format change. See docs/proposals/scrypt-kdf-hardening.md.
+ */
+const SCRYPT_V1: ScryptParams = { N: 16384, r: 8, p: 1, dkLen: 32 };
+const SCRYPT_V2: ScryptParams = { N: 65536, r: 8, p: 1, dkLen: 32 };
+
+/** Prefix marking the versioned, self-describing format: `v2.<base64 header>.<base64 body>`. */
+const V2_PREFIX = 'v2.';
+
+/** Which on-disk format a value was decrypted from. Drives the re-encrypt-on-unlock upgrade. */
+export type EncryptionFormat = 'v1' | 'v2' | 'legacy';
+
+function deriveKey(password: string, salt: Buffer, params: ScryptParams): Promise<Buffer> {
+  return scryptPromise(Buffer.from(password, 'utf-8'), salt, params.N, params.r, params.p, params.dkLen);
+}
+
+function gcmDecrypt(key: Buffer, iv: Buffer, tag: Buffer, ciphertext: Buffer): string {
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}
+
+interface ParsedBlob {
+  params: ScryptParams;
+  salt: Buffer;
+  iv: Buffer;
+  tag: Buffer;
+  ciphertext: Buffer;
+}
+
+// Slice a raw `salt ‖ iv ‖ tag ‖ ciphertext` buffer into its parts.
+function sliceBlob(bin: Buffer, params: ScryptParams): ParsedBlob {
+  return {
+    params,
+    salt: bin.subarray(0, SALT_LENGTH),
+    iv: bin.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH),
+    tag: bin.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH),
+    ciphertext: bin.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH),
+  };
+}
+
+// Parse a `v2.<base64 header>.<base64 body>` blob, reading the KDF params from its header.
+function parseV2(encrypted: string): ParsedBlob {
+  const parts = encrypted.split('.');
+  if (parts.length !== 3 || parts[0] !== 'v2') {
+    throw new Error('Malformed v2 ciphertext');
+  }
+  const header = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf-8'));
+  const params: ScryptParams = {
+    N: header.N,
+    r: header.r,
+    p: header.p,
+    dkLen: header.dkLen ?? 32,
+  };
+  if (
+    !Number.isInteger(params.N) ||
+    !Number.isInteger(params.r) ||
+    !Number.isInteger(params.p) ||
+    !Number.isInteger(params.dkLen)
+  ) {
+    throw new Error('Invalid v2 KDF parameters');
+  }
+  return sliceBlob(Buffer.from(parts[2], 'base64'), params);
+}
 
 export async function secureEncrypt(data: string, password: string): Promise<string> {
   const salt = randomBytes(SALT_LENGTH);
-  const key = await scryptPromise(
-    Buffer.from(password, 'utf-8'),
-    salt,
-    SCRYPT.N,
-    SCRYPT.r,
-    SCRYPT.p,
-    SCRYPT.dkLen,
-  );
+  const key = await deriveKey(password, salt, SCRYPT_V2);
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, key, iv);
   const encrypted = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
   const tag = cipher.getAuthTag();
-  return Buffer.concat([salt, iv, tag, encrypted]).toString('hex');
+  const header = Buffer.from(
+    JSON.stringify({ kdf: 'scrypt', ...SCRYPT_V2 }),
+    'utf-8',
+  ).toString('base64');
+  const body = Buffer.concat([salt, iv, tag, encrypted]).toString('base64');
+  return `${V2_PREFIX}${header}.${body}`;
 }
 
-export async function secureDecrypt(encryptedHex: string, password: string): Promise<string> {
-  const encryptedData = Buffer.from(encryptedHex, 'hex');
-  const salt = encryptedData.subarray(0, SALT_LENGTH);
-  const iv = encryptedData.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
-  const tag = encryptedData.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
-  const encrypted = encryptedData.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
-  const key = await scryptPromise(
-    Buffer.from(password, 'utf-8'),
-    salt,
-    SCRYPT.N,
-    SCRYPT.r,
-    SCRYPT.p,
-    SCRYPT.dkLen,
-  );
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
-  decipher.setAuthTag(tag);
-  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-  return decrypted.toString('utf8');
+export async function secureDecrypt(encryptedText: string, password: string): Promise<string> {
+  // v2: self-describing — read the params from the header.
+  if (encryptedText.startsWith(V2_PREFIX)) {
+    const { params, salt, iv, tag, ciphertext } = parseV2(encryptedText);
+    const key = await deriveKey(password, salt, params);
+    return gcmDecrypt(key, iv, tag, ciphertext);
+  }
+  // v1: hex `salt ‖ iv ‖ tag ‖ ciphertext` derived with the original interactive factors.
+  const { salt, iv, tag, ciphertext } = sliceBlob(Buffer.from(encryptedText, 'hex'), SCRYPT_V1);
+  const key = await deriveKey(password, salt, SCRYPT_V1);
+  return gcmDecrypt(key, iv, tag, ciphertext);
 }
 
 /**
@@ -136,11 +194,13 @@ export function legacyDecrypt(encryptedData: string, password: string): string {
 export async function decryptData(
   encryptedData: string,
   password: string,
-): Promise<{ decrypted: string; wasLegacy: boolean }> {
+): Promise<{ decrypted: string; wasLegacy: boolean; format: EncryptionFormat }> {
   try {
-    // The current format is hex; non-hex legacy data fails here and falls through.
+    // v2 is `v2.`-prefixed; the current format is hex; non-hex legacy data fails here and falls
+    // through. `format` lets callers upgrade v1/legacy blobs to v2 after a successful unlock.
     const decrypted = await secureDecrypt(encryptedData, password);
-    return { decrypted, wasLegacy: false };
+    const format: EncryptionFormat = encryptedData.startsWith(V2_PREFIX) ? 'v2' : 'v1';
+    return { decrypted, wasLegacy: false, format };
   } catch (secureError) {
     walletLogger.debug('Secure decryption failed, attempting legacy method', {
       error: secureError instanceof Error ? secureError.message : 'Unknown error',
@@ -148,7 +208,7 @@ export async function decryptData(
 
     try {
       const decrypted = legacyDecrypt(encryptedData, password);
-      return { decrypted, wasLegacy: true };
+      return { decrypted, wasLegacy: true, format: 'legacy' };
     } catch (legacyError) {
       walletLogger.error('Decryption failed for both secure and legacy methods.', {
         secureError: secureError instanceof Error ? secureError.message : 'Unknown error',

--- a/src/services/wallet/exports.test.ts
+++ b/src/services/wallet/exports.test.ts
@@ -178,7 +178,7 @@ describe('exportActiveWalletPrivateKey', () => {
 
     // The stored blob should now be scrypt/AES-GCM hex, not the old base64 form.
     const stored = await StorageService.getWalletById(created.id!);
-    expect(stored?.privateKey).toMatch(/^[0-9a-f]+$/);
+    expect(stored?.privateKey).toMatch(/^v2\./);
     expect(stored?.privateKey).not.toBe(created.privateKey);
   });
 });


### PR DESCRIPTION
At-rest encryption derived its key with **scrypt N=16384, r=8** (~16 MB, <100 ms) — weak enough that an attacker with the ciphertext (it's in IndexedDB and in exported backups) could brute-force weak passwords cheaply. And the parameters were a hardcoded constant shared by encrypt *and* decrypt, so they couldn't be raised without stranding every existing wallet.

Design doc: [`docs/proposals/scrypt-kdf-hardening.md`](docs/proposals/scrypt-kdf-hardening.md) (approved).

### What changed
- **Versioned, self-describing format** — new ciphertext is `v2.<base64 header>.<base64 body>`; the header records the KDF params, so decryption never guesses and a future bump is just another profile. Unambiguous vs. the v1 (pure-hex) and legacy (CryptoJS) formats, both of which **still decrypt forever**.
- **Hardened profile** `v2 = N=65536, r=8` (~64 MB). Benchmarked with `scripts/bench-scrypt.cjs`:

  | N | memory | median |
  |---|--------|--------|
  | 16384 (old) | 16 MB | 79 ms |
  | 32768 | 32 MB | 157 ms |
  | **65536** | **64 MB** | **323 ms** ✓ |
  | 131072 | 128 MB | 675 ms |

  In the 250–750 ms band at a mobile-tolerable memory cost. **Please run the harness on a real handset** — if a phone is too slow, dropping the profile is a one-line change thanks to the versioned format.
- **Transparent upgrade** — the existing re-encrypt-on-unlock path (previously legacy-only) now re-seals *any* non-v2 blob (private key + mnemonic) after the key is validated as a real WIF. Wallets upgrade themselves as they're opened; a wallet that's never opened stays v1 and still decrypts.

### Scope note
The biometric-password blob is sealed under a **high-entropy device key**, not a user password, so its KDF profile isn't a brute-force concern — new setups are v2, existing ones aren't migrated.

### Tests
- A **real v1 golden vector** proves pre-hardening ciphertext still decrypts (back-compat).
- v2 format assertions; legacy path unchanged; re-encrypt-on-unlock now asserts `v2.`.
- E2E: signing is heavier now, so the sign-gated connect assertion gets headroom under parallel workers.
- ✅ typecheck · ✅ 543 unit · ✅ build · ✅ 33 E2E