### PR TITLE
feat(ui): shared animated PFD instrument on lock/loading/balance (+ v2.4.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -321,3 +321,84 @@
     appearance: textfield;
   }
 }
+
+/* Attitude indicator — the shared PFD instrument (see components/AttitudeIndicator.tsx).
+   A committed-dark artificial horizon: sky/ground split with a mint line, a pitch ladder, the
+   aircraft reference symbol, and an optional roll scale, with a one-time skew->level animation. */
+.att {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+.att__horizon {
+  position: absolute;
+  inset: 0;
+  transform-origin: 50% 58%;
+}
+.att--animate .att__horizon {
+  animation: att-level 1.8s cubic-bezier(0.16, 0.84, 0.3, 1) both;
+  will-change: transform;
+}
+.att__sky {
+  position: absolute;
+  inset: 0 0 42% 0;
+  background: linear-gradient(180deg, #16525c, #123e46);
+}
+.att__ground {
+  position: absolute;
+  inset: 58% 0 0 0;
+  background: linear-gradient(180deg, #1a1f52, #12163a);
+}
+.att__line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 58%;
+  height: 2px;
+  background: #34f5c6;
+  opacity: 0.6;
+  box-shadow: 0 0 14px rgba(52, 245, 198, 0.6);
+}
+.att__ladder {
+  position: absolute;
+  top: 58%;
+  left: 50%;
+  pointer-events: none;
+}
+.att__ladder span {
+  position: absolute;
+  left: 0;
+  transform: translateX(-50%);
+  height: 2px;
+  border-radius: 2px;
+  background: #34f5c6;
+  opacity: 0.26;
+}
+.att__aircraft {
+  position: absolute;
+  left: 50%;
+  top: 58%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}
+.att__roll {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+}
+@keyframes att-level {
+  from {
+    transform: scale(1.16) translateY(-3.4%) rotate(-5deg);
+  }
+  to {
+    transform: scale(1) translateY(0) rotate(0deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .att--animate .att__horizon {
+    animation: none !important;
+  }
+}

--- a/src/components/AttitudeIndicator.tsx
+++ b/src/components/AttitudeIndicator.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+interface AttitudeIndicatorProps {
+    /**
+     * Show the roll / bank scale at the top. It's sized for a tall or squarish display; drop it on
+     * wide, short surfaces where a top-centre arc would float awkwardly.
+     */
+    roll?: boolean;
+    /** Play the one-time skew->level animation on mount (honours prefers-reduced-motion). */
+    animate?: boolean;
+    className?: string;
+}
+
+/**
+ * A reusable primary-flight-display backdrop: an artificial horizon (sky/ground split with a mint
+ * line), a pitch ladder, the aircraft reference symbol, and an optional roll scale. Renders as an
+ * absolute fill, so drop it inside a positioned, `overflow-hidden` parent and layer the surface's
+ * own content above it. Styling lives in globals.css under `.att*`.
+ *
+ * Extracted from the landing page so the lock screen, the loading screen, and the balance card all
+ * share one instrument instead of re-implementing the SVGs and the level animation.
+ */
+export function AttitudeIndicator({
+    roll = true,
+    animate = true,
+    className = '',
+}: AttitudeIndicatorProps) {
+    return (
+        <div
+            aria-hidden
+            className={`att${animate ? ' att--animate' : ''}${className ? ` ${className}` : ''}`}
+        >
+            <div className="att__horizon">
+                <div className="att__sky" />
+                <div className="att__ground" />
+                <div className="att__line" />
+                {/* pitch-ladder reference marks — drift with the horizon */}
+                <div className="att__ladder">
+                    <span style={{ top: -56, width: 34 }} />
+                    <span style={{ top: -28, width: 22 }} />
+                    <span style={{ top: 28, width: 22 }} />
+                    <span style={{ top: 56, width: 34 }} />
+                </div>
+            </div>
+
+            {/* aircraft reference symbol, fixed at the centre of the display */}
+            <svg className="att__aircraft" width="150" height="30" viewBox="0 0 150 30">
+                <path d="M18 15 L58 15 M92 15 L132 15" stroke="#34F5C6" strokeWidth="3.5" strokeLinecap="round" />
+                <path d="M58 15 L64 22 M92 15 L86 22" stroke="#34F5C6" strokeWidth="3.5" strokeLinecap="round" />
+                <circle cx="75" cy="15" r="3.4" fill="#04121a" stroke="#34F5C6" strokeWidth="2.2" />
+            </svg>
+
+            {roll && (
+                // roll / bank scale — a fixed reference at the top of the display
+                <svg className="att__roll" width="132" height="34" viewBox="0 0 132 34">
+                    <path d="M12 30 A56 56 0 0 1 120 30" fill="none" stroke="rgba(230,240,242,0.4)" strokeWidth="1.4" />
+                    <path d="M66 6 L61 15 L71 15 Z" fill="#34F5C6" />
+                    <path d="M28 20 L26 25 M104 20 L106 25 M66 12 L66 17" stroke="rgba(230,240,242,0.5)" strokeWidth="1.2" />
+                </svg>
+            )}
+        </div>
+    );
+}

--- a/src/components/BalanceInstrument.tsx
+++ b/src/components/BalanceInstrument.tsx
@@ -135,6 +135,17 @@ export function BalanceInstrument({
                         aria-hidden
                         className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(26,31,82,0.45),rgba(18,22,58,0.55))]"
                     />
+                    {/* aircraft reference symbol riding the horizon line — the instrument signature,
+                        kept faint so it never competes with the figure below it. */}
+                    <svg
+                        aria-hidden
+                        viewBox="0 0 150 30"
+                        className="pointer-events-none absolute left-1/2 top-0 z-[1] w-[104px] -translate-x-1/2 -translate-y-1/2 opacity-60"
+                    >
+                        <path d="M18 15 L58 15 M92 15 L132 15" stroke="#34F5C6" strokeWidth="3.5" strokeLinecap="round" />
+                        <path d="M58 15 L64 22 M92 15 L86 22" stroke="#34F5C6" strokeWidth="3.5" strokeLinecap="round" />
+                        <circle cx="75" cy="15" r="3.4" fill="#04121a" stroke="#34F5C6" strokeWidth="2.2" />
+                    </svg>
                     <div className="fd-readout fd-glow-teal relative flex flex-wrap items-baseline gap-x-2 text-3xl font-semibold leading-none text-[#34E2D5] md:text-4xl">
                         {isLoading && !processingProgress.isProcessing ? (
                             <span className="text-[#9DB4BC]">Loading…</span>

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -3,9 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { StorageService } from '@/services/core/StorageService';
-import { Loader } from 'lucide-react';
-import GradientBackground from '@/components/GradientBackground';
-import Image from 'next/image';
+import { AttitudeIndicator } from '@/components/AttitudeIndicator';
 import { routeGuardLogger } from '@/lib/Logger';
 
 interface RouteGuardProps {
@@ -70,16 +68,16 @@ export default function RouteGuard({
         checkAccess();
     }, [router, requireTerms, requireWallet, redirectTo]);
 
-    // Show loading screen while checking
+    // Show loading screen while checking — a branded PFD "coming online" instrument.
     if (isChecking) {
         return (
-            <div className="min-h-screen bg-gradient-to-br from-card to-background flex items-center justify-center relative">
-                <GradientBackground>
-                    <div className="flex flex-col items-center space-y-4 z-10">
-                        <Image src="/avian_spinner.png" alt="Loading..." width={96} height={96} unoptimized />
-                        <p className="text-sm text-muted-foreground">Loading...</p>
+            <div className="flex min-h-screen items-center justify-center bg-[#0D1B21] px-4">
+                <div className="w-full max-w-xs">
+                    <div className="relative aspect-[4/3.1] overflow-hidden rounded-2xl border border-[#24404A] bg-[linear-gradient(180deg,#163139,#122730)] shadow-[0_40px_80px_-40px_rgba(0,0,0,0.9)]">
+                        <AttitudeIndicator />
                     </div>
-                </GradientBackground>
+                    <p className="mt-4 text-center text-sm text-[#9DB4BC]">Loading…</p>
+                </div>
             </div>
         );
     }

--- a/src/components/SecurityLockScreen.tsx
+++ b/src/components/SecurityLockScreen.tsx
@@ -7,6 +7,7 @@ import { StorageService } from '@/services/core/StorageService';
 import { toast } from 'sonner';
 import ThemeSwitcher from '@/components/ThemeSwitcher';
 import BiometricSetupButton from '@/components/BiometricSetupButton';
+import { AttitudeIndicator } from '@/components/AttitudeIndicator';
 
 interface SecurityLockScreenProps {
   // `switchedWallet` tells the provider the active wallet changed (a multi-wallet pick), so it can
@@ -571,12 +572,8 @@ export default function SecurityLockScreen({ onUnlock, lockReason }: SecurityLoc
       <div className="flex min-h-screen items-center justify-center px-4 py-10">
         <div className="w-full max-w-sm">
           <div className="relative overflow-hidden rounded-2xl border border-[#24404A] bg-[linear-gradient(180deg,#163139,#122730)] shadow-[0_40px_80px_-40px_rgba(0,0,0,0.9)]">
-            {/* artificial-horizon backdrop */}
-            <div aria-hidden className="pointer-events-none absolute inset-0 opacity-45">
-              <div className="absolute inset-x-0 top-0 bottom-[44%] bg-[linear-gradient(180deg,#16525C,#123E46)]" />
-              <div className="absolute inset-x-0 top-[56%] bottom-0 bg-[linear-gradient(180deg,#1A1F52,#12163A)]" />
-              <div className="absolute inset-x-0 top-[56%] h-0.5 bg-[#34F5C6] opacity-60 shadow-[0_0_12px_rgba(52,245,198,0.5)]" />
-            </div>
+            {/* artificial-horizon backdrop — the full instrument, dimmed so the form reads over it */}
+            <AttitudeIndicator className="opacity-40" />
 
             <div className="absolute right-3 top-3 z-10">
               <ThemeSwitcher />


### PR DESCRIPTION
The aircraft symbol, roll/pitch marks, and the one-time skew→level horizon animation lived **only** on the landing page. This extracts them into a reusable `AttitudeIndicator` and brings them to the other instrument surfaces you picked.

## New: `AttitudeIndicator`
An absolute-fill artificial-horizon backdrop — sky/ground split with a mint line, pitch ladder, aircraft reference symbol, and an optional roll scale — with a one-time level animation that honours `prefers-reduced-motion`. Styling lives in `globals.css` under `.att*`. Props: `roll`, `animate`.

## Wired in
- **Lock screen** — replaced the plain horizon backdrop with the full instrument, dimmed (`opacity-40`) so the password form reads over it.
- **Loading screen** (`RouteGuard`) — replaced the spinner image with a boxed, animated PFD "coming online" boot screen. Drops the now-unused `GradientBackground` / `Image` / `Loader` imports.
- **Balance card** — added the aircraft reference symbol riding its horizon line, kept faint (`opacity-60`) so it never competes with the number. The card is wide and short, so the *full* PFD would look stretched — I used just the signature mark here.

## Safe
Presentational only, all instrument layers are `aria-hidden` / `pointer-events-none`. The balance card still renders `"<value> AVN"` as one text node, so the E2E balance contract is unchanged. Nothing in E2E depends on the old loading spinner. Typecheck + `pnpm build` clean.

## Note
The landing page keeps its own `.fdl-*` PFD for now (works, untouched) — it could later adopt this shared component too.

## Version
Bumps **2.4.9 → 2.4.10**.

> These are visual placements I couldn't render locally. The lock and loading screens are natural full-instrument fits; the **balance card** aircraft mark is the one most worth eyeballing once deployed — easy to dim further, resize, or drop if it feels busy.