### PR TITLE
docs: refresh README + docs for the flight-deck UI and Argon2id KDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Progressive Web App (PWA) implementation of the Avian cryptocurrency wallet, b
 - 💰 **UTXO Management**: Comprehensive UTXO overview and selection tools
 - 💾 **Comprehensive Backup**: Full wallet backup with security settings and selective backup types (Full/Wallets Only)
 - 🌐 **Progressive Web App**: Installable, offline-capable application with responsive mobile-first design
-- 🎨 **Modern UI**: Clean, responsive design with dark mode support and mobile-optimized interface
+- 🎨 **Flight-deck UI**: An "instrument panel" design language — night ground, mint→cyan gradients, mono readouts and an artificial-horizon motif — carried through the landing page, guided onboarding wizard, and dashboard. Responsive, mobile-first, with dark mode support
 - 🔧 **Wallet Settings**: Comprehensive wallet management tools with responsive modal/drawer interfaces
 - 🔔 **Notifications**: Privacy-focused push notifications for transactions and security events
 - 🐛 **Debug Tools**: In-app log viewer with debug status indicators and security audit integration
@@ -32,7 +32,7 @@ A Progressive Web App (PWA) implementation of the Avian cryptocurrency wallet, b
 - **Cryptocurrency**: bitcoinjs-lib for wallet operations
 - **QR Codes**: qrcode library for address display
 - **Icons**: Lucide React icons
-- **Encryption**: CryptoJS for wallet security
+- **Encryption**: Argon2id key derivation (hash-wasm) with AES-256-GCM; CryptoJS retained only to read legacy blobs
 - **Authentication**: WebAuthn/FIDO2 for biometric authentication
 - **Storage**: IndexedDB for persistent data storage
 - **Security**: Client-side encryption for sensitive data protection
@@ -41,7 +41,7 @@ A Progressive Web App (PWA) implementation of the Avian cryptocurrency wallet, b
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 22+
 - pnpm
 
 ### Installation
@@ -160,10 +160,10 @@ src/
 
 ### Security
 
-- Client-side private key storage
-- Optional AES encryption with user passwords
-- Biometric authentication (Face ID, Touch ID, Windows Hello)
-- Per-wallet biometric security configuration
+- Client-side private key storage — keys are generated, encrypted, and used entirely on-device
+- Password-based encryption: **AES-256-GCM** with a key derived by **Argon2id** (memory-hard KDF, tuned so unlocking takes a few hundred ms). Older scrypt and CryptoJS blobs are still read and are transparently re-encrypted to the current format on the next successful unlock
+- Optional lock screen with a durable manual lock (survives a page refresh) and a multi-wallet unlock picker, so forgetting one wallet's password never locks you out of the others
+- Biometric authentication (Face ID, Touch ID, Windows Hello), scoped per wallet
 - Security audit logging for sensitive operations
 - Secure key generation using bitcoinjs-lib
 - No private keys transmitted over network
@@ -247,10 +247,9 @@ PWA configuration is handled in:
 
 ### Testing
 
-- Test wallet operations with small amounts
-- Verify PWA installation on different devices
-- Test offline functionality
-- Validate transaction signing and broadcasting
+- **Unit / integration** (Vitest): `pnpm test` (or `pnpm test:watch`)
+- **End-to-end** (Playwright): `pnpm build:e2e` then `pnpm test:e2e`. The e2e scripts set cheap Argon2id parameters (`NEXT_PUBLIC_ARGON2_M` / `NEXT_PUBLIC_ARGON2_T`) so the browser KDF stays fast and deterministic — production builds set nothing and get the hardened defaults. See [docs/TESTING.md](docs/TESTING.md).
+- Manually: test wallet operations with small amounts, verify PWA installation and offline functionality, and validate transaction signing and broadcasting
 
 ### Security Notes
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -8,7 +8,7 @@ Avian FlightDeck Wallet is a progressive web application (PWA) that provides a s
 
 ### Is my wallet data secure?
 
