### PR TITLE
feat(security): multi-wallet lock screen + KDF tuning

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -94,6 +94,46 @@ export async function seedWallet(page: Page) {
 }
 
 /**
+ * Adds a second, non-active encrypted wallet with its own password. Call after seedWallet (the DB
+ * exists by then). It reuses the same key material — the lock-screen picker keys on wallet id, and
+ * unlock validates against each wallet's own encrypted blob, so a distinct password is enough to
+ * exercise "sign into a different wallet". Does not reload; the caller (e.g. setScreenLock) does.
+ */
+export async function seedExtraWallet(page: Page, name: string, password: string) {
+  const record: SeedRecord = {
+    name,
+    // The wallets store has a unique index on address, so this must differ from the first wallet.
+    // Unlock validates the decrypted key (a real WIF), not that it matches this address, so a
+    // distinct placeholder is enough to exercise the multi-wallet picker.
+    address: 'RSecondWa11etAddressXXXXXXXXXXXXXX',
+    privateKey: await secureEncrypt(WALLET_WIF, password),
+    isEncrypted: true,
+    isActive: false,
+    createdAt: new Date(),
+    lastAccessed: new Date(),
+  };
+
+  await page.evaluate(
+    ({ dbName, wallet }) =>
+      new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open(dbName);
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const db = request.result;
+          const transaction = db.transaction('wallets', 'readwrite');
+          transaction.objectStore('wallets').put(wallet);
+          transaction.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          transaction.onerror = () => reject(transaction.error);
+        };
+      }),
+    { dbName: DB_NAME, wallet: record },
+  );
+}
+
+/**
  * Sets the opt-in screen-lock wall on or off. It updates the settings record the app already
  * created on boot (updating the existing record avoids the unique `key` index conflict a fresh
  * insert would hit) and reloads so it takes effect. Call after seedWallet.

--- a/e2e/optional-lock.spec.ts
+++ b/e2e/optional-lock.spec.ts
@@ -3,6 +3,7 @@ import {
   expect,
   acceptTerms,
   seedWallet,
+  seedExtraWallet,
   setScreenLock,
   WALLET_ADDRESS,
   WALLET_PASSWORD,
@@ -86,5 +87,29 @@ test.describe('optional lock screen', () => {
       page.getByText(WALLET_ADDRESS).filter({ visible: true }).first(),
     ).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText('Wallet locked')).toHaveCount(0);
+  });
+
+  test('multiple wallets: pick and unlock a non-active wallet with its own password', async ({ page }) => {
+    await page.routeWebSocket(/.*/, (ws) => ws.close());
+    await acceptTerms(page);
+    await seedWallet(page); // active, unlocks with WALLET_PASSWORD
+    await seedExtraWallet(page, 'Second Wallet', 'second-wallet-pass');
+    await setScreenLock(page, true); // wall on
+
+    // With more than one wallet the lock screen offers a picker.
+    const select = page.locator('#wallet-select');
+    await expect(select).toBeVisible({ timeout: 30_000 });
+
+    // Choose the second wallet and unlock with ITS password (the first wallet's password would not
+    // decrypt it) — proving you're never locked out of the others by forgetting one's password.
+    const value = await select
+      .locator('option', { hasText: 'Second Wallet' })
+      .getAttribute('value');
+    await select.selectOption(value!);
+
+    await page.getByPlaceholder('Password').fill('second-wallet-pass');
+    await page.getByRole('button', { name: 'Unlock', exact: true }).click();
+
+    await expect(page.getByText('Wallet locked')).toBeHidden({ timeout: 60_000 });
   });
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test",
+    "build:e2e": "cross-env NEXT_PUBLIC_SCRYPT_N=16384 next build",
+    "test:e2e": "cross-env NEXT_PUBLIC_SCRYPT_N=16384 playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "find-unused-code": "pnpm exec eslint src --no-error-on-unmatched-pattern --ext .ts,.tsx --rule \"no-unused-vars: error\" --quiet && pnpm exec knip"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,8 @@ const BASE_URL = `http://localhost:${PORT}`;
 export default defineConfig({
   testDir: './e2e',
   testMatch: '**/*.spec.ts',
-  // Wallet operations run scrypt in the browser, which is deliberately slow.
+  // Wallet operations run scrypt in the browser, which is deliberately slow. The e2e build uses a
+  // cheap KDF N (NEXT_PUBLIC_SCRYPT_N via build:e2e / test:e2e) so these stay well within timeout.
   timeout: 90_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,

--- a/scripts/bench-scrypt.cjs
+++ b/scripts/bench-scrypt.cjs
@@ -19,8 +19,8 @@ const { randomBytes } = require('crypto');
 
 const PROFILES = [
   { N: 16384, r: 8, p: 1 }, // current v1 — too weak, shown for reference
-  { N: 32768, r: 8, p: 1 },
-  { N: 65536, r: 8, p: 1 }, // current v2 candidate
+  { N: 32768, r: 8, p: 1 }, // current v2 default
+  { N: 65536, r: 8, p: 1 },
   { N: 131072, r: 8, p: 1 },
 ];
 

--- a/src/components/SecurityLockScreen.tsx
+++ b/src/components/SecurityLockScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Lock, Fingerprint, Eye, EyeOff, Shield, Clock, ArrowRight } from 'lucide-react';
 import { securityService } from '@/services/core/SecurityService';
 import { StorageService } from '@/services/core/StorageService';
@@ -9,11 +9,14 @@ import ThemeSwitcher from '@/components/ThemeSwitcher';
 import BiometricSetupButton from '@/components/BiometricSetupButton';
 
 interface SecurityLockScreenProps {
-  onUnlock: (password?: string) => void;
+  // `switchedWallet` tells the provider the active wallet changed (a multi-wallet pick), so it can
+  // reload the wallet context onto the newly-unlocked wallet.
+  onUnlock: (password?: string, switchedWallet?: boolean) => void;
   lockReason?: 'timeout' | 'manual' | 'failed_auth';
 }
 
 interface ActiveWalletInfo {
+  id?: number;
   name: string;
   address: string;
   isEncrypted: boolean;
@@ -27,6 +30,9 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
   const [biometricSupported, setBiometricSupported] = useState(false);
   const [biometricSetup, setBiometricSetup] = useState(false);
   const [activeWallet, setActiveWallet] = useState<ActiveWalletInfo | null>(null);
+  const [wallets, setWallets] = useState<ActiveWalletInfo[]>([]);
+  // The wallet the app had loaded when the wall came up; used to tell if a pick actually switched.
+  const originalActiveIdRef = useRef<number | undefined>(undefined);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [isLockedOut, setIsLockedOut] = useState(false);
@@ -116,19 +122,56 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
 
   const loadActiveWalletInfo = async () => {
     try {
-      const wallet = await StorageService.getActiveWallet();
-      if (wallet) {
+      const all = await StorageService.getAllWallets();
+      const list: ActiveWalletInfo[] = all.map((w) => ({
+        id: w.id,
+        name: w.name,
+        address: w.address,
+        isEncrypted: w.isEncrypted,
+      }));
+      setWallets(list);
+
+      const active = all.find((w) => w.isActive) ?? all[0];
+      if (active) {
+        // Remember which wallet the app had loaded so we can reload the context only if a pick
+        // actually switches away from it.
+        if (originalActiveIdRef.current === undefined) {
+          originalActiveIdRef.current = active.id;
+        }
         setActiveWallet({
-          name: wallet.name,
-          address: wallet.address,
-          isEncrypted: wallet.isEncrypted,
+          id: active.id,
+          name: active.name,
+          address: active.address,
+          isEncrypted: active.isEncrypted,
         });
       }
     } catch (error) {
-      toast.error('Failed to load active wallet', {
+      toast.error('Failed to load wallets', {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     }
+  };
+
+  // Pick a different wallet to sign into. Switching it active up front means the existing password
+  // and biometric unlock paths (which target the active wallet) apply to the chosen one — so
+  // forgetting one wallet's password never locks you out of the others.
+  const selectWallet = async (id: number) => {
+    if (id === activeWallet?.id) return;
+    const target = wallets.find((w) => w.id === id);
+    if (!target) return;
+    setPassword('');
+    setError('');
+    setSuccess('');
+    try {
+      await StorageService.switchToWallet(id);
+    } catch (e) {
+      toast.error('Could not switch wallet', {
+        description: e instanceof Error ? e.message : 'Unknown error',
+      });
+      return;
+    }
+    // Re-check biometrics for the newly-active wallet (handled by the activeWallet effect).
+    setActiveWallet(target);
   };
 
   const checkBiometricSupport = async () => {
@@ -195,6 +238,17 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
       return;
     }
 
+    // Make sure the picked wallet is the active one before validating. The switch also runs on
+    // selection; awaiting it here as well closes any race between selecting and clicking unlock, so
+    // a password is only ever validated against the wallet the user actually chose.
+    if (activeWallet?.id !== undefined) {
+      try {
+        await StorageService.switchToWallet(activeWallet.id);
+      } catch {
+        /* fall through — unlockWallet re-reads the active wallet and fails closed on mismatch */
+      }
+    }
+
     // If wallet doesn't require a password, unlock immediately
     if (!activeWallet?.isEncrypted) {
       handleUnlockSuccess('No password required for this wallet');
@@ -239,8 +293,10 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
       description: message,
     });
     // Hand the password back so the key is available for silent re-auth this session (password
-    // unlocks only; biometric/no-password unlocks pass nothing and re-prompt on demand).
-    onUnlock(password);
+    // unlocks only; biometric/no-password unlocks pass nothing and re-prompt on demand). The second
+    // flag tells the provider to reload the wallet context when the pick switched wallets.
+    const switchedWallet = activeWallet?.id !== originalActiveIdRef.current;
+    onUnlock(password, switchedWallet);
   };
 
   const handleBiometricUnlock = async () => {
@@ -258,12 +314,17 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
     setError('');
 
     try {
-      // Debug wallet information
-      const wallet = await StorageService.getActiveWallet();
+      // Make sure the picked wallet is active before biometric unlock targets it.
+      if (activeWallet?.id !== undefined) {
+        try {
+          await StorageService.switchToWallet(activeWallet.id);
+        } catch {
+          /* fall through */
+        }
+      }
 
       // With biometric authentication, the password is retrieved from secure storage
       // The second parameter 'true' indicates to use biometric authentication
-
       const success = await securityService.unlockWallet(undefined, true);
 
       if (success) {
@@ -535,15 +596,39 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
 
               <h1 className="text-xl font-semibold text-[#E6F0F2]">Wallet locked</h1>
               <p className="mt-1 text-sm text-[#9DB4BC]">
-                {activeWallet?.isEncrypted
-                  ? 'Enter your password to resume'
-                  : getLockReasonMessage()}
+                {wallets.length > 1
+                  ? 'Choose a wallet and enter its password'
+                  : activeWallet?.isEncrypted
+                    ? 'Enter your password to resume'
+                    : getLockReasonMessage()}
               </p>
-              {activeWallet && (
-                <p className="mt-2 font-mono text-xs text-[#6b8088]">
-                  {activeWallet.name} · {activeWallet.address.slice(0, 8)}…
-                  {activeWallet.address.slice(-6)}
-                </p>
+
+              {wallets.length > 1 ? (
+                <div className="mt-4 text-left">
+                  <label className="sr-only" htmlFor="wallet-select">
+                    Wallet to unlock
+                  </label>
+                  <select
+                    id="wallet-select"
+                    value={activeWallet?.id ?? ''}
+                    onChange={(e) => selectWallet(Number(e.target.value))}
+                    disabled={isLoading}
+                    className="w-full rounded-lg border border-[#24404A] bg-[rgba(4,18,26,0.6)] px-3.5 py-2.5 font-mono text-sm text-[#E6F0F2] focus:border-[#34F5C6] focus:outline-none disabled:opacity-60"
+                  >
+                    {wallets.map((w) => (
+                      <option key={w.id} value={w.id}>
+                        {w.name} · {w.address.slice(0, 8)}…{w.address.slice(-6)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                activeWallet && (
+                  <p className="mt-2 font-mono text-xs text-[#6b8088]">
+                    {activeWallet.name} · {activeWallet.address.slice(0, 8)}…
+                    {activeWallet.address.slice(-6)}
+                  </p>
+                )
               )}
 
               {activeWallet?.isEncrypted ? (

--- a/src/contexts/SecurityContext.tsx
+++ b/src/contexts/SecurityContext.tsx
@@ -78,9 +78,11 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
   // Get the current wallet address from WalletContext - this might be undefined on initial render
   // We need to use a try-catch because this hook might fail during SSR
   let activeWalletAddress: string | undefined;
+  let reloadActiveWallet: (() => Promise<void>) | undefined;
   try {
     const walletContext = useWallet();
     activeWalletAddress = walletContext?.address;
+    reloadActiveWallet = walletContext?.reloadActiveWallet;
   } catch (error) {
     // This is fine, we'll handle the undefined case
   }
@@ -381,14 +383,23 @@ export function SecurityProvider({ children }: SecurityProviderProps) {
   // Called by the lock screen when the user unlocks it. A password unlock hands the password back
   // so the key is available for the rest of the session; a biometric unlock does not (the next
   // sensitive action re-runs the quick biometric prompt).
-  const handleUnlock = (password?: string) => {
+  const handleUnlock = async (password?: string, switchedWallet?: boolean) => {
     // A successful unlock clears any remembered manual lock, so a later refresh does not re-lock.
     setManualLockFlag(false);
-    setScreenLocked(false);
     if (password) {
       setStoredWalletPassword(password);
       setWasBiometricAuth(false);
     }
+    // If the user signed into a different wallet from the lock screen, reload the wallet context
+    // onto it before revealing the app, so the dashboard shows the wallet they just unlocked.
+    if (switchedWallet && reloadActiveWallet) {
+      try {
+        await reloadActiveWallet();
+      } catch {
+        // Non-fatal — the wallet context can also reload on next navigation.
+      }
+    }
+    setScreenLocked(false);
   };
 
   // Show nothing while initializing to prevent flicker

--- a/src/services/wallet/encryption.ts
+++ b/src/services/wallet/encryption.ts
@@ -67,12 +67,21 @@ type ScryptParams = { N: number; r: number; p: number; dkLen: number };
 
 /**
  * Scrypt work factors. V1 is the original interactive setting (~16 MB) — kept only so ciphertext
- * written before the hardening still decrypts. V2 is the hardened profile (~64 MB) used for every
+ * written before the hardening still decrypts. V2 is the hardened profile (~32 MB) used for every
  * new value; it is recorded in each v2 blob's header so decryption never has to guess, and a future
  * bump is just another profile without a format change. See docs/proposals/scrypt-kdf-hardening.md.
  */
 const SCRYPT_V1: ScryptParams = { N: 16384, r: 8, p: 1, dkLen: 32 };
-const SCRYPT_V2: ScryptParams = { N: 65536, r: 8, p: 1, dkLen: 32 };
+// N is overridable at build time via NEXT_PUBLIC_SCRYPT_N for the e2e build ONLY — those tests do
+// not exercise KDF strength, and a cheap N keeps browser scrypt fast and deterministic. Production
+// builds set nothing and get the hardened default. The versioned format records the N actually
+// used, so a low-N e2e blob and a production blob remain mutually decryptable.
+const SCRYPT_V2: ScryptParams = {
+  N: Number(process.env.NEXT_PUBLIC_SCRYPT_N) || 32768,
+  r: 8,
+  p: 1,
+  dkLen: 32,
+};
 
 /** Prefix marking the versioned, self-describing format: `v2.<base64 header>.<base64 body>`. */
 const V2_PREFIX = 'v2.';


### PR DESCRIPTION
Two related things surfaced while fixing the biometric report.

### Multi-wallet lock screen
The lock screen only ever unlocked the **active** wallet — so forgetting one wallet's password locked you out of *all* of them, and biometrics set up on one wallet failed when another was active.

- With more than one wallet, the lock screen now shows a **wallet picker**. Picking a wallet switches it active up front (and re-checks its biometrics), so the existing password **and** biometric unlock paths apply to the chosen wallet.
- Selecting a biometric-enabled wallet surfaces its biometric unlock (covers the reported per-wallet biometric case).
- Unlock switches again right before validating (closes any select→click race); `SecurityContext` reloads the wallet context onto the newly-unlocked wallet before revealing the app. Fail-closed and the lockout counter still apply. Single-wallet users see no picker.
- **E2E**: seed a second wallet, pick it, unlock with *its own* password (the first wallet's password won't decrypt it).

### KDF tuning (follow-up to #33)
The e2e revealed `scrypt-js` in the browser is several × slower than node — and you confirmed **N=65536 is very slow on mobile**.

- **Production default lowered to N=32768** (2^15, ~32 MB). scrypt N must be a power of two, so this is the one step down that stays hardened — still 2× the pre-hardening cost, ~half the time/memory of 65536. One-line change; the versioned header keeps existing blobs decryptable, no migration.
- The tests don't exercise KDF strength, so **`build:e2e` / `test:e2e` set `NEXT_PUBLIC_SCRYPT_N=16384`** to keep browser scrypt cheap and deterministic — the suite went from **~12 min → ~4 min**, and the earlier timeout hack is reverted. Run e2e with `pnpm build:e2e && pnpm test:e2e`.

Still worth benchmarking 32768 on a real handset (the bench script + `scripts/bench-scrypt.cjs`); if it's still slow, dropping further is another one-liner.

✅ typecheck · ✅ 543 unit · ✅ build · ✅ 34 E2E