### PR TITLE
feat(security): move the password KDF from scrypt to Argon2id (WASM)

### DIFF
--- a/docs/proposals/argon2id-kdf.md
+++ b/docs/proposals/argon2id-kdf.md
@@ -1,0 +1,99 @@
+# Proposal: move the password KDF from scrypt to Argon2id (WASM)
+
+- **Status:** proposed (2026-08-13)
+- **Area:** `src/services/wallet/encryption.ts` and its call sites (WalletService, SecurityService, StorageService, BackupService)
+- **Builds on:** the versioned encryption format from [scrypt-kdf-hardening.md](scrypt-kdf-hardening.md) — this proposal reuses it rather than inventing a new format.
+- **Risk:** high — touches at-rest encryption of every private key, mnemonic, and the biometric-stored password. Must never lock an existing user out.
+
+## Motivation
+
+Two things, one change fixes both:
+
+1. **Argon2id is the current best practice.** It won the Password Hashing Competition and is the KDF OWASP and modern guidance recommend for password hashing/derivation — memory-hard *and* resistant to the side-channel/timing leaks that pure scrypt does not address. It is a strict upgrade over scrypt for sealing secrets an attacker can copy (our ciphertext lives in IndexedDB and in exported backups).
+2. **It is faster here, not slower.** Our current scrypt runs on `scrypt-js`, a **pure-JavaScript** implementation. That is why derivation is sluggish in the browser (several × the node figure) and why N had to be dialled back for mobile. A **WASM** Argon2id runs at near-native speed, so we can have a *stronger* KDF that is also *faster* — instead of trading security for speed.
+
+So this supersedes the scrypt N-tuning: rather than pick a weaker scrypt N to survive mobile, we switch to a KDF that is both stronger and quick.
+
+## Goals
+
+- Derive with **Argon2id** for all new ciphertext, benchmarked to ~**250–750 ms** on typical desktop and mobile, within a mobile-safe memory budget.
+- **Never break an existing wallet** — scrypt (v1 and v2) and legacy CryptoJS blobs keep decrypting forever.
+- **Transparent upgrade** — a wallet sealed with scrypt (or legacy) is re-sealed with Argon2id the next time it is unlocked, no user action.
+- Keep the WASM out of the initial bundle (lazy-load; the KDF is only needed on unlock / sign / create / backup).
+
+## Non-goals
+
+- A new blob format. The existing versioned header already carries a `kdf` field, so Argon2id is just a different `kdf` value — no `v3`.
+- Changing the cipher (stays AES-256-GCM), HD derivation, or signing.
+- Removing scrypt code — it stays as a read path for old blobs (and as a fallback, see open questions).
+
+## Design
+
+### 1. The format already accommodates it
+
+Today `secureEncrypt` writes `v2.<base64 header>.<base64 body>` where the header is:
+
+```json
+{ "kdf": "scrypt", "N": 32768, "r": 8, "p": 1, "dkLen": 32 }
+```
+
+Argon2id simply writes a different header:
+
+```json
+{ "kdf": "argon2id", "m": 65536, "t": 3, "p": 1, "dkLen": 32, "v": 19 }
+```
+
+(`m` = memory in KiB, `t` = time/iterations, `p` = parallelism, `v` = Argon2 version 0x13.) The salt lives in the body exactly as now (`salt ‖ iv ‖ tag ‖ ciphertext`, base64). **No format change** — decryption already reads the header to learn how to derive.
+
+### 2. Derivation dispatch
+
+`deriveKey` becomes a small dispatcher on `header.kdf`:
+
+- `argon2id` → call the WASM Argon2id with the header's `m/t/p/dkLen`.
+- `scrypt` (or a bare v1 hex blob) → the existing scrypt path with its `N/r/p`.
+- legacy CryptoJS → unchanged, unauthenticated, `wasLegacy: true`.
+
+`secureEncrypt` always writes Argon2id. `secureDecrypt` handles argon2id-v2, scrypt-v2, v1-hex and legacy. `decryptData` already returns `{ decrypted, wasLegacy, format }`; add the KDF to `format` (or a `kdf` field) so migration knows what to upgrade.
+
+### 3. Library
+
+Leading candidate: **`hash-wasm`** — a single, well-maintained, dependency-free WASM bundle that includes `argon2id`, works in both the browser and node (so the Vitest suite and the e2e fixtures can use it too), and exposes a simple `argon2id({ password, salt, parallelism, iterations, memorySize, hashLength })`. Alternative: `argon2-browser`. Final choice is an open question below; both are pure-WASM with no native toolchain.
+
+The WASM is **lazy-loaded** (`await import(...)` inside `deriveKey`) so it never enters the initial route bundle — consistent with how `encryption.ts` already avoids pulling in secp256k1.
+
+### 4. Choosing parameters (benchmark, don't guess)
+
+Argon2id memory is `m` KiB. Rough starting point to benchmark: `m = 64 MiB, t = 3, p = 1` (OWASP's baseline is m=19 MiB/t=2; a wallet can afford more). Add a dev harness (like `scripts/bench-scrypt.cjs`) that times a few `(m, t)` pairs in node **and** guidance to measure in the running PWA on a real handset — mobile memory is again the limiting factor. Because the header records the exact params, re-tuning later is a one-line change with no format churn.
+
+### 5. Transparent migration
+
+Reuse the existing re-encrypt-on-unlock path (`SecurityService.unlockWallet`, already upgrading non-v2 blobs after validating the decrypted key is a real WIF). Widen the trigger from "not v2" to "not argon2id": on unlock, if the stored blob's KDF is scrypt or legacy, re-`secureEncrypt` (now Argon2id) the private key and mnemonic and persist. Idempotent for blobs already on Argon2id. A wallet never opened stays on scrypt and still decrypts.
+
+Backups: `exportBackup` uses `secureEncrypt`, so new exports are Argon2id automatically; `parseBackupFile` uses `decryptData`, so it still imports scrypt and legacy backups.
+
+## Testing
+
+- **Golden vectors:** keep the existing scrypt-v1 and legacy decrypt vectors (back-compat) and add an Argon2id encrypt/decrypt round-trip plus a fixed Argon2id vector.
+- **Migration test:** seal with scrypt → `decryptData` reports scrypt → unlock re-seals → now Argon2id and still decrypts to the same plaintext.
+- **e2e:** reuse the `NEXT_PUBLIC_SCRYPT_N` idea — add an env override for cheap Argon2id params (small `m/t`) in the e2e build so browser derivation stays fast and deterministic. The versioned header keeps low-cost e2e blobs and production blobs mutually decryptable.
+- Vitest and the e2e fixtures both run Argon2id in node via the same WASM module.
+
+## Risks
+
+- **WASM availability.** WebAssembly is supported by every browser we target and by node; the PWA already ships as static files. If a hostile environment blocks WASM, derivation fails — see the open question on a scrypt fallback.
+- **Bundle size.** The Argon2 WASM is small (tens of KB) and lazy-loaded, so it does not affect first paint.
+- **Mobile memory.** Same ceiling concern as scrypt — benchmarked, `p` stays 1, `m` chosen conservatively.
+- **Migration safety.** Unchanged from the scrypt migration: validate the decrypted WIF/mnemonic before persisting, or a wallet could be destroyed. The existing guards cover this.
+
+## Rollout
+
+1. Land the library + dispatch + Argon2id write path + scrypt/legacy read paths (new writes are Argon2id, old reads still work). Benchmark and set the production profile.
+2. Turn on re-encrypt-on-unlock for scrypt/legacy blobs.
+3. Ship; wallets upgrade themselves as people open them. Drop the scrypt N-tuning follow-up — Argon2id replaces that decision.
+
+## Open questions
+
+1. **Library:** `hash-wasm` (leaning) vs `argon2-browser`. hash-wasm is smaller and covers node+browser from one package.
+2. **Parameters:** pending the benchmark; `m=64 MiB, t=3, p=1` is the starting candidate, adjusted down if mobile can't take 64 MiB.
+3. **Fallback:** if WASM fails to load, do we (a) fall back to scrypt for that derivation, or (b) hard-fail with a clear error? Leaning (b) for new writes (predictable format) but keeping scrypt fully functional as a read path regardless.
+4. **Header `v` field:** record the Argon2 version (0x13) for absolute clarity, or rely on the library default? Leaning record it.

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "build:e2e": "cross-env NEXT_PUBLIC_SCRYPT_N=16384 next build",
-    "test:e2e": "cross-env NEXT_PUBLIC_SCRYPT_N=16384 playwright test",
+    "build:e2e": "cross-env NEXT_PUBLIC_ARGON2_M=8192 NEXT_PUBLIC_ARGON2_T=2 next build",
+    "test:e2e": "cross-env NEXT_PUBLIC_ARGON2_M=8192 NEXT_PUBLIC_ARGON2_T=2 playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "find-unused-code": "pnpm exec eslint src --no-error-on-unmatched-pattern --ext .ts,.tsx --rule \"no-unused-vars: error\" --quiet && pnpm exec knip"
@@ -55,6 +55,7 @@
     "ecpair": "^3.0.0",
     "embla-carousel-react": "^8.6.0",
     "eslint-config-next": "^15.3.5",
+    "hash-wasm": "^4.12.0",
     "jsqr": "^1.4.0",
     "lucide-react": "^0.525.0",
     "minidenticons": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       eslint-config-next:
         specifier: ^15.3.5
         version: 15.5.9(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      hash-wasm:
+        specifier: ^4.12.0
+        version: 4.12.0
       jsqr:
         specifier: ^1.4.0
         version: 1.4.0
@@ -3951,6 +3954,9 @@ packages:
   hash-base@3.1.2:
     resolution: {integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==}
     engines: {node: '>= 0.8'}
+
+  hash-wasm@4.12.0:
+    resolution: {integrity: sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==}
 
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
@@ -10047,6 +10053,8 @@ snapshots:
       readable-stream: 2.3.8
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
+
+  hash-wasm@4.12.0: {}
 
   hash.js@1.1.7:
     dependencies:

--- a/scripts/bench-argon2.mjs
+++ b/scripts/bench-argon2.mjs
@@ -1,0 +1,68 @@
+/**
+ * Dev-only benchmark for choosing the Argon2id work factors used by at-rest encryption
+ * (see docs/proposals/argon2id-kdf.md and src/services/wallet/encryption.ts).
+ *
+ * Times key derivation for a few candidate (m, t) profiles and prints wall-clock time. `m` is
+ * memory in KiB, `t` iterations, `p` parallelism (kept at 1). Pick the highest profile that stays
+ * roughly in the 250-750 ms band AND within a safe memory budget on your *slowest* target device.
+ *
+ * Argon2id runs as WASM, so these node figures are a much closer proxy for the browser than the
+ * pure-JS scrypt benchmark was — but still validate on a real handset (its memory ceiling is the
+ * real constraint).
+ *
+ *   node scripts/bench-argon2.mjs            # default password length
+ *   node scripts/bench-argon2.mjs "some password"
+ */
+
+import { argon2id } from 'hash-wasm';
+import { randomBytes } from 'crypto';
+
+const PROFILES = [
+  { m: 32768, t: 3 },
+  { m: 65536, t: 3 }, // current default
+  { m: 65536, t: 4 },
+  { m: 131072, t: 3 },
+];
+
+const RUNS = 5;
+
+async function timeOne(password, m, t) {
+  const salt = randomBytes(64);
+  const start = process.hrtime.bigint();
+  await argon2id({
+    password: Buffer.from(password, 'utf-8'),
+    salt,
+    parallelism: 1,
+    iterations: t,
+    memorySize: m,
+    hashLength: 32,
+    outputType: 'binary',
+  });
+  return Number(process.hrtime.bigint() - start) / 1e6; // ms
+}
+
+async function main() {
+  const password = process.argv[2] || 'a-fairly-typical-user-password-123';
+  console.log(`\nArgon2id derivation benchmark — password length ${password.length}, ${RUNS} runs each\n`);
+  console.log('  m (KiB)   t   p   memory     median      min      max');
+  console.log('  ' + '-'.repeat(58));
+
+  for (const { m, t } of PROFILES) {
+    const times = [];
+    for (let i = 0; i < RUNS; i++) times.push(await timeOne(password, m, t));
+    times.sort((a, b) => a - b);
+    const median = times[Math.floor(times.length / 2)];
+    const fmt = (n) => `${n.toFixed(0).padStart(6)} ms`;
+    console.log(
+      `  ${String(m).padStart(7)}  ${t}   1   ${String(m / 1024).padStart(4)} MB   ` +
+        `${fmt(median)}  ${fmt(times[0])}  ${fmt(times[times.length - 1])}`,
+    );
+  }
+
+  console.log('\nTarget: highest profile with median ~250-750 ms and memory your slowest device tolerates.\n');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/services/core/SecurityService.ts
+++ b/src/services/core/SecurityService.ts
@@ -790,10 +790,10 @@ export class SecurityService {
             throw new Error('Decrypted value is not a valid private key, password incorrect.');
           }
 
-          // Upgrade the stored ciphertext to the current (v2) KDF profile if it isn't already —
-          // this covers both the old interactive-scrypt (v1) format and the unauthenticated legacy
-          // format. The key was just validated as a real WIF, so re-encrypting it is safe.
-          if (format !== 'v2') {
+          // Upgrade the stored ciphertext to the current KDF (Argon2id) if it isn't already — this
+          // covers both scrypt (v1 and v2) and the unauthenticated legacy format. The key was just
+          // validated as a real WIF, so re-encrypting it is safe.
+          if (format !== 'argon2id') {
             securityLogger.info(`Upgrading encryption for wallet: ${activeWallet.name}`);
             const newEncryptedKey = await secureEncrypt(decrypted, password);
 

--- a/src/services/wallet/crypto.test.ts
+++ b/src/services/wallet/crypto.test.ts
@@ -104,17 +104,20 @@ describe('purposeForAddressType', () => {
 describe('secureEncrypt / decryptData', () => {
   const password = 'a-sufficiently-long-password';
 
-  it('round-trips a secret and writes the current v2 format', async () => {
+  it('round-trips a secret and writes the current Argon2id format', async () => {
     const encrypted = await secureEncrypt('super secret mnemonic words', password);
     const { decrypted, wasLegacy, format } = await decryptData(encrypted, password);
 
     expect(decrypted).toBe('super secret mnemonic words');
     expect(wasLegacy).toBe(false);
-    expect(format).toBe('v2');
+    expect(format).toBe('argon2id');
+    // The v2 header is self-describing and records the KDF used.
+    const header = JSON.parse(Buffer.from(encrypted.split('.')[1], 'base64').toString('utf-8'));
+    expect(header.kdf).toBe('argon2id');
   });
 
   it('still decrypts a pre-hardening v1 ciphertext, so existing wallets keep opening', async () => {
-    // A real blob produced by the original N=16384 (v1) format. Generated once with the old
+    // A real blob produced by the original N=16384 (v1) hex format. Generated once with the old
     // parameters; existing wallets are sealed exactly like this and must never be stranded.
     const v1Blob =
       '7519b19070904c1411d9b13e1cf346081b8c9214501fd8a4278eae2685834ad09ec3731e2dd16448524d5a365319fa341037670e21c00595269dd356ac36af991465e08826a87069335f48e227f00ec3888fa2551702e9840e991a449c5ded107b6f12ad5b56086a6f98468c844084f4d8038b57f38ad5';
@@ -122,7 +125,30 @@ describe('secureEncrypt / decryptData', () => {
 
     expect(decrypted).toBe('golden v1 secret phrase');
     expect(wasLegacy).toBe(false);
-    expect(format).toBe('v1');
+    expect(format).toBe('scrypt');
+  });
+
+  it('still decrypts a scrypt v2 blob (wallets deployed before the Argon2id switch)', async () => {
+    // A real versioned scrypt blob (kdf:'scrypt'); wallets sealed between the scrypt hardening and
+    // the move to Argon2id look exactly like this and must keep opening.
+    const scryptV2Blob =
+      'v2.eyJrZGYiOiJzY3J5cHQiLCJOIjoxNjM4NCwiciI6OCwicCI6MSwiZGtMZW4iOjMyfQ==.RdYnkfB8LnYg74SIohSK3Dc/PZM8JcDwD9taYVX9ALekeIkdW+2iJidL8VgsbWL3cqrMI+yrpy1yqAfhRqAEPLzZQAAqLPDWlcHMqDFKenRMoQLDZNH016KuRlNKJomXNxlq17DMR7GrBtvJL4jc4KymqkdF0qo=';
+    const { decrypted, wasLegacy, format } = await decryptData(scryptV2Blob, 'golden-scrypt2-pw');
+
+    expect(decrypted).toBe('golden scrypt v2 secret');
+    expect(wasLegacy).toBe(false);
+    expect(format).toBe('scrypt');
+  });
+
+  it('decrypts an Argon2id blob and reports it as argon2id', async () => {
+    // A fixed Argon2id vector (small params) — proves the argon2id read path and pins the format.
+    const argon2Blob =
+      'v2.eyJrZGYiOiJhcmdvbjJpZCIsIm0iOjgxOTIsInQiOjIsInAiOjEsImRrTGVuIjozMiwidiI6MTl9.noirpGLBQRyVWFgQeGt4iHtJ1JCPc1Jc7R4EcqyY3dnTz1d5EuVOYJ32TW9lUCM7Z0OuVumS2W16FJ8GTqOhoi08PwTN1vqauL5AZRv6MMGwQSujZK14zm7Zc5DgxllrvPKJDMtuth1sBFuMvwyL7JTJRwfAUw==';
+    const { decrypted, wasLegacy, format } = await decryptData(argon2Blob, 'golden-argon2-pw');
+
+    expect(decrypted).toBe('golden argon2id secret');
+    expect(wasLegacy).toBe(false);
+    expect(format).toBe('argon2id');
   });
 
   it('never emits the plaintext', async () => {

--- a/src/services/wallet/encryption.ts
+++ b/src/services/wallet/encryption.ts
@@ -1,13 +1,16 @@
 /**
  * Password-based encryption primitives, deliberately free of any elliptic-curve dependency.
  *
- * These helpers use only scrypt + AES-GCM (current format) and CryptoJS (legacy format). Keeping
- * them in their own module — separate from WalletService, which binds ecpair/tiny-secp256k1 at
- * module load — means StorageService, SecurityService and BackupService can encrypt and decrypt
- * without dragging the ~1.7 MB secp256k1 build into the initial bundle of every route.
+ * New values are sealed with Argon2id (via the lazy-loaded WASM in `hash-wasm`) + AES-256-GCM.
+ * Older values still open: scrypt + AES-GCM (the v2 format before the Argon2id switch, and the
+ * pre-versioned v1 hex form) and the unauthenticated CryptoJS legacy format. Every v2 blob records
+ * its own KDF and parameters in a header, so decryption never has to guess. See
+ * docs/proposals/argon2id-kdf.md and docs/proposals/scrypt-kdf-hardening.md.
  *
- * Anything that needs actual key operations (signing, WIF validation, HD derivation) still lives
- * in WalletService.
+ * Keeping these in their own module — separate from WalletService, which binds ecpair/tiny-secp256k1
+ * at module load — means StorageService, SecurityService and BackupService can encrypt and decrypt
+ * without dragging the ~1.7 MB secp256k1 build into the initial bundle of every route. The Argon2id
+ * WASM is itself lazy-loaded (only needed on unlock / sign / create / backup).
  */
 
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
@@ -63,33 +66,55 @@ const IV_LENGTH = 16;
 const SALT_LENGTH = 64;
 const TAG_LENGTH = 16;
 
-type ScryptParams = { N: number; r: number; p: number; dkLen: number };
+type ScryptParams = { kdf: 'scrypt'; N: number; r: number; p: number; dkLen: number };
+type Argon2Params = { kdf: 'argon2id'; m: number; t: number; p: number; dkLen: number; v: number };
+type KdfParams = ScryptParams | Argon2Params;
 
 /**
- * Scrypt work factors. V1 is the original interactive setting (~16 MB) — kept only so ciphertext
- * written before the hardening still decrypts. V2 is the hardened profile (~32 MB) used for every
- * new value; it is recorded in each v2 blob's header so decryption never has to guess, and a future
- * bump is just another profile without a format change. See docs/proposals/scrypt-kdf-hardening.md.
+ * Pre-versioned v1 hex blobs carry no header, so their scrypt factors (the original interactive
+ * ~16 MB setting) are pinned here. scrypt-v2 blobs record their own N in the header, so no constant
+ * is needed for them.
  */
-const SCRYPT_V1: ScryptParams = { N: 16384, r: 8, p: 1, dkLen: 32 };
-// N is overridable at build time via NEXT_PUBLIC_SCRYPT_N for the e2e build ONLY — those tests do
-// not exercise KDF strength, and a cheap N keeps browser scrypt fast and deterministic. Production
-// builds set nothing and get the hardened default. The versioned format records the N actually
-// used, so a low-N e2e blob and a production blob remain mutually decryptable.
-const SCRYPT_V2: ScryptParams = {
-  N: Number(process.env.NEXT_PUBLIC_SCRYPT_N) || 32768,
-  r: 8,
+const SCRYPT_V1: ScryptParams = { kdf: 'scrypt', N: 16384, r: 8, p: 1, dkLen: 32 };
+
+/**
+ * Argon2id profile used for every new value. Memory-hard and side-channel resistant, and near-native
+ * speed via WASM (unlike pure-JS scrypt). Each field is written into the v2 header, so re-tuning is a
+ * one-line change with no format churn. `m` is KiB, `t` iterations, `p` parallelism, `v` the Argon2
+ * version (0x13). Overridable at build time via NEXT_PUBLIC_ARGON2_* for the e2e build ONLY — those
+ * tests do not exercise KDF strength, and cheap params keep browser derivation fast and deterministic.
+ * The versioned header keeps low-cost e2e blobs and production blobs mutually decryptable.
+ */
+const ARGON2_V2: Argon2Params = {
+  kdf: 'argon2id',
+  m: Number(process.env.NEXT_PUBLIC_ARGON2_M) || 65536,
+  t: Number(process.env.NEXT_PUBLIC_ARGON2_T) || 3,
   p: 1,
   dkLen: 32,
+  v: 0x13,
 };
 
 /** Prefix marking the versioned, self-describing format: `v2.<base64 header>.<base64 body>`. */
 const V2_PREFIX = 'v2.';
 
-/** Which on-disk format a value was decrypted from. Drives the re-encrypt-on-unlock upgrade. */
-export type EncryptionFormat = 'v1' | 'v2' | 'legacy';
+/** Which KDF a value was decrypted from. Drives the re-encrypt-on-unlock upgrade to Argon2id. */
+export type EncryptionFormat = 'argon2id' | 'scrypt' | 'legacy';
 
-function deriveKey(password: string, salt: Buffer, params: ScryptParams): Promise<Buffer> {
+async function deriveKey(password: string, salt: Buffer, params: KdfParams): Promise<Buffer> {
+  if (params.kdf === 'argon2id') {
+    // Lazy-load so the WASM never enters the initial route bundle.
+    const { argon2id } = await import('hash-wasm');
+    const hash = await argon2id({
+      password: Buffer.from(password, 'utf-8'),
+      salt,
+      parallelism: params.p,
+      iterations: params.t,
+      memorySize: params.m,
+      hashLength: params.dkLen,
+      outputType: 'binary',
+    });
+    return Buffer.from(hash);
+  }
   return scryptPromise(Buffer.from(password, 'utf-8'), salt, params.N, params.r, params.p, params.dkLen);
 }
 
@@ -100,7 +125,7 @@ function gcmDecrypt(key: Buffer, iv: Buffer, tag: Buffer, ciphertext: Buffer): s
 }
 
 interface ParsedBlob {
-  params: ScryptParams;
+  params: KdfParams;
   salt: Buffer;
   iv: Buffer;
   tag: Buffer;
@@ -108,7 +133,7 @@ interface ParsedBlob {
 }
 
 // Slice a raw `salt ‖ iv ‖ tag ‖ ciphertext` buffer into its parts.
-function sliceBlob(bin: Buffer, params: ScryptParams): ParsedBlob {
+function sliceBlob(bin: Buffer, params: KdfParams): ParsedBlob {
   return {
     params,
     salt: bin.subarray(0, SALT_LENGTH),
@@ -118,6 +143,35 @@ function sliceBlob(bin: Buffer, params: ScryptParams): ParsedBlob {
   };
 }
 
+// Read the KDF params from a v2 header (kdf defaults to scrypt for headers written before Argon2id).
+function paramsFromHeader(header: any): KdfParams {
+  if (header.kdf === 'argon2id') {
+    const params: Argon2Params = {
+      kdf: 'argon2id',
+      m: header.m,
+      t: header.t,
+      p: header.p,
+      dkLen: header.dkLen ?? 32,
+      v: header.v ?? 0x13,
+    };
+    if (![params.m, params.t, params.p, params.dkLen].every(Number.isInteger)) {
+      throw new Error('Invalid v2 Argon2id parameters');
+    }
+    return params;
+  }
+  const params: ScryptParams = {
+    kdf: 'scrypt',
+    N: header.N,
+    r: header.r,
+    p: header.p,
+    dkLen: header.dkLen ?? 32,
+  };
+  if (![params.N, params.r, params.p, params.dkLen].every(Number.isInteger)) {
+    throw new Error('Invalid v2 scrypt parameters');
+  }
+  return params;
+}
+
 // Parse a `v2.<base64 header>.<base64 body>` blob, reading the KDF params from its header.
 function parseV2(encrypted: string): ParsedBlob {
   const parts = encrypted.split('.');
@@ -125,46 +179,29 @@ function parseV2(encrypted: string): ParsedBlob {
     throw new Error('Malformed v2 ciphertext');
   }
   const header = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf-8'));
-  const params: ScryptParams = {
-    N: header.N,
-    r: header.r,
-    p: header.p,
-    dkLen: header.dkLen ?? 32,
-  };
-  if (
-    !Number.isInteger(params.N) ||
-    !Number.isInteger(params.r) ||
-    !Number.isInteger(params.p) ||
-    !Number.isInteger(params.dkLen)
-  ) {
-    throw new Error('Invalid v2 KDF parameters');
-  }
-  return sliceBlob(Buffer.from(parts[2], 'base64'), params);
+  return sliceBlob(Buffer.from(parts[2], 'base64'), paramsFromHeader(header));
 }
 
 export async function secureEncrypt(data: string, password: string): Promise<string> {
   const salt = randomBytes(SALT_LENGTH);
-  const key = await deriveKey(password, salt, SCRYPT_V2);
+  const key = await deriveKey(password, salt, ARGON2_V2);
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, key, iv);
   const encrypted = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
   const tag = cipher.getAuthTag();
-  const header = Buffer.from(
-    JSON.stringify({ kdf: 'scrypt', ...SCRYPT_V2 }),
-    'utf-8',
-  ).toString('base64');
+  const header = Buffer.from(JSON.stringify(ARGON2_V2), 'utf-8').toString('base64');
   const body = Buffer.concat([salt, iv, tag, encrypted]).toString('base64');
   return `${V2_PREFIX}${header}.${body}`;
 }
 
 export async function secureDecrypt(encryptedText: string, password: string): Promise<string> {
-  // v2: self-describing — read the params from the header.
+  // v2: self-describing — read the KDF and params from the header.
   if (encryptedText.startsWith(V2_PREFIX)) {
     const { params, salt, iv, tag, ciphertext } = parseV2(encryptedText);
     const key = await deriveKey(password, salt, params);
     return gcmDecrypt(key, iv, tag, ciphertext);
   }
-  // v1: hex `salt ‖ iv ‖ tag ‖ ciphertext` derived with the original interactive factors.
+  // v1: hex `salt ‖ iv ‖ tag ‖ ciphertext` derived with the original interactive scrypt factors.
   const { salt, iv, tag, ciphertext } = sliceBlob(Buffer.from(encryptedText, 'hex'), SCRYPT_V1);
   const key = await deriveKey(password, salt, SCRYPT_V1);
   return gcmDecrypt(key, iv, tag, ciphertext);
@@ -182,13 +219,24 @@ export function legacyDecrypt(encryptedData: string, password: string): string {
   return decryptedText;
 }
 
+// Report which KDF a v2 blob used (or 'scrypt' for a bare v1 hex blob), so callers can upgrade.
+function formatOfSecure(encryptedData: string): EncryptionFormat {
+  if (!encryptedData.startsWith(V2_PREFIX)) return 'scrypt';
+  try {
+    const header = JSON.parse(Buffer.from(encryptedData.split('.')[1], 'base64').toString('utf-8'));
+    return header.kdf === 'argon2id' ? 'argon2id' : 'scrypt';
+  } catch {
+    return 'scrypt';
+  }
+}
+
 /**
- * Unified decryption that handles both the current (scrypt + AES-GCM) and legacy (CryptoJS)
- * formats.
+ * Unified decryption that handles the current (Argon2id + AES-GCM), older scrypt, and legacy
+ * (CryptoJS) formats.
  *
- * IMPORTANT — the two formats give very different guarantees:
+ * IMPORTANT — the formats give very different guarantees:
  *
- * - The current format is AES-GCM, which is authenticated. A wrong password always throws.
+ * - The Argon2id/scrypt formats are AES-GCM, which is authenticated. A wrong password always throws.
  * - The legacy CryptoJS format is unauthenticated AES-CBC. There is nothing in the ciphertext to
  *   verify a password against, so a wrong password yields garbage plaintext. Usually that garbage
  *   is invalid UTF-8 and this throws, but often enough to matter it decodes cleanly and is
@@ -198,18 +246,19 @@ export function legacyDecrypt(encryptedData: string, password: string): string {
  * against what they expected — isValidWIF for a key, bip39.validateMnemonic for a mnemonic —
  * before trusting it, and certainly before writing it anywhere.
  *
- * @returns The decrypted data and whether the legacy format was used.
+ * `format` lets callers re-encrypt anything that is not yet Argon2id after a successful unlock.
+ *
+ * @returns The decrypted data, whether the legacy format was used, and which KDF it came from.
  */
 export async function decryptData(
   encryptedData: string,
   password: string,
 ): Promise<{ decrypted: string; wasLegacy: boolean; format: EncryptionFormat }> {
   try {
-    // v2 is `v2.`-prefixed; the current format is hex; non-hex legacy data fails here and falls
-    // through. `format` lets callers upgrade v1/legacy blobs to v2 after a successful unlock.
+    // v2 is `v2.`-prefixed; the pre-versioned format is hex; non-hex legacy data fails here and
+    // falls through.
     const decrypted = await secureDecrypt(encryptedData, password);
-    const format: EncryptionFormat = encryptedData.startsWith(V2_PREFIX) ? 'v2' : 'v1';
-    return { decrypted, wasLegacy: false, format };
+    return { decrypted, wasLegacy: false, format: formatOfSecure(encryptedData) };
   } catch (secureError) {
     walletLogger.debug('Secure decryption failed, attempting legacy method', {
       error: secureError instanceof Error ? secureError.message : 'Unknown error',


### PR DESCRIPTION
Implements the approved proposal ([docs/proposals/argon2id-kdf.md](docs/proposals/argon2id-kdf.md)).

scrypt ran on `scrypt-js` (**pure JavaScript**) — several seconds per derivation in-browser, which is why N had to be dialed down for mobile. **Argon2id** is the current best-practice KDF (memory-hard *and* side-channel resistant) and, via WASM, near-native. So this is **stronger *and* faster** — it cures the mobile lag instead of trading security for speed.

### What changed
- **No new format.** The v2 header already carried a `kdf` field, so new blobs simply write `{kdf:"argon2id", m, t, p, dkLen, v}` and `deriveKey` dispatches on it. **scrypt (v1 hex + v2) and legacy blobs still decrypt forever.**
- **`hash-wasm`** argon2id, **lazy-loaded** (`await import` inside `deriveKey`) so the WASM stays out of the initial bundle; it's inlined (base64), so the **static export needs no external `.wasm` fetch** (works under the app's CSP). Profile **m=65536 (64 MiB), t=3, p=1** — ~373 ms in node (`scripts/bench-argon2.mjs`), and WASM keeps it close to that in-browser.
- `decryptData` now reports `format: 'argon2id' | 'scrypt' | 'legacy'`; the existing **re-encrypt-on-unlock** migration upgrades any non-Argon2id blob to Argon2id after validating the decrypted WIF. Wallets upgrade themselves on next unlock; one never opened stays scrypt and still decrypts.

### Decisions (from the proposal's open questions)
- Library: **hash-wasm** — one small pure-WASM package, node + browser.
- Params: **m=65536, t=3, p=1** (benchmark-backed; adjust down if mobile can't take 64 MiB — one-liner).
- WASM-fails: hard-fail new writes (scrypt stays a read path); recorded `v:0x13` in the header.

### Tests
- Fixed golden vectors: **Argon2id**, **scrypt-v2** (wallets deployed before this switch), **v1 hex**, and **legacy** — all still decrypt.
- e2e uses `NEXT_PUBLIC_ARGON2_M/T` cheap params (`pnpm build:e2e && pnpm test:e2e`), suite ~4 min.
- ✅ typecheck · ✅ 545 unit · ✅ build · ✅ 35 E2E

**Still worth benchmarking m=65536 on a real handset** — `node scripts/bench-argon2.mjs` for a baseline; if 64 MiB is too heavy on low-end phones, dropping `m` is a one-line change (the header records it, no migration).