### PR TITLE
perf(sync): concurrent + cached Electrum history sync (+ v2.4.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -23,6 +23,12 @@ import {
 import * as bitcoinMessage from 'bitcoinjs-message';
 import { randomBytes, createHash, createCipheriv, createDecipheriv, createHmac } from 'crypto';
 import { secureEncrypt, secureDecrypt, decryptData, legacyDecrypt } from './encryption';
+import { runWithConcurrency } from './concurrency';
+
+// How many transaction.get requests to keep in flight while syncing history. Electrum matches
+// responses by id, so a small pool cuts the latency of a large sync ~N-fold without hammering the
+// server. Kept modest to stay friendly to public ElectrumX nodes.
+const HISTORY_SYNC_CONCURRENCY = 12;
 
 // Re-exported so existing importers of these helpers from WalletService keep working. New code
 // that only needs encryption should import from './encryption' directly, to avoid pulling the
@@ -2232,18 +2238,45 @@ export class WalletService {
 
         try {
             const currentHeight = await this.electrum.getCurrentBlockHeight();
-            if (currentHeight === 0) {
-                // If we can't get current height, assume 1 confirmation for confirmed transactions
-                return 1;
-            }
-
-            const confirmations = Math.max(0, currentHeight - blockHeight + 1);
-            return confirmations;
+            return this.confirmationsAtHeight(blockHeight, currentHeight);
         } catch (error) {
             walletLogger.error('Error calculating confirmations:', error);
             // Fallback: return 1 for confirmed transactions, 0 for unconfirmed
             return blockHeight ? 1 : 0;
         }
+    }
+
+    // Synchronous confirmation count against an already-known chain tip. Lets a bulk sync fetch the
+    // tip once instead of calling getCurrentBlockHeight for every transaction.
+    private confirmationsAtHeight(blockHeight?: number, currentHeight?: number): number {
+        if (!blockHeight) return 0; // Unconfirmed
+        if (!currentHeight) return 1; // Tip unknown but the tx is in a block — at least 1
+        return Math.max(0, currentHeight - blockHeight + 1);
+    }
+
+    // Fetch a verbose transaction, reusing a per-sync cache so the same parent transaction is never
+    // pulled from the server twice. Input-address resolution repeatedly needs a transaction's
+    // parents, and across a whole history the same parents recur constantly (a wallet's sends spend
+    // its own earlier receives), so this collapses a large share of the round-trips.
+    //
+    // The cache stores the in-flight promise, not the resolved value, so many concurrent workers
+    // asking for the same parent at once share a single request instead of each firing their own (a
+    // thundering herd the pool would otherwise create). A failed fetch is evicted so a later item
+    // can retry rather than inheriting a cached rejection.
+    private getTransactionCached(txid: string, cache?: Map<string, Promise<any>>): Promise<any> {
+        if (!cache) {
+            return this.electrum.getTransaction(txid, true);
+        }
+        const inFlight = cache.get(txid);
+        if (inFlight) {
+            return inFlight;
+        }
+        const request = this.electrum.getTransaction(txid, true).catch((error) => {
+            cache.delete(txid);
+            throw error;
+        });
+        cache.set(txid, request);
+        return request;
     }
 
     /**
@@ -2285,34 +2318,49 @@ export class WalletService {
             // Report initial progress
             onProgress?.(0, total);
 
-            // Process each transaction from history (both new and existing for updates)
-            for (const historyTx of txHistory) {
+            // Fetch the chain tip once so each transaction's confirmation count is computed locally
+            // rather than asking the server per transaction.
+            let currentHeight = 0;
+            try {
+                currentHeight = await this.electrum.getCurrentBlockHeight();
+            } catch (heightError) {
+                walletLogger.warn('Could not fetch chain tip for confirmations; using fallback', heightError);
+            }
+
+            // Shared per-sync cache so input-address resolution never refetches the same parent tx.
+            const txCache = new Map<string, Promise<any>>();
+
+            // Fetch and classify with a bounded pool of concurrent requests instead of one-at-a-time.
+            // Each worker is self-contained and swallows its own errors, so a single bad transaction
+            // never aborts the sync; progress is reported as each finishes (order is not guaranteed,
+            // but the count is monotonic).
+            await runWithConcurrency(txHistory, HISTORY_SYNC_CONCURRENCY, async (historyTx) => {
                 try {
                     // Skip already processed transactions if onlyNewTransactions is true
                     if (onlyNewTransactions && existingTxIdSet.has(historyTx.tx_hash)) {
                         // Still count as processed for progress reporting
                         processedCount++;
                         onProgress?.(processedCount, total, historyTx.tx_hash);
-                        continue;
+                        return;
                     }
-                    // Get detailed transaction information
-                    const txDetails = await this.electrum.getTransaction(historyTx.tx_hash, true);
+                    // Get detailed transaction information (cached, so parents resolve cheaply)
+                    const txDetails = await this.getTransactionCached(historyTx.tx_hash, txCache);
                     if (!txDetails) {
                         processedCount++;
                         onProgress?.(processedCount, total, historyTx.tx_hash);
-                        continue;
+                        return;
                     }
 
-                    // Classify transaction as sent or received
-                    const classification = await this.classifyTransaction(txDetails, address);
+                    // Classify transaction as sent or received, sharing the per-sync cache
+                    const classification = await this.classifyTransaction(txDetails, address, txCache);
                     if (!classification) {
                         processedCount++;
                         onProgress?.(processedCount, total, historyTx.tx_hash);
-                        continue;
+                        return;
                     }
 
-                    // Calculate proper confirmations
-                    const confirmations = await this.calculateConfirmations(historyTx.height);
+                    // Confirmations against the tip we fetched once above
+                    const confirmations = this.confirmationsAtHeight(historyTx.height, currentHeight);
 
                     // Check if we have an existing transaction of this type
                     const existingTx = existingTxMap.get(`${historyTx.tx_hash}-${classification.type}`);
@@ -2377,7 +2425,7 @@ export class WalletService {
                     processedCount++;
                     onProgress?.(processedCount, total, historyTx.tx_hash);
                 }
-            }
+            });
 
             // Report final progress
             if (total > 0) {
@@ -2583,6 +2631,7 @@ export class WalletService {
     private async classifyTransaction(
         txDetails: any,
         address: string,
+        cache?: Map<string, Promise<any>>,
     ): Promise<{
         type: 'send' | 'receive';
         amount: number;
@@ -2628,7 +2677,7 @@ export class WalletService {
                     // If no direct address, we need to look up the previous transaction output
                     else if (input.txid && input.vout !== undefined) {
                         try {
-                            const prevTxDetails = await this.electrum.getTransaction(input.txid, true);
+                            const prevTxDetails = await this.getTransactionCached(input.txid, cache);
                             if (prevTxDetails && prevTxDetails.vout && prevTxDetails.vout[input.vout]) {
                                 const prevOutput = prevTxDetails.vout[input.vout];
 

--- a/src/services/wallet/concurrency.test.ts
+++ b/src/services/wallet/concurrency.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { runWithConcurrency } from './concurrency';
+
+const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('runWithConcurrency', () => {
+  it('runs every item exactly once, with its original index', async () => {
+    const seen: Array<[number, number]> = [];
+    await runWithConcurrency([10, 20, 30], 2, async (item, index) => {
+      seen.push([item, index]);
+    });
+    expect(seen.sort((a, b) => a[1] - b[1])).toEqual([
+      [10, 0],
+      [20, 1],
+      [30, 2],
+    ]);
+  });
+
+  it('processes a list longer than the limit', async () => {
+    const done: number[] = [];
+    await runWithConcurrency([1, 2, 3, 4, 5, 6, 7], 3, async (n) => {
+      done.push(n);
+    });
+    expect(done.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('never exceeds the concurrency limit, but does run in parallel', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    await runWithConcurrency(items, 4, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await tick(5);
+      inFlight--;
+    });
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(1);
+  });
+
+  it('clamps a limit below 1 to serial execution', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await runWithConcurrency([1, 2, 3], 0, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await tick(1);
+      inFlight--;
+    });
+    expect(peak).toBe(1);
+  });
+
+  it('does nothing for an empty list', async () => {
+    const worker = vi.fn(async () => {});
+    await runWithConcurrency([], 4, worker);
+    expect(worker).not.toHaveBeenCalled();
+  });
+
+  it('rejects when a worker throws', async () => {
+    await expect(
+      runWithConcurrency([1, 2, 3], 2, async (n) => {
+        if (n === 2) throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/src/services/wallet/concurrency.ts
+++ b/src/services/wallet/concurrency.ts
@@ -1,0 +1,35 @@
+/**
+ * Run an async worker over a list with a bounded number of tasks in flight at once.
+ *
+ * Electrum's transport matches responses to requests by id, so many `transaction.get` calls can be
+ * outstanding on one socket simultaneously. Fetching a large transaction history one-at-a-time pays
+ * the round-trip latency serially; a small pool cuts the wall-clock time by roughly the pool size
+ * while keeping a ceiling on how hard the server is hit.
+ *
+ * Ordering is not preserved — workers pull from a shared cursor as they free up — so the worker must
+ * not rely on completion order. A worker that throws rejects the whole run (like `Promise.all`);
+ * callers that want to tolerate per-item failure should catch inside the worker.
+ *
+ * @param items   the work list
+ * @param limit   maximum tasks running concurrently (clamped to >= 1)
+ * @param worker  invoked once per item with the item and its original index
+ */
+export async function runWithConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  const bound = Math.max(1, Math.floor(limit));
+  let cursor = 0;
+
+  const runner = async (): Promise<void> => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      await worker(items[index], index);
+    }
+  };
+
+  const runners = Array.from({ length: Math.min(bound, items.length) }, () => runner());
+  await Promise.all(runners);
+}

