### PR TITLE
fix(ui): non-reflowing sync progress + usable connection buttons (+ v2.4.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/BalanceInstrument.tsx
+++ b/src/components/BalanceInstrument.tsx
@@ -182,23 +182,25 @@ export function BalanceInstrument({
                     )}
                 </div>
 
-                {/* processing progress */}
-                {processingProgress.isProcessing && (
-                    <div className="mt-4 rounded-lg border border-white/15 bg-white/10 p-2 text-xs text-white">
-                        <div className="flex flex-wrap items-center">
-                            <Loader className="mr-1.5 h-3 w-3 flex-shrink-0 animate-spin text-white" />
-                            <span className="font-medium">
-                                Processing… {processingProgress.processed}/{processingProgress.total}
-                            </span>
-                        </div>
-                        {processingProgress.currentTx && (
-                            <div className="mt-1 truncate pl-4 text-white/80">
-                                TX: {processingProgress.currentTx.slice(0, 6)}…
-                            </div>
-                        )}
-                    </div>
-                )}
             </div>
+
+            {/* history-sync progress: a thin bar pinned to the bottom edge of the card so it signals
+                activity without growing the card and pushing the dashboard down. The running count
+                still shows in the Transaction History panel. */}
+            {processingProgress.isProcessing && processingProgress.total > 0 && (
+                <div
+                    aria-hidden
+                    className="absolute inset-x-0 bottom-0 h-0.5 bg-white/10"
+                    title={`Syncing transaction history ${processingProgress.processed}/${processingProgress.total}`}
+                >
+                    <div
+                        className="h-full bg-[#34F5C6] shadow-[0_0_8px_rgba(52,245,198,0.6)] transition-[width] duration-500 ease-out"
+                        style={{
+                            width: `${Math.min(100, (processingProgress.processed / processingProgress.total) * 100)}%`,
+                        }}
+                    />
+                </div>
+            )}
         </section>
     );
 }

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -158,14 +158,17 @@ export default function ConnectionStatus({ className = '' }: ConnectionStatusPro
               {isLoading ? 'Connecting...' : 'Connect'}
             </Button>
           ) : (
-            <Button onClick={handleDisconnect} disabled={isLoading} variant="destructive" size="sm">
+            // Only rendered when connected, so disconnecting is always safe — don't gate it on the
+            // global loading flag, which the long history sync holds true and used to leave this
+            // (and Ping) stuck disabled.
+            <Button onClick={handleDisconnect} variant="destructive" size="sm">
               Disconnect
             </Button>
           )}
 
           <Button
             onClick={handleTest}
-            disabled={isLoading || isTesting}
+            disabled={isTesting}
             variant="secondary"
             size="sm"
           >


### PR DESCRIPTION
Two rough edges the longer background history sync exposed.

## 1. Balance card no longer gets pushed down
The card rendered a full padded "Processing… n/total" box below the address, so while syncing it grew and shoved the whole dashboard down. Replaced with a **thin progress bar pinned to the card's bottom edge** (absolute, `overflow-hidden` clip) — it shows sync activity/progress without changing layout. The running count still lives in the **Transaction History** panel, which is the natural place for it.

## 2. Disconnect / Ping stay usable during a sync
You asked whether these are still needed or stuck behind a gate — **it's the gate.** Both were `disabled={isLoading}`, and the long history sync holds `isLoading` true for minutes, so they sat greyed out the whole time.

- **Disconnect** only renders when connected, so disconnecting is always safe — removed the gate.
- **Ping Server** now keys off its own in-flight state (`isTesting`) only, not the sync.
- **Connect** keeps its `isLoading` guard (it only shows while disconnected, where the guard prevents a double auto-connect).

## Notes
UI-only; typecheck + `pnpm build` clean. (Also confirms server persistence is working — your screenshot shows EU connected.)

## Version
Bumps **2.4.6 → 2.4.7**.