### PR TITLE
perf(sync): process history newest-first (+ v2.4.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -2311,6 +2311,20 @@ export class WalletService {
         return request;
     }
 
+    // Order a raw get_history list newest-first, in place: mempool entries (height <= 0) first, then
+    // confirmed transactions by descending block height. get_history only carries tx_hash + height,
+    // so this is approximate within a single block — good enough to surface recent activity first.
+    private sortHistoryNewestFirst(history: Array<{ tx_hash: string; height: number }>): void {
+        history.sort((a, b) => {
+            const aUnconfirmed = (a.height ?? 0) <= 0;
+            const bUnconfirmed = (b.height ?? 0) <= 0;
+            if (aUnconfirmed !== bUnconfirmed) {
+                return aUnconfirmed ? -1 : 1;
+            }
+            return (b.height ?? 0) - (a.height ?? 0);
+        });
+    }
+
     /**
      * Process transaction history for a wallet address
      * @param address - The wallet address
@@ -2329,6 +2343,12 @@ export class WalletService {
             if (!txHistory || txHistory.length === 0) {
                 return;
             }
+
+            // Process newest-first so the transactions a user actually looks at land in storage (and
+            // on screen) first, while older history backfills behind them. get_history's own order is
+            // not guaranteed, so sort explicitly for deterministic behaviour: mempool entries
+            // (height <= 0) first, then confirmed transactions by descending block height.
+            this.sortHistoryNewestFirst(txHistory);
 
             // Get existing transactions from local storage.
             // getTransactionHistory falls back to matching the counterparty address when a wallet

--- a/src/services/wallet/transactionClassification.test.ts
+++ b/src/services/wallet/transactionClassification.test.ts
@@ -589,6 +589,29 @@ describe('sync efficiency', () => {
     expect(await historyFor(WALLET_A)).toHaveLength(COUNT);
   });
 
+  it('fetches newest-first: unconfirmed, then highest block height', async () => {
+    await ownWallets(WALLET_A);
+    const A = 'a'.repeat(64); // height 100 (oldest)
+    const B = 'b'.repeat(64); // height 300 (newest confirmed)
+    const C = 'c'.repeat(64); // height 0   (unconfirmed / mempool)
+    const D = 'd'.repeat(64); // height 200
+    const received = { vin: [from(EXTERNAL)], vout: [out(WALLET_A, 1)] };
+    const electrum = createElectrum(
+      { [A]: received, [B]: received, [C]: received, [D]: received },
+      [
+        { tx_hash: A, height: 100 },
+        { tx_hash: B, height: 300 },
+        { tx_hash: C, height: 0 },
+        { tx_hash: D, height: 200 },
+      ],
+    );
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    const fetchOrder = electrum.getTransaction.mock.calls.map(([hash]) => hash);
+    expect(fetchOrder).toEqual([C, B, D, A]); // mempool, then 300 → 200 → 100
+  });
+
   it('reads the chain tip once for the whole sync, not per transaction', async () => {
     await ownWallets(WALLET_A);
     const electrum = createElectrum(


### PR DESCRIPTION
Follow-up to #45. Even with the concurrent/cached sync, a large history was fetched in whatever order `get_history` returned (often oldest-first), so the transactions you actually want to see were the *last* to land.

## Change
Sort the `get_history` list before fetching bodies — **mempool entries (`height <= 0`) first, then confirmed by descending block height** (your comparator). Because the dashboard renders during the sync and `TransactionHistory` re-reads storage every few seconds while it runs, newest-first processing means **recent transactions show within seconds** while older history backfills behind them.

This is the "eager page + background backfill" approach:
- Recent activity is visible almost immediately.
- The full history still ends up local, so **backup and search stay complete**.
- `get_history`'s own order isn't guaranteed, so this also makes ordering **deterministic**.

Balance is unaffected either way — it comes from `get_balance`, not from summing history.

## Test
`processTransactionHistory` fetches an unconfirmed tx first, then confirmed transactions in descending-height order.

## Not included
The total sync still completes in the background (the progress indicator counts up for a while on a 5k+ wallet). If that's still too prominent, the next step is **true lazy paging** (only fetch pages as viewed) — a larger change we scoped but deferred.

## Version
Bumps **2.4.5 → 2.4.6**.