--- a/src/services/wallet/transactionClassification.test.ts
+++ b/src/services/wallet/transactionClassification.test.ts
@@ -538,3 +538,72 @@ describe('bookkeeping', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe('sync efficiency', () => {
+  it('fetches a shared parent transaction only once across the whole sync', async () => {
+    await ownWallets(WALLET_A);
+    const PARENT = 'p'.repeat(64);
+    const SEND_1 = '1'.repeat(64);
+    const SEND_2 = '2'.repeat(64);
+    const SEND_3 = '3'.repeat(64);
+    // Three sends that each spend an output of the same funding tx. The inputs carry no address, so
+    // classification must resolve them from the parent — which the per-sync cache should pull once.
+    const spendParent = { vin: [{ txid: PARENT, vout: 0 }], vout: [out(EXTERNAL, 1)] };
+    const electrum = createElectrum(
+      {
+        [PARENT]: { vout: [out(WALLET_A, 100)] },
+        [SEND_1]: spendParent,
+        [SEND_2]: spendParent,
+        [SEND_3]: spendParent,
+      },
+      [
+        { tx_hash: SEND_1, height: 990 },
+        { tx_hash: SEND_2, height: 990 },
+        { tx_hash: SEND_3, height: 990 },
+      ],
+    );
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    const parentCalls = electrum.getTransaction.mock.calls.filter(([hash]) => hash === PARENT);
+    expect(parentCalls).toHaveLength(1);
+    // 3 history txs + 1 shared parent = 4 (not 3 + 3 without the cache).
+    expect(electrum.getTransaction).toHaveBeenCalledTimes(4);
+    expect(await historyFor(WALLET_A)).toHaveLength(3);
+  });
+
+  it('records every transaction in a history larger than the concurrency limit', async () => {
+    await ownWallets(WALLET_A);
+    const COUNT = 30; // comfortably above HISTORY_SYNC_CONCURRENCY
+    const transactions: Record<string, TxDetails> = {};
+    const history: { tx_hash: string; height: number }[] = [];
+    for (let i = 0; i < COUNT; i++) {
+      const hash = i.toString(16).padStart(64, '0');
+      transactions[hash] = { time: 1_700_000_000 + i, vin: [from(EXTERNAL)], vout: [out(WALLET_A, i + 1)] };
+      history.push({ tx_hash: hash, height: 900 + i });
+    }
+    const electrum = createElectrum(transactions, history);
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    expect(await historyFor(WALLET_A)).toHaveLength(COUNT);
+  });
+
+  it('reads the chain tip once for the whole sync, not per transaction', async () => {
+    await ownWallets(WALLET_A);
+    const electrum = createElectrum(
+      {
+        ['1'.repeat(64)]: { vin: [from(EXTERNAL)], vout: [out(WALLET_A, 1)] },
+        ['2'.repeat(64)]: { vin: [from(EXTERNAL)], vout: [out(WALLET_A, 2)] },
+      },
+      [
+        { tx_hash: '1'.repeat(64), height: 990 },
+        { tx_hash: '2'.repeat(64), height: 991 },
+      ],
+    );
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    expect(electrum.getCurrentBlockHeight).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## The problem you hit
Syncing a wallet that doesn't have its full history yet was slow because [`processTransactionHistory`](src/services/wallet/WalletService.ts) fetched everything **strictly one-at-a-time**, and each transaction hid *more* serial round-trips:

1. fetch the tx,
2. for each **input**, fetch its parent tx to resolve the sender address,
3. fetch the chain tip for confirmations (per tx!),
4. one IndexedDB write per tx.

For 5000+ transactions that's tens of thousands of sequential network round-trips — you were paying the latency serially.

## The fix (network-latency focused; classification logic unchanged)
1. **Bounded-concurrency fetch pool** (`runWithConcurrency`, 12 in flight) replaces the sequential loop. The transport already matches responses by request id, so many `transaction.get` calls can be outstanding on one socket. This is the big win — roughly an N-fold cut in serial round-trips.
2. **Per-sync transaction cache**, shared across the main loop and input-address resolution, so a parent tx (a wallet's sends spend its own earlier receives) is pulled **once** instead of once per referencing input. It caches the *in-flight promise*, not the resolved value, so concurrent workers asking for the same parent share one request rather than stampeding; a failed fetch is evicted so a later item can retry.
3. **Fetch the chain tip once** before the loop and compute confirmations locally, instead of calling `getCurrentBlockHeight` per transaction.

## Scope
This targets the on-load incremental sync path (`refreshTransactionHistory` → `processTransactionHistory`). The on-demand full reprocess (`reprocessTransactionHistory`, balance-card long-press) still uses its own loop — a candidate for the same treatment later if you want it.

## Tests
- `concurrency.test.ts`: pool respects the limit, actually runs in parallel, propagates worker errors, clamps `<1`, handles empty.
- `transactionClassification.test.ts` (new `sync efficiency` block): a shared parent is fetched **once**, a history larger than the pool is recorded in full, and the tip is read **once**.
- 561 unit tests pass; typecheck + `pnpm build` clean.

## Version
Bumps **2.4.3 → 2.4.4** so the About page confirms the deploy landed.