### PR TITLE
fix(ui): tidy balance card — drop duplicate address, fix horizon strikethrough (+ v2.4.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,6 @@ export default function Home() {
     // null = still determining; false = no wallet on device (show the landing page); true = dashboard
     const [walletExists, setWalletExists] = useState<boolean | null>(null);
     const [showAboutModal, setShowAboutModal] = useState(false);
-    const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
     const [termsAccepted, setTermsAccepted] = useState<boolean | null>(null);
 
     const fullRefreshRequestedRef = useRef(false);
@@ -114,24 +113,6 @@ export default function Home() {
         return `${address.slice(0, 8)}...${address.slice(-8)}`;
     };
 
-    const handleCopyAddress = async (address: string) => {
-        try {
-            await navigator.clipboard.writeText(address);
-            setCopiedAddress(address);
-            toast.success('Address copied to clipboard', {
-                description: 'Wallet address has been copied successfully',
-            });
-
-            // Reset the copied state after 2 seconds
-            setTimeout(() => {
-                setCopiedAddress(null);
-            }, 2000);
-        } catch (error) {
-            toast.error('Copy Failed', {
-                description: 'Could not copy address to clipboard',
-            });
-        }
-    };
     const handleRefresh = async () => {
         try {
             setIsRefreshing(true);
@@ -263,16 +244,13 @@ export default function Home() {
                     className="mb-6"
                     balance={balance}
                     balanceStatus={balanceStatus}
-                    address={address ?? null}
                     isLoading={isLoading}
                     processingProgress={processingProgress}
                     isRefreshing={isRefreshing}
-                    copied={copiedAddress === address}
                     formatBalance={formatBalance}
                     onRefresh={handleRefresh}
                     onRefreshMouseDown={handleRefreshMouseDown}
                     onRefreshMouseUp={handleRefreshMouseUp}
-                    onCopy={handleCopyAddress}
                 />
 
                 {/* Navigation Tabs */}
@@ -337,16 +315,13 @@ export default function Home() {
                     className="mb-8"
                     balance={balance}
                     balanceStatus={balanceStatus}
-                    address={address ?? null}
                     isLoading={isLoading}
                     processingProgress={processingProgress}
                     isRefreshing={isRefreshing}
-                    copied={copiedAddress === address}
                     formatBalance={formatBalance}
                     onRefresh={handleRefresh}
                     onRefreshMouseDown={handleRefreshMouseDown}
                     onRefreshMouseUp={handleRefreshMouseUp}
-                    onCopy={handleCopyAddress}
                 />
 
                 <div className="grid grid-cols-12 gap-6">

--- a/src/components/BalanceInstrument.tsx
+++ b/src/components/BalanceInstrument.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { RefreshCw, Loader, Copy } from 'lucide-react';
+import { RefreshCw, Loader } from 'lucide-react';
 
 /**
  * Animate a number toward `target`, easing from its previous value (0 on first mount) over ~1.2s —
@@ -49,7 +49,8 @@ function useCountUp(target: number): number {
  * BalanceInstrument — the wallet's primary flight display.
  *
  * An always-dark "cockpit" surface (in both light and dark themes) carrying the
- * balance readout, a mainnet annunciator, and the receive address. The state
+ * balance readout and a mainnet annunciator. The active address is shown in the
+ * Wallet card, so it is not repeated here. The state
  * branches (loading / unavailable / stale / processing) and their data-testids
  * are preserved exactly from the original balance card, so the E2E balance
  * contract is unchanged: the figure renders as a single "<value> AVN" text node,
@@ -66,32 +67,26 @@ interface ProcessingProgress {
 interface BalanceInstrumentProps {
     balance: number;
     balanceStatus: 'live' | 'stale' | 'unknown';
-    address: string | null;
     isLoading: boolean;
     processingProgress: ProcessingProgress;
     isRefreshing: boolean;
-    copied: boolean;
     formatBalance: (balance: number) => string;
     onRefresh: () => void;
     onRefreshMouseDown: () => void;
     onRefreshMouseUp: () => void;
-    onCopy: (address: string) => void;
     className?: string;
 }
 
 export function BalanceInstrument({
     balance,
     balanceStatus,
-    address,
     isLoading,
     processingProgress,
     isRefreshing,
-    copied,
     formatBalance,
     onRefresh,
     onRefreshMouseDown,
     onRefreshMouseUp,
-    onCopy,
     className = '',
 }: BalanceInstrumentProps) {
     // The figure spins up from 0 on load and eases to each new value after a refresh.
@@ -101,16 +96,9 @@ export function BalanceInstrument({
         <section
             className={`relative overflow-hidden rounded-2xl border border-[#24404A] bg-[linear-gradient(180deg,#163139,#122730)] shadow-[0_30px_60px_-40px_rgba(0,0,0,0.8)] ${className}`}
         >
-            {/* artificial-horizon backdrop */}
-            <div aria-hidden className="pointer-events-none absolute inset-0 opacity-50">
-                <div className="absolute inset-x-0 top-0 bottom-[42%] bg-[linear-gradient(180deg,#16525C,#123E46)]" />
-                <div className="absolute inset-x-0 top-[58%] bottom-0 bg-[linear-gradient(180deg,#1A1F52,#12163A)]" />
-                <div className="absolute inset-x-0 top-[58%] h-0.5 bg-[#34F5C6] opacity-60 shadow-[0_0_12px_rgba(52,245,198,0.5)]" />
-            </div>
-
-            <div className="relative p-6">
+            <div className="relative flex min-h-[168px] flex-col p-6">
                 {/* top strip: label + annunciator + refresh */}
-                <div className="mb-4 flex items-center justify-between gap-3">
+                <div className="mb-6 flex items-center justify-between gap-3">
                     <span className="fd-label text-[#9DB4BC]">Total balance · Mainnet</span>
                     <div className="flex items-center gap-2">
                         <span className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-[rgba(4,18,26,0.5)] px-2.5 py-1.5">
@@ -164,24 +152,13 @@ export function BalanceInstrument({
                     )}
                 </div>
 
-                {/* address + copy */}
-                <div className="mt-4 flex items-center gap-1.5 font-mono text-xs text-[#9DB4BC] md:text-sm">
-                    <span className="truncate">{address ? address : 'No wallet loaded'}</span>
-                    {address && (
-                        <button
-                            onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                onCopy(address);
-                            }}
-                            className="flex-shrink-0 rounded p-1 text-[#9DB4BC] transition-colors hover:bg-white/10 hover:text-white"
-                            title="Copy address to clipboard"
-                        >
-                            <Copy size={14} className={copied ? 'text-[#34F5C6]' : ''} />
-                        </button>
-                    )}
+                {/* artificial-horizon ground: a mint line just below the readout, then a night wash
+                    filling the rest of the card. Flowing it under the readout (instead of at a fixed
+                    percentage of the card) keeps the line clear of the number at any font size. */}
+                <div aria-hidden className="pointer-events-none relative -mx-6 -mb-6 mt-5 flex-1">
+                    <div className="absolute inset-x-0 top-0 h-0.5 bg-[#34F5C6] opacity-50 shadow-[0_0_12px_rgba(52,245,198,0.4)]" />
+                    <div className="absolute inset-x-0 top-0 bottom-0 bg-[linear-gradient(180deg,rgba(26,31,82,0.45),rgba(18,22,58,0.55))]" />
                 </div>
-
             </div>
 
             {/* history-sync progress: a thin bar pinned to the bottom edge of the card so it signals


### PR DESCRIPTION
Two things on the primary balance card, from your feedback.

## 1. Removed the duplicate address
The active address showed here **and** in the Wallet card on the right (`ACTIVE ADDRESS`). Removed it from the balance card so the Wallet card owns it — less clutter, and the header stops carrying redundant rows.

## 2. Fixed the "looks wrong" spacing
The artificial-horizon mint line was pinned at a fixed **58% of the card height**, so it cut straight through the balance figure and the "last known" tag — it read like a strikethrough (visible in your screenshot). Now the line **flows just below the readout** instead of at a fixed percentage, so it clears the number at any font size, with a `min-height` so the "ground" band sits cleanly beneath it.

Also removed the now-unused address/copy props + handler from the component and `page.tsx`.

## Safe
The balance still renders as a single `"<value> AVN"` text node, so the E2E balance contract (`getByText('… AVN')`, `balance-stale`, `balance-unavailable`) is unchanged. Typecheck + `pnpm build` clean.

## Version
Bumps **2.4.7 → 2.4.8**.

> These are visual values I tuned without a live render — if the ground band feels too tall/short once deployed, it's a one-line `min-h` / `mt` nudge. Happy to prototype it in an artifact if you'd rather fine-tune interactively.