-Yes! Your private keys and sensitive data are encrypted using scrypt-based encryption and stored locally on your device. The wallet uses industry-standard cryptographic practices and never transmits your private keys to any server.
+Yes! Your private keys and sensitive data are encrypted with AES-256-GCM, using a key derived from your password by Argon2id (a memory-hard key-derivation function), and stored locally on your device. The wallet uses industry-standard cryptographic practices and never transmits your private keys to any server.
 
 ### Can I use this wallet on mobile devices?
 
@@ -226,9 +226,10 @@ Your transaction history is automatically synced and includes:
 
 ### What security features are available?
 
-- **Scrypt encryption**: Industry-standard key derivation
+- **Argon2id + AES-256-GCM encryption**: Memory-hard key derivation with authenticated encryption
 - **Biometric authentication**: Use fingerprint/face unlock where supported
-- **Auto-lock**: Wallet locks after inactivity
+- **Auto-lock and a durable manual lock**: Wallet locks after inactivity, and the manual lock survives a refresh
+- **Multi-wallet lock screen**: Pick which wallet to unlock, so forgetting one password never locks you out of the others
 - **Security alerts**: Notifications for important security events
 
 ### Should I enable notifications?

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -7,7 +7,7 @@
 - ✅ Tailwind CSS styling
 - ✅ PWA capabilities (next-pwa)
 - ✅ Wallet services and components
-- ✅ Cryptocurrency libraries (bitcoinjs-lib, crypto-js)
+- ✅ Cryptocurrency libraries (bitcoinjs-lib; Argon2id via hash-wasm; crypto-js for reading legacy blobs)
 - ✅ QR code generation
 - ✅ React Context for state management
 

--- a/docs/RECENT_UPDATES.md
+++ b/docs/RECENT_UPDATES.md
@@ -2,6 +2,39 @@
 
 This document tracks recent enhancements to the Avian FlightDeck Wallet application.
 
+## Flight-deck refresh (2026)
+
+### Brand & UI/UX
+
+- **Instrument-panel design language**: A committed "flight deck" look — night ground, mint→cyan
+  gradients, Roboto Mono readouts, and an artificial-horizon motif — carried across the app.
+- **New-visitor landing page** at `/` (shown only when no wallet exists), with an animated
+  primary-flight-display that levels its horizon once on load (respecting reduced-motion).
+- **Guided onboarding wizard** for creating a wallet, unified with Wallet Management's create flow
+  behind one headless hook (`useCreateWalletWizard`) and two theme-aware skins.
+- **Dashboard balance count-up** animation and fuller layout; refreshed lock/auth, Avian Connect,
+  settings, and backup/security surfaces.
+
+### Security
+
+- **Argon2id key derivation** (via `hash-wasm`, run in WebAssembly) replaces scrypt for
+  password-based encryption, paired with **AES-256-GCM**. The ciphertext format is versioned and
+  self-describing, so older scrypt and CryptoJS blobs still decrypt and are transparently
+  re-encrypted to the current format on the next successful unlock. Parameters are tuned so an
+  unlock takes a few hundred milliseconds.
+- **Multi-wallet lock screen**: an unlock picker so forgetting one wallet's password never locks you
+  out of the others; biometric unlock is scoped to its own wallet.
+- **Durable manual lock**: the Lock action now survives a page refresh even with the open-time wall
+  off.
+- **Terms acceptance** moved to wallet creation; the public landing page is the entry point.
+
+### Testing & tooling
+
+- E2E coverage expanded beyond Avian Connect to the landing page, onboarding, the lock screen,
+  balance, and empty states.
+- E2E builds use cheap Argon2id parameters (`pnpm build:e2e` / `pnpm test:e2e`) so browser unlocks
+  stay fast and deterministic; production builds keep the hardened defaults.
+
 ## Latest Features (July 2025)
 
 ### Enhanced User Experience

--- a/docs/SECURITY_FEATURES.md
+++ b/docs/SECURITY_FEATURES.md
@@ -1,28 +1,10 @@
 # Security Features Implementation Summary
 
