### PR TITLE
fix(electrum): persist server choice and actually switch to it (+ v2.4.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -152,6 +152,20 @@ export function WalletProvider({ children }: WalletProviderProps) {
     currentTx?: string;
   }>({ isProcessing: false, processed: 0, total: 0 });
 
+  // Wallet activation callbacks, shared by the initial load and by re-activation after a server
+  // switch so both wire up the same balance/progress handling.
+  const handleWalletBalanceUpdate = useCallback((data: { balance: number }) => {
+    setBalance(data.balance);
+    setBalanceStatus('live');
+  }, []);
+
+  const handleWalletProgress = useCallback(
+    (processed: number, total: number, currentTx?: string) => {
+      setProcessingProgress({ isProcessing: total > 0, processed, total, currentTx });
+    },
+    [],
+  );
+
   const initializeWallet = async () => {
     try {
       setIsLoading(true);
@@ -164,6 +178,10 @@ export function WalletProvider({ children }: WalletProviderProps) {
       const { WalletService } = await import('@/services/wallet/WalletService');
       const walletService = new WalletService(electrumService);
       setWallet(walletService);
+
+      // Re-apply the user's saved server choice before connecting — the ElectrumService defaults to
+      // the first server, so without this a reload silently reverts the selection.
+      await walletService.restoreSelectedServer();
 
       // Update server info
       setServerInfo(walletService.getElectrumServerInfo());
@@ -195,19 +213,8 @@ export function WalletProvider({ children }: WalletProviderProps) {
         // Initialize wallet with subscription for real-time updates
         await walletService.initializeWallet(
           activeWallet.address,
-          (data) => {
-            setBalance(data.balance);
-            setBalanceStatus('live');
-          },
-          (processed, total, currentTx) => {
-            // Set processing progress during initial transaction loading
-            setProcessingProgress({
-              isProcessing: total > 0,
-              processed,
-              total,
-              currentTx,
-            });
-          },
+          handleWalletBalanceUpdate,
+          handleWalletProgress,
         );
 
         // Clear processing progress when initialization is complete
@@ -622,9 +629,23 @@ export function WalletProvider({ children }: WalletProviderProps) {
 
     try {
       setIsLoading(true);
+      // Switches server, persists the choice, and reconnects if we were connected.
       await wallet.selectElectrumServer(index);
       setIsConnected(wallet.isConnectedToElectrum());
       setServerInfo(wallet.getElectrumServerInfo());
+
+      // Switching servers tears down the old socket, which also drops its address subscriptions.
+      // Re-activate the active wallet on the new server so balance and history updates resume —
+      // otherwise the wallet looks "stuck" until a reload.
+      const activeWallet = await StorageService.getActiveWallet();
+      if (activeWallet?.address) {
+        await wallet.initializeWallet(
+          activeWallet.address,
+          handleWalletBalanceUpdate,
+          handleWalletProgress,
+        );
+        setProcessingProgress({ isProcessing: false, processed: 0, total: 0 });
+      }
     } catch (error) {
       walletContextLogger.error('Failed to select ElectrumX server:', error);
       throw error;

--- a/src/services/core/StorageService.ts
+++ b/src/services/core/StorageService.ts
@@ -1157,6 +1157,17 @@ export class StorageService {
     }
   }
 
+  // Which ElectrumX server the user last selected, by host. Persisted so the choice survives a
+  // page reload — the ElectrumService otherwise defaults back to the first server on every load.
+  static async getSelectedElectrumServer(): Promise<string | null> {
+    const host = (await this.getPreference('selectedElectrumServerHost')) as string | null;
+    return host || null;
+  }
+
+  static async setSelectedElectrumServer(host: string): Promise<void> {
+    await this.setPreference('selectedElectrumServerHost', host);
+  }
+
   // Script hash methods
   static async getScriptHash(): Promise<string> {
     return (await this.getPreference('scripthash')) || '';

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -1300,14 +1300,46 @@ export class WalletService {
 
     async selectElectrumServer(index: number): Promise<void> {
         try {
+            // Capture the connection state up front: selectServer() tears the socket down, so
+            // checking afterwards always reads "disconnected" and the reconnect never fired — that
+            // was the bug where switching servers left the wallet dead until a reload.
+            const wasConnected = this.isConnectedToElectrum();
+            if (wasConnected) {
+                // Await a full disconnect so the old socket is closed before we open the new one.
+                await this.disconnectFromElectrum();
+            }
+
             this.electrum.selectServer(index);
-            // Reconnect to the new server
-            if (this.isConnectedToElectrum()) {
+
+            // Persist the choice so it survives a reload.
+            const host = this.electrum.getCurrentServer()?.host;
+            if (host) {
+                await StorageService.setSelectedElectrumServer(host);
+            }
+
+            if (wasConnected) {
                 await this.connectToElectrum();
             }
         } catch (error) {
             walletLogger.error('Error selecting ElectrumX server:', error);
             throw error;
+        }
+    }
+
+    /**
+     * Re-apply the user's last saved ElectrumX server before connecting. The ElectrumService always
+     * constructs with the first server as its default, so without this a reload silently reverts to
+     * it. Call this after constructing the service and before connecting. A saved host that no longer
+     * exists (the server list changed) just falls back to the default.
+     */
+    async restoreSelectedServer(): Promise<void> {
+        try {
+            const host = await StorageService.getSelectedElectrumServer();
+            if (host) {
+                this.electrum.selectServerByHost(host);
+            }
+        } catch (error) {
+            walletLogger.warn('Could not restore the saved ElectrumX server; using default', error);
         }
     }
 

--- a/src/services/wallet/serverSelection.test.ts
+++ b/src/services/wallet/serverSelection.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WalletService } from './WalletService';
+import { StorageService } from '@/services/core/StorageService';
+import { resetStorage } from '@/test/helpers';
+
+/**
+ * Choosing an ElectrumX server must (1) reconnect to the new server, (2) survive a reload, and
+ * (3) tolerate a saved server that no longer exists. The ElectrumService always constructs with the
+ * first server as its default, so these behaviours live in WalletService, which owns persistence.
+ */
+
+const SERVERS = [
+  { host: 'electrum-us.avn.network', port: 50003, protocol: 'wss', region: 'US' },
+  { host: 'electrum-eu.avn.network', port: 50003, protocol: 'wss', region: 'EU' },
+];
+
+/** A minimal stand-in for ElectrumService covering just the server-selection surface. */
+function fakeElectrum() {
+  let current = SERVERS[0];
+  let connected = false;
+  return {
+    getAvailableServers: vi.fn(() => SERVERS),
+    getCurrentServer: vi.fn(() => current),
+    getServerUrl: vi.fn(() => `${current.protocol}://${current.host}:${current.port}`),
+    isConnectedToServer: vi.fn(() => connected),
+    connect: vi.fn(async () => {
+      connected = true;
+    }),
+    disconnect: vi.fn(async () => {
+      connected = false;
+    }),
+    selectServer: vi.fn((index: number) => {
+      current = SERVERS[index];
+    }),
+    selectServerByHost: vi.fn((host: string) => {
+      const match = SERVERS.find((s) => s.host === host);
+      if (!match) throw new Error(`Server not found: ${host}`);
+      current = match;
+    }),
+  };
+}
+
+beforeEach(() => {
+  resetStorage();
+});
+
+describe('selectElectrumServer', () => {
+  it('persists the chosen server so it survives a reload', async () => {
+    const electrum = fakeElectrum();
+    await new WalletService(electrum as never).selectElectrumServer(1);
+
+    expect(electrum.selectServer).toHaveBeenCalledWith(1);
+    expect(await StorageService.getSelectedElectrumServer()).toBe('electrum-eu.avn.network');
+  });
+
+  it('reconnects to the new server when it was connected', async () => {
+    const electrum = fakeElectrum();
+    await electrum.connect(); // start connected
+    electrum.connect.mockClear();
+
+    await new WalletService(electrum as never).selectElectrumServer(1);
+
+    expect(electrum.disconnect).toHaveBeenCalled();
+    expect(electrum.connect).toHaveBeenCalledTimes(1); // reconnected to the new server
+    expect(electrum.isConnectedToServer()).toBe(true);
+  });
+
+  it('does not connect when it was not connected to begin with', async () => {
+    const electrum = fakeElectrum();
+
+    await new WalletService(electrum as never).selectElectrumServer(1);
+
+    expect(electrum.disconnect).not.toHaveBeenCalled();
+    expect(electrum.connect).not.toHaveBeenCalled();
+    // But the choice is still remembered for next time.
+    expect(await StorageService.getSelectedElectrumServer()).toBe('electrum-eu.avn.network');
+  });
+});
+
+describe('restoreSelectedServer', () => {
+  it('re-applies the saved server before connecting', async () => {
+    await StorageService.setSelectedElectrumServer('electrum-eu.avn.network');
+    const electrum = fakeElectrum();
+
+    await new WalletService(electrum as never).restoreSelectedServer();
+
+    expect(electrum.selectServerByHost).toHaveBeenCalledWith('electrum-eu.avn.network');
+    expect(electrum.getCurrentServer().host).toBe('electrum-eu.avn.network');
+  });
+
+  it('does nothing when no server has been saved', async () => {
+    const electrum = fakeElectrum();
+
+    await new WalletService(electrum as never).restoreSelectedServer();
+
+    expect(electrum.selectServerByHost).not.toHaveBeenCalled();
+    expect(electrum.getCurrentServer().host).toBe('electrum-us.avn.network');
+  });
+
+  it('falls back to the default when the saved server no longer exists', async () => {
+    await StorageService.setSelectedElectrumServer('electrum-gone.avn.network');
+    const electrum = fakeElectrum();
+
+    await expect(
+      new WalletService(electrum as never).restoreSelectedServer(),
+    ).resolves.toBeUndefined();
+    expect(electrum.getCurrentServer().host).toBe('electrum-us.avn.network');
+  });
+});


### PR DESCRIPTION
Selecting a different ElectrumX server (you're in the EU) appeared to break the wallet, and a reload always snapped back to the US server. Three separate bugs:

1. **Dead reconnect.** `selectElectrumServer` checked `isConnected` *after* `selectServer()` had already disconnected, so the reconnect branch never ran — switching left the socket closed and never reopened.
2. **Subscriptions wiped.** `disconnect()` clears the address subscriptions, so even once reconnected the wallet got no balance/history updates until a full reload — the "stops working" symptom.
3. **No persistence.** `ElectrumService` constructs with the first server (US) as its default and the choice was never saved, so every reload reverted.

## Fixes
- **`WalletService.selectElectrumServer`** — capture the connection state up front, await a clean disconnect, switch, **persist the host**, then reconnect.
- **`WalletService.restoreSelectedServer`** (new) — re-apply the saved host before the initial connect; a saved host that no longer exists falls back to the default.
- **`StorageService`** — scoped `get/setSelectedElectrumServer` preference.
- **`WalletContext`** — restore the saved server on init, and after a switch re-run `initializeWallet` for the active wallet so its **subscription and refresh come back on the new server**. Balance/progress callbacks factored out and shared with the initial-load path.

## Tests
`serverSelection.test.ts`: persists the host, reconnects when it was connected, stays disconnected otherwise; `restoreSelectedServer` re-applies a saved host and falls back cleanly when it's gone (6 cases). Full suite green; typecheck + `pnpm build` clean.

## Version
Bumps **2.4.4 → 2.4.5**.

> Note: switching also triggers a re-sync on the new server, which now benefits from the concurrent/cached sync (#45).