### PR TITLE
chore(ci): run CI only on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
-  pull_request:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Drops the `pull_request` trigger (and the `master` branch) so the CI workflow runs once per merge to `main` instead of on every PR push.