-## ✅ Implemen### 7. **Privacy-Preserving Wallet Storage**
-
-- **Files**: `src/services/wallet/WalletService.ts`
-- **Features**:
-  - Secure local storage of wallet data
-  - Optional encryption of sensitive information
-  - Complete client-side privacy protection
-  - No transmission of private keys or seed phrases
-
-### 8. **Encrypted Local Storage**
-
-- **File**: `src/services/StorageService.ts`
-- **Features**:
-  - AES-GCM encrypted local storage
-  - Password-derived key generation
-  - Secure storage of wallet data, preferences, and transactions
-  - Resilient against local storage attacks
-
-### 9. **Debug and Audit Tools**es
+## ✅ Implemented Security Features
 
 ### 1. **Client-Side Data Protection**
 
-- **File**: `src/services/StorageService.ts`
+- **File**: `src/services/core/StorageService.ts`
 - **Features**:
   - Secure client-side storage model
   - Encrypted storage of sensitive information
@@ -31,7 +13,7 @@
 
 ### 2. **Biometric Authentication (Fingerprint/Face ID)**
 
-- **File**: `src/services/SecurityService.ts`
+- **File**: `src/services/core/SecurityService.ts`
 - **Features**:
   - WebAuthn-based biometric authentication
   - Fallback methods for different device types
@@ -40,16 +22,17 @@
 
 ### 3. **Auto-lock Timer**
 
-- **File**: `src/services/SecurityService.ts`
+- **File**: `src/services/core/SecurityService.ts`
 - **Features**:
   - Configurable timeout settings (1 minute to 4 hours)
   - Activity tracking and automatic lock on inactivity
-  - Manual lock functionality
+  - Durable manual lock — the Lock action survives a page refresh
+  - Multi-wallet lock screen with an unlock picker, so forgetting one wallet's password never locks you out of the others; biometric unlock is scoped to its own wallet
   - Lock state management and notifications
 
 ### 4. **Security Audit Log**
 
-- **File**: `src/services/SecurityService.ts`
+- **File**: `src/services/core/SecurityService.ts`
 - **Features**:
   - Comprehensive logging of security events
   - Tracks wallet operations, authentication attempts, and security actions
@@ -87,10 +70,10 @@
 
 ### 7. **Encrypted Local Storage**
 
-- **File**: `src/services/StorageService.ts`
+- **File**: `src/services/core/StorageService.ts`
 - **Features**:
-  - AES-GCM encrypted local storage
-  - Password-derived key generation
+  - AES-256-GCM encrypted local storage
+  - Argon2id password-derived key generation
   - Secure storage of wallet data, preferences, and transactions
   - Resilient against local storage attacks
 
@@ -116,7 +99,7 @@
 
 ### 10. **Application-level Permissions**
 
-- **File**: `src/services/PermissionsService.ts`
+- **File**: `src/services/provider/PermissionService.ts`
 - **Features**:
   - Fine-grained control of sensitive actions
   - Permission checks before critical operations
@@ -130,8 +113,9 @@
   - Optional encryption of sensitive information
   - User control over data persistence
 - **Encryption Implementation**:
-  - AES encryption of private keys and seed phrases
-  - Password-based key derivation for security
+  - AES-256-GCM (authenticated) encryption of private keys and seed phrases
+  - Argon2id password-based key derivation (memory-hard, run in WebAssembly), tuned so an unlock takes a few hundred milliseconds
+  - Self-describing versioned ciphertext: each blob records the KDF and its parameters in a header, so older scrypt/CryptoJS blobs still decrypt and are transparently re-encrypted to the current format on the next successful unlock
   - Client-side only operations with proper error handling
 
 - **Authentication Flow**:
@@ -184,7 +168,7 @@
    - Configure transaction requirements
 
 3. **Monitor Security**:
-   - Security events are securely logged server-side
+   - Security events are logged locally on the device (nothing is sent to a server)
    - Monitor unlock attempts in security panel
 
 4. **Manual Security Actions**:

--- a/docs/SECURITY_SETTINGS.md
+++ b/docs/SECURITY_SETTINGS.md
@@ -7,8 +7,8 @@ This document covers important security configuration settings for the Avian Fli
 The Avian FlightDeck Wallet implements a client-side security model that doesn't rely on server-side environment variables for encryption. Instead, it uses:
 
 1. **User-provided passwords** for encryption of sensitive data
