### PR TITLE
feat(security): in-app encryption-format indicator (+ v2.4.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/SecuritySettingsPanel.tsx
+++ b/src/components/SecuritySettingsPanel.tsx
@@ -5,6 +5,7 @@ import { securityService } from '@/services/core/SecurityService';
 import { toast } from 'sonner';
 import { SecuritySettings, SecurityAuditEntry } from '@/types/security';
 import { StorageService } from '@/services/core/StorageService';
+import { inspectEncryptionFormat, EncryptionFormat } from '@/services/wallet/encryption';
 import {
   Shield,
   Fingerprint,
@@ -14,6 +15,7 @@ import {
   X,
   Info,
   AlertTriangle,
+  KeyRound,
 } from 'lucide-react';
 import { EmptyState } from '@/components/EmptyState';
 import { useMediaQuery } from '@/hooks/use-media-query';
@@ -65,6 +67,32 @@ import {
 } from '@/components/ui/drawer';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 
+/**
+ * How each on-disk encryption format is presented in the read-only indicator. `argon2id` is the
+ * current, up-to-date format; the others still decrypt and are transparently re-encrypted to
+ * Argon2id the next time the wallet is unlocked with a password.
+ */
+const ENCRYPTION_FORMAT_META: Record<
+  EncryptionFormat,
+  { label: string; current: boolean; note: string }
+> = {
+  argon2id: {
+    label: 'Argon2id · AES-256-GCM',
+    current: true,
+    note: 'Current format — your password is stretched with a memory-hard key-derivation function before it encrypts your key.',
+  },
+  scrypt: {
+    label: 'scrypt · AES-256-GCM',
+    current: false,
+    note: 'An earlier format. It upgrades to Argon2id automatically the next time you unlock this wallet with your password.',
+  },
+  legacy: {
+    label: 'Legacy (CryptoJS)',
+    current: false,
+    note: 'A legacy format. It upgrades to Argon2id automatically the next time you unlock this wallet with your password.',
+  },
+};
+
 interface SecuritySettingsPanelProps {
   isOpen?: boolean;
   onClose?: () => void;
@@ -85,6 +113,11 @@ export default function SecuritySettingsPanel({
   const [expandedEntries, setExpandedEntries] = useState<Record<string, boolean>>({});
   const [currentPage, setCurrentPage] = useState(1);
   const [entriesPerPage] = useState(10); // Show 10 entries per page
+  // Read-only encryption format of the active wallet: null while unknown / no wallet,
+  // { encrypted: false } for an unencrypted wallet, otherwise the KDF its stored key uses.
+  const [encryption, setEncryption] = useState<
+    { encrypted: false } | { encrypted: true; format: EncryptionFormat } | null
+  >(null);
   const updateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isMobile = useMediaQuery('(max-width: 640px)');
 
@@ -110,10 +143,27 @@ export default function SecuritySettingsPanel({
       setBiometricSupported(capabilities.isSupported);
     };
 
+    // Inspect the active wallet's stored key by shape only — no password, no decryption.
+    const loadEncryptionInfo = async () => {
+      try {
+        const wallet = await StorageService.getActiveWallet();
+        if (!wallet) {
+          setEncryption(null);
+        } else if (!wallet.isEncrypted) {
+          setEncryption({ encrypted: false });
+        } else {
+          setEncryption({ encrypted: true, format: inspectEncryptionFormat(wallet.privateKey) });
+        }
+      } catch {
+        setEncryption(null);
+      }
+    };
+
     const init = async () => {
       await loadSettings();
       await loadAuditLog();
       await checkBiometricSupport();
+      await loadEncryptionInfo();
     };
     init();
 
@@ -362,6 +412,58 @@ export default function SecuritySettingsPanel({
 
         <CardContent className={cn('pt-6', isMobile ? 'px-4 pb-4' : '')}>
           <TabsContent value="settings" className="space-y-6 mt-0">
+            {/* Encryption format (read-only) */}
+            {encryption && (
+              <div className="space-y-4">
+                <div className="flex items-center">
+                  <KeyRound className="h-5 w-5 text-primary mr-2" />
+                  <h3 className="text-lg font-medium">Encryption</h3>
+                </div>
+
+                <Separator />
+
+                {encryption.encrypted ? (
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Label>This wallet is encrypted with</Label>
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            'font-mono',
+                            ENCRYPTION_FORMAT_META[encryption.format].current
+                              ? 'border-primary/40 text-primary'
+                              : 'border-caution/40 text-caution',
+                          )}
+                        >
+                          {ENCRYPTION_FORMAT_META[encryption.format].label}
+                        </Badge>
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {ENCRYPTION_FORMAT_META[encryption.format].note}
+                      </p>
+                    </div>
+                    {ENCRYPTION_FORMAT_META[encryption.format].current ? (
+                      <CheckCircle className="h-5 w-5 shrink-0 text-primary" aria-label="Up to date" />
+                    ) : (
+                      <AlertTriangle
+                        className="h-5 w-5 shrink-0 text-caution"
+                        aria-label="Upgrades on next unlock"
+                      />
+                    )}
+                  </div>
+                ) : (
+                  <Alert>
+                    <AlertTriangle className="h-4 w-4 text-caution" />
+                    <AlertDescription>
+                      This wallet is not password-encrypted — its key is stored in the clear on this
+                      device. Add a password from Wallet Settings to encrypt it with Argon2id.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </div>
+            )}
+
             {/* Auto-lock Settings Section */}
             <div className="space-y-4">
               <div className="flex items-center">

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -27,7 +27,7 @@ import { secureEncrypt, secureDecrypt, decryptData, legacyDecrypt } from './encr
 // Re-exported so existing importers of these helpers from WalletService keep working. New code
 // that only needs encryption should import from './encryption' directly, to avoid pulling the
 // elliptic-curve dependencies this module binds at load.
-export { secureEncrypt, decryptData, legacyDecrypt } from './encryption';
+export { secureEncrypt, decryptData, legacyDecrypt, inspectEncryptionFormat } from './encryption';
 
 // Initialize ECPair and BIP32 with secp256k1
 const ECPair = ECPairFactory(ecc);

--- a/src/services/wallet/crypto.test.ts
+++ b/src/services/wallet/crypto.test.ts
@@ -10,6 +10,7 @@ import {
   avianNetwork,
   decryptData,
   deriveAddress,
+  inspectEncryptionFormat,
   isValidWIF,
   legacyDecrypt,
   purposeForAddressType,
@@ -204,6 +205,38 @@ describe('secureEncrypt / decryptData', () => {
   it('handles an empty string as a distinct value from a failure', async () => {
     const encrypted = await secureEncrypt('', password);
     expect((await decryptData(encrypted, password)).decrypted).toBe('');
+  });
+});
+
+describe('inspectEncryptionFormat', () => {
+  // The read-only indicator classifies a stored blob by shape alone — no password, no decryption —
+  // and must agree with the format decryptData reports for the same value.
+  it('reports argon2id for a current v2 blob', async () => {
+    const encrypted = await secureEncrypt('secret', 'a-sufficiently-long-password');
+    expect(inspectEncryptionFormat(encrypted)).toBe('argon2id');
+  });
+
+  it('reports argon2id for a fixed argon2id vector without decrypting it', () => {
+    const argon2Blob =
+      'v2.eyJrZGYiOiJhcmdvbjJpZCIsIm0iOjgxOTIsInQiOjIsInAiOjEsImRrTGVuIjozMiwidiI6MTl9.noirpGLBQRyVWFgQeGt4iHtJ1JCPc1Jc7R4EcqyY3dnTz1d5EuVOYJ32TW9lUCM7Z0OuVumS2W16FJ8GTqOhoi08PwTN1vqauL5AZRv6MMGwQSujZK14zm7Zc5DgxllrvPKJDMtuth1sBFuMvwyL7JTJRwfAUw==';
+    expect(inspectEncryptionFormat(argon2Blob)).toBe('argon2id');
+  });
+
+  it('reports scrypt for a v2 header written before the Argon2id switch', () => {
+    const scryptV2Blob =
+      'v2.eyJrZGYiOiJzY3J5cHQiLCJOIjoxNjM4NCwiciI6OCwicCI6MSwiZGtMZW4iOjMyfQ==.RdYnkfB8LnYg74SIohSK3Dc/PZM8JcDwD9taYVX9ALekeIkdW+2iJidL8VgsbWL3cqrMI+yrpy1yqAfhRqAEPLzZQAAqLPDWlcHMqDFKenRMoQLDZNH016KuRlNKJomXNxlq17DMR7GrBtvJL4jc4KymqkdF0qo=';
+    expect(inspectEncryptionFormat(scryptV2Blob)).toBe('scrypt');
+  });
+
+  it('reports scrypt for a bare v1 hex blob', () => {
+    const v1Blob =
+      '7519b19070904c1411d9b13e1cf346081b8c9214501fd8a4278eae2685834ad09ec3731e2dd16448524d5a365319fa341037670e21c00595269dd356ac36af991465e08826a87069335f48e227f00ec3888fa2551702e9840e991a449c5ded107b6f12ad5b56086a6f98468c844084f4d8038b57f38ad5';
+    expect(inspectEncryptionFormat(v1Blob)).toBe('scrypt');
+  });
+
+  it('reports legacy for a CryptoJS payload', () => {
+    const legacyBlob = CryptoJS.AES.encrypt('legacy mnemonic', 'legacy-password').toString();
+    expect(inspectEncryptionFormat(legacyBlob)).toBe('legacy');
   });
 });
 

--- a/src/services/wallet/encryption.ts
+++ b/src/services/wallet/encryption.ts
@@ -219,6 +219,29 @@ export function legacyDecrypt(encryptedData: string, password: string): string {
   return decryptedText;
 }
 
+/**
+ * Inspect which on-disk encryption format a stored blob uses WITHOUT decrypting it — purely from
+ * its shape. Safe to call with no password; intended for a read-only indicator ("Encryption:
+ * Argon2id"). It classifies the same way `decryptData` does, so the label matches the format the
+ * next unlock would report and upgrade from:
+ *
+ *  - `v2.` prefix  → read the header's `kdf` ('argon2id', or 'scrypt' for headers written before
+ *                    the Argon2id switch)
+ *  - bare hex      → the original scrypt format (v1)
+ *  - anything else → legacy CryptoJS
+ */
+export function inspectEncryptionFormat(encryptedData: string): EncryptionFormat {
+  if (encryptedData.startsWith(V2_PREFIX)) {
+    try {
+      const header = JSON.parse(Buffer.from(encryptedData.split('.')[1], 'base64').toString('utf-8'));
+      return header.kdf === 'argon2id' ? 'argon2id' : 'scrypt';
+    } catch {
+      return 'scrypt';
+    }
+  }
+  return /^[0-9a-f]+$/i.test(encryptedData) ? 'scrypt' : 'legacy';
+}
+
 // Report which KDF a v2 blob used (or 'scrypt' for a bare v1 hex blob), so callers can upgrade.
 function formatOfSecure(encryptedData: string): EncryptionFormat {
   if (!encryptedData.startsWith(V2_PREFIX)) return 'scrypt';


### PR DESCRIPTION
Surfaces the active wallet's key-derivation format in the Security Settings panel, so you can tell whether a wallet is on Argon2id without opening the devtools console.

## What you see
- **Argon2id · AES-256-GCM** — current format, shown in mint with a check.
- **scrypt · AES-256-GCM** or **Legacy (CryptoJS)** — shown in caution orange with a note that it upgrades to Argon2id automatically on the next password unlock (the existing re-encrypt-on-unlock migration).
- An unencrypted wallet gets a plain warning to add a password.

## How
- `encryption.ts` exports `inspectEncryptionFormat(blob)` — classifies a stored blob **by shape alone, no password and no decryption**, the same way `decryptData` classifies it: `v2` header `kdf` → `argon2id`/`scrypt`, bare hex → `scrypt` (v1), otherwise `legacy`. Re-exported from `WalletService`.
- `SecuritySettingsPanel` reads the active wallet (`StorageService.getActiveWallet()`) and renders the indicator at the top of the Settings tab. Guarded on `isEncrypted` so an unencrypted wallet isn't misread as legacy.

## Tests
- `crypto.test.ts`: `inspectEncryptionFormat` covered against the argon2id / scrypt-v2 / v1-hex / legacy golden vectors, asserting it never decrypts. Full suite: **550 passed**. Typecheck + `pnpm build` clean.

## Version
Bumps **2.4.1 → 2.4.2** so the About page confirms the automated server deploy landed.