### PR TITLE
fix(security): migrate biometric password to Argon2id on read (+ v2.4.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/core/StorageService.test.ts
+++ b/src/services/core/StorageService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { StorageService } from './StorageService';
+import { inspectEncryptionFormat } from '@/services/wallet/encryption';
 import { resetStorage } from '@/test/helpers';
 
 const ADDRESS_A = 'RAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -17,6 +18,51 @@ const createWallet = (overrides: Record<string, unknown> = {}) =>
 
 beforeEach(() => {
   resetStorage();
+});
+
+describe('biometric password migration', () => {
+  // A real scrypt v2 blob: decrypts with secureKey 'golden-scrypt2-pw' to 'golden scrypt v2 secret'.
+  // Stands in for a biometric credential enrolled before the move to Argon2id.
+  const SCRYPT_BIO_BLOB =
+    'v2.eyJrZGYiOiJzY3J5cHQiLCJOIjoxNjM4NCwiciI6OCwicCI6MSwiZGtMZW4iOjMyfQ==.RdYnkfB8LnYg74SIohSK3Dc/PZM8JcDwD9taYVX9ALekeIkdW+2iJidL8VgsbWL3cqrMI+yrpy1yqAfhRqAEPLzZQAAqLPDWlcHMqDFKenRMoQLDZNH016KuRlNKJomXNxlq17DMR7GrBtvJL4jc4KymqkdF0qo=';
+  const SECURE_KEY = 'golden-scrypt2-pw';
+  const EXPECTED_PW = 'golden scrypt v2 secret';
+
+  it('recovers the password and re-seals an older scrypt blob as Argon2id on read', async () => {
+    const wallet = await createWallet();
+    // Seed a biometric password sealed in the pre-Argon2id scrypt format.
+    await StorageService.saveWalletWithBiometricData(
+      { ...wallet, encryptedBiometricPassword: SCRYPT_BIO_BLOB },
+      [1, 2, 3],
+    );
+    expect(inspectEncryptionFormat(SCRYPT_BIO_BLOB)).toBe('scrypt');
+
+    const recovered = await StorageService.getEncryptedWalletPassword(SECURE_KEY, ADDRESS_A);
+    expect(recovered).toBe(EXPECTED_PW);
+
+    // The stored blob is upgraded to Argon2id, so future biometric logins skip the slow scrypt path…
+    const after = await StorageService.getWalletByAddress(ADDRESS_A);
+    expect(after?.encryptedBiometricPassword).toBeTruthy();
+    expect(inspectEncryptionFormat(after!.encryptedBiometricPassword!)).toBe('argon2id');
+    // …and it still unlocks to the same password.
+    expect(await StorageService.getEncryptedWalletPassword(SECURE_KEY, ADDRESS_A)).toBe(EXPECTED_PW);
+  });
+
+  it('leaves an already-Argon2id biometric blob untouched', async () => {
+    await createWallet();
+    await StorageService.setEncryptedWalletPassword(SECURE_KEY, 'my-wallet-pw', ADDRESS_A);
+    const before = (await StorageService.getWalletByAddress(ADDRESS_A))?.encryptedBiometricPassword;
+    expect(inspectEncryptionFormat(before!)).toBe('argon2id');
+
+    expect(await StorageService.getEncryptedWalletPassword(SECURE_KEY, ADDRESS_A)).toBe(
+      'my-wallet-pw',
+    );
+
+    // No needless rewrite: secureEncrypt uses a fresh salt/IV each call, so an untouched blob is
+    // byte-for-byte identical.
+    const after = (await StorageService.getWalletByAddress(ADDRESS_A))?.encryptedBiometricPassword;
+    expect(after).toBe(before);
+  });
 });
 
 describe('creating wallets', () => {

--- a/src/services/core/StorageService.ts
+++ b/src/services/core/StorageService.ts
@@ -2105,10 +2105,17 @@ export class StorageService {
       // Try to get password from wallet record
       if (wallet?.encryptedBiometricPassword) {
         // Decrypt the password using the secure key
-        const { decrypted, wasLegacy } = await decryptData(
+        const { decrypted, format } = await decryptData(
           wallet.encryptedBiometricPassword,
           secureKey,
         );
+        // Unlike the wallet key, this blob has no unlock path that re-seals it, so a credential
+        // enrolled under an older KDF (scrypt/legacy) would re-run that slow derivation on every
+        // biometric login — painfully slow in a mobile browser. Transparently upgrade it to the
+        // current Argon2id format on first read; best-effort, and never blocks the unlock.
+        if (format !== 'argon2id') {
+          await this.migrateBiometricPassword(secureKey, decrypted, walletAddress);
+        }
         return decrypted;
       }
 
@@ -2123,11 +2130,30 @@ export class StorageService {
       }
 
       // Decrypt the password using the secure key
-      const { decrypted } = await decryptData(encryptedPassword, secureKey);
+      const { decrypted, format } = await decryptData(encryptedPassword, secureKey);
+      if (format !== 'argon2id') {
+        await this.migrateBiometricPassword(secureKey, decrypted, walletAddress);
+      }
       return decrypted;
     } catch (error) {
       storageLogger.error('Failed to retrieve encrypted wallet password:', error);
       return null;
+    }
+  }
+
+  // Re-seal a biometric password blob with the current Argon2id format after it was read from an
+  // older KDF. Best-effort: a failure here must never turn a successful biometric unlock into a
+  // failed one, so it only logs. Reuses setEncryptedWalletPassword, which writes both the wallet
+  // record and the legacy preferences map.
+  private static async migrateBiometricPassword(
+    secureKey: string,
+    password: string,
+    walletAddress: string,
+  ): Promise<void> {
+    try {
+      await this.setEncryptedWalletPassword(secureKey, password, walletAddress);
+    } catch (migrationError) {
+      storageLogger.warn('Could not upgrade biometric password to Argon2id', migrationError);
     }
   }
 


### PR DESCRIPTION
## The bug you hit
On iPhone, biometric login was slow until you deleted and re-added the credential — then it was fast. That's a real gap, not a fluke.

The wallet **key** re-encrypts to Argon2id on the first unlock, so that part got fast. But the wallet **password** stashed behind a biometric credential had *no* re-seal path. A credential enrolled under the old scrypt build meant every biometric login re-ran a multi-second **scrypt** derivation (scrypt-js is pure-JS and painfully slow in mobile Safari). Deleting + re-adding fixed it only because that rewrote the blob with the current KDF.

## The fix
`getEncryptedWalletPassword` now upgrades the blob transparently, mirroring the wallet-key migration: after decrypting, if the format isn't `argon2id` it re-seals with `setEncryptedWalletPassword` (Argon2id). Best-effort — a write failure only logs, so it can never turn a successful unlock into a failed one. Covers both the wallet-record and the legacy-preferences read paths.

**Effect:** the first biometric login after this deploy pays the old slow scrypt derivation once, then re-seals; every login after is fast. No manual delete/re-add needed.

## Tests
- Seed a scrypt-format biometric blob → read returns the right password **and** leaves the stored blob as `argon2id`, and it still unlocks.
- An existing `argon2id` blob is left byte-for-byte untouched (no needless rewrite).
- 552 unit tests pass; typecheck + `pnpm build` clean.

## Version
Bumps **2.4.2 → 2.4.3** so the About page confirms the automated deploy landed.