-2. **Scrypt key derivation** with strong parameters for password-based encryption
-3. **AES-GCM encryption** for secure storage of private keys and mnemonics
+2. **Argon2id key derivation** (a memory-hard KDF, run in WebAssembly) with strong parameters for password-based encryption, tuned so an unlock takes a few hundred milliseconds. Data written by earlier scrypt and CryptoJS builds is still read and is transparently re-encrypted to the current format on the next successful unlock.
+3. **AES-256-GCM encryption** for secure storage of private keys and mnemonics
 
 ## Local Storage Security
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,7 +5,7 @@ Two suites, with different jobs:
 | Suite | Runner | Location | Covers |
 | ----- | ------ | -------- | ------ |
 | Unit / service | [Vitest](https://vitest.dev) | `src/**/*.test.ts` | Crypto, coin selection, storage, classification, backup, security |
-| End to end | [Playwright](https://playwright.dev) | `e2e/**/*.spec.ts` | Avian Connect in a real browser: popups, postMessage, redirects, approval dialogs |
+| End to end | [Playwright](https://playwright.dev) | `e2e/**/*.spec.ts` | The app in a real browser: landing, onboarding, the lock screen, balance, empty states, and Avian Connect (popups, postMessage, redirects, approval dialogs) |
 
 ```bash
 pnpm test           # Vitest, run once
@@ -13,10 +13,18 @@ pnpm test:watch     # Vitest, re-run on change
 pnpm test -- src/services/wallet    # a single directory
 pnpm test -- -t "descriptor"        # tests matching a name
 
-pnpm test:e2e           # Playwright, headless
+pnpm build:e2e          # static export with cheap KDF params (see below)
+pnpm test:e2e           # Playwright, headless — serves out/
 pnpm test:e2e:headed    # watch it drive the browser
 pnpm test:e2e:ui        # Playwright's interactive UI
 ```
+
+Both `build:e2e` and `test:e2e` set cheap Argon2id parameters (`NEXT_PUBLIC_ARGON2_M` /
+`NEXT_PUBLIC_ARGON2_T`). The KDF is memory-hard and deliberately slow at production settings —
+several seconds per unlock in a pure-WASM browser context — which blows the Playwright timeouts.
+The e2e parameters keep unlocks fast and deterministic; the versioned ciphertext records the
+parameters actually used, so a low-cost e2e blob and a production blob remain mutually decryptable.
+Production builds set nothing and get the hardened defaults.
 
 First-time setup for the E2E suite needs the browser binary:
 
@@ -66,8 +74,9 @@ Playwright drives the built app in Chromium. It exists for the things the Vitest
 cannot reach: a popup is a second real window, `postMessage` needs a real message channel, and a
 redirect round trip needs real navigation.
 
-`pnpm test:e2e` builds nothing — it starts `next start`, so **run `pnpm build` first** after
-changing app code, or set `E2E_USE_DEV=1` to run against `next dev` instead.
+`pnpm test:e2e` builds nothing — it serves the static export from `out/`, so **run `pnpm build:e2e`
+first** after changing app code (plain `pnpm build` bakes in the slow production KDF and the unlock
+steps will time out). Set `E2E_USE_DEV=1` to run against `next dev` instead.
 
 ### How a test gets a usable wallet
 
@@ -87,8 +96,8 @@ the same golden values the Vitest suite uses.
 ### Two traps worth knowing
 
 - **The lock screen's button changes label rather than disappearing.** It reads "Unlocking…" while
-  scrypt runs, so waiting for the button to go hidden lets a test navigate away mid-unlock. The
-  fixture waits for the *lock screen* to clear instead.
+  the Argon2id KDF runs, so waiting for the button to go hidden lets a test navigate away
+  mid-unlock. The fixture waits for the *lock screen* to clear instead.
 - **`window.open` reuses a window with the same name.** The wallet popup is named `avian-connect`,
   so if a previous popup is still open no new `popup` event fires and `waitForEvent('popup')` hangs
   until timeout. Close the popup before expecting a new one.
@@ -100,6 +109,11 @@ the same golden values the Vitest suite uses.
 | `e2e/avian-connect-popup.spec.ts` | connect, reject, signMessage with authentication, getAccounts, getNetwork, unsupported methods, and refusing a signature to an unconnected site |
 | `e2e/avian-connect-redirect.spec.ts` | the redirect round trip, fragment scrubbing, challenge survival across navigation, and the origin-mismatch / malformed-request guards |
 | `e2e/avian-connect-permissions.spec.ts` | remembering a site, Connected Sites, revoke, `disconnect()`, and the acceptance check that a signature verifies in Message Utilities → Verify |
+| `e2e/landing.spec.ts` | the new-visitor landing page at `/` when no wallet exists |
+| `e2e/onboarding.spec.ts` | the guided create-wallet wizard |
+| `e2e/optional-lock.spec.ts` | the optional lock screen, the durable manual lock, and the multi-wallet unlock picker |
+| `e2e/balance.spec.ts` | the dashboard balance readout when the server is unreachable — unavailable vs. last-known |
+| `e2e/empty-states.spec.ts` | empty / loading states before data arrives |
 
 The demo page carries `data-testid` hooks (`demo-address`, `demo-signature`, `demo-verification`,
 `demo-log`) so the specs do not depend on its layout.
@@ -187,7 +201,8 @@ Known gaps, in rough order of how much they would be worth adding:
 - **React components in isolation.** No `@testing-library/react` is installed. The Avian Connect
   dialogs are exercised through Playwright, but `SendForm`, `WalletCreationForm` and the contexts
   have no unit-level coverage.
-- **Onboarding, sending and backup as user journeys.** The E2E suite only covers Avian Connect;
+- **Sending and backup as user journeys.** Onboarding, the landing page, the lock screen, balance
+  and empty states have E2E coverage alongside Avian Connect, but sending and backup do not yet;
   the `walletPage` fixture is reusable for more journeys.
 - **Browsers other than Chromium.** The Playwright config declares one project; Firefox and
   WebKit would need `playwright install` for each.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,9 @@ const BASE_URL = `http://localhost:${PORT}`;
 export default defineConfig({
   testDir: './e2e',
   testMatch: '**/*.spec.ts',
-  // Wallet operations run scrypt in the browser, which is deliberately slow. The e2e build uses a
-  // cheap KDF N (NEXT_PUBLIC_SCRYPT_N via build:e2e / test:e2e) so these stay well within timeout.
+  // Wallet operations run the Argon2id KDF in the browser, which is deliberately slow. The e2e
+  // build uses cheap KDF parameters (NEXT_PUBLIC_ARGON2_M / NEXT_PUBLIC_ARGON2_T via
+  // build:e2e / test:e2e) so these stay well within timeout.
   timeout: 90_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,


### PR DESCRIPTION
The docs had drifted behind the app. They still described CryptoJS/scrypt encryption, Node 18, an Avian-Connect-only e2e suite, and service paths that moved into `src/services/core` and `src/services/provider`.

## README
- Encryption stack is now **Argon2id (hash-wasm) + AES-256-GCM**, with CryptoJS/scrypt kept only as legacy read paths.
- Node **22+**.
- Flight-deck UI, landing page, guided onboarding, and the multi-wallet / durable manual lock.
- Real test commands: Vitest (`pnpm test`) and Playwright (`pnpm build:e2e` → `pnpm test:e2e`).

## docs/
- **SECURITY_FEATURES**: repaired a corrupted header, fixed stale service paths, corrected the "logged server-side" claim to local, and described the versioned Argon2id/AES-256-GCM format plus the multi-wallet and durable lock.
- **SECURITY_SETTINGS / FAQ / GETTING_STARTED**: scrypt → Argon2id, AES-GCM → AES-256-GCM, and the transparent re-encrypt-on-unlock migration.
- **TESTING** (+ the matching `playwright.config.ts` comment): the `build:e2e`/`test:e2e` flow with cheap Argon2id params, and the landing/onboarding/lock/balance/empty-state specs the suite now carries.
- **RECENT_UPDATES**: added a 2026 flight-deck section.

## Not included
The `manifest.json` PWA screenshots are still the pre-refresh UI (last updated 2025-07-31). They need re-capturing from the running app — to be dropped into `public/screenshots/` under the existing filenames (`{mobile,desktop}-{home,transactions}.png`, 1080×1920 / 1920×1080).