### PR TITLE
fix(electrum): survive rate-limiting servers that drop the connection (+ v2.4.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/core/ElectrumService.test.ts
+++ b/src/services/core/ElectrumService.test.ts
@@ -126,4 +126,9 @@ describe('connection state', () => {
     const fresh = new ElectrumService();
     await expect(fresh.getTransactionHistory(P2PKH)).resolves.toEqual([]);
   });
+
+  it('waitForConnection gives up after its timeout when the socket never comes back', async () => {
+    const fresh = new ElectrumService();
+    await expect(fresh.waitForConnection(200)).rejects.toThrow(/Timed out/);
+  });
 });

--- a/src/services/core/ElectrumService.ts
+++ b/src/services/core/ElectrumService.ts
@@ -141,6 +141,12 @@ export class ElectrumService {
             `WebSocket closed: code=${event.code}, reason=${event.reason || 'unknown'}`,
           );
 
+          // Fail every in-flight request now. The socket is gone, so no response will ever arrive;
+          // without this each pending request would hang until its own 30s timeout, stalling a sync
+          // for half a minute every time a rate-limiting server drops the connection. Rejecting now
+          // lets callers fail fast and retry once we reconnect.
+          this.failPendingRequests(`Connection closed (code ${event.code})`);
+
           // If the socket closed before it ever opened, nothing else will settle the connect()
           // promise: onopen never fires, and this handler clears isConnecting, which defuses
           // the connection-timeout guard below. Without this reject, callers await forever and
@@ -638,6 +644,33 @@ export class ElectrumService {
     });
   }
 
+  // Reject and clear every in-flight request. Called when the socket closes so callers fail fast
+  // instead of waiting out each request's 30s timeout on a connection that is already gone.
+  private failPendingRequests(reason: string): void {
+    if (this.pendingRequests.size === 0) return;
+    const error = new Error(reason);
+    for (const { reject } of this.pendingRequests.values()) {
+      reject(error);
+    }
+    this.pendingRequests.clear();
+  }
+
+  /**
+   * Resolve once the socket is connected again, or reject after `timeoutMs`. The close handler
+   * already schedules reconnection with backoff; this lets a caller (e.g. a history sync that lost
+   * a request to a dropped connection) wait for that reconnect and retry on the fresh socket.
+   */
+  async waitForConnection(timeoutMs = 15000): Promise<void> {
+    if (this.isConnected) return;
+    const start = Date.now();
+    while (!this.isConnected) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error('Timed out waiting for Electrum reconnection');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  }
+
   async subscribeToAddress(address: string, callback: (data: any) => void): Promise<void> {
     try {
       electrumLogger.debug(`Subscribing to address: ${address.substring(0, 5)}...`);
@@ -802,7 +835,7 @@ export class ElectrumService {
 
     this.isConnected = false;
     this.isConnecting = false;
-    this.pendingRequests.clear();
+    this.failPendingRequests('Disconnected from Electrum server');
     this.subscriptions.clear();
     this.reconnectAttempts = 0;
 

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -26,9 +26,15 @@ import { secureEncrypt, secureDecrypt, decryptData, legacyDecrypt } from './encr
 import { runWithConcurrency } from './concurrency';
 
 // How many transaction.get requests to keep in flight while syncing history. Electrum matches
-// responses by id, so a small pool cuts the latency of a large sync ~N-fold without hammering the
-// server. Kept modest to stay friendly to public ElectrumX nodes.
-const HISTORY_SYNC_CONCURRENCY = 12;
+// responses by id, so a small pool cuts the latency of a large sync ~N-fold. Kept deliberately low:
+// public ElectrumX nodes rate-limit per connection and will drop the socket under a burst, so a
+// gentle pool (plus retry-on-drop below) syncs reliably rather than fast-but-flaky.
+const HISTORY_SYNC_CONCURRENCY = 4;
+
+// Per-transaction fetch retries when a request fails mid-sync (a rate-limiting server dropping the
+// connection is the common cause). Between attempts we wait for the socket to reconnect and back
+// off a little, so a dropped request is recovered instead of losing that transaction.
+const TX_FETCH_ATTEMPTS = 3;
 
 // Re-exported so existing importers of these helpers from WalletService keep working. New code
 // that only needs encryption should import from './encryption' directly, to avoid pulling the
@@ -2297,18 +2303,43 @@ export class WalletService {
     // can retry rather than inheriting a cached rejection.
     private getTransactionCached(txid: string, cache?: Map<string, Promise<any>>): Promise<any> {
         if (!cache) {
-            return this.electrum.getTransaction(txid, true);
+            return this.fetchTransactionWithRetry(txid);
         }
         const inFlight = cache.get(txid);
         if (inFlight) {
             return inFlight;
         }
-        const request = this.electrum.getTransaction(txid, true).catch((error) => {
+        const request = this.fetchTransactionWithRetry(txid).catch((error) => {
             cache.delete(txid);
             throw error;
         });
         cache.set(txid, request);
         return request;
+    }
+
+    // Fetch a verbose transaction, retrying when the request fails mid-flight. The usual cause is a
+    // rate-limiting server dropping the connection, which now rejects in-flight requests immediately
+    // (see ElectrumService.failPendingRequests); between attempts we wait for the socket to
+    // reconnect and back off, so a dropped request is recovered instead of losing that transaction.
+    private async fetchTransactionWithRetry(txid: string): Promise<any> {
+        for (let attempt = 1; attempt <= TX_FETCH_ATTEMPTS; attempt++) {
+            try {
+                return await this.electrum.getTransaction(txid, true);
+            } catch (error) {
+                if (attempt === TX_FETCH_ATTEMPTS) {
+                    throw error;
+                }
+                // Wait for the connection to come back (the close handler reconnects with backoff),
+                // then pause briefly before retrying so we don't immediately re-trip the rate limit.
+                try {
+                    await this.electrum.waitForConnection();
+                } catch {
+                    // If it never reconnects, fall through and let the next attempt (or the final
+                    // throw) surface the failure.
+                }
+                await new Promise((resolve) => setTimeout(resolve, 300 * attempt));
+            }
+        }
     }
 
     // Order a raw get_history list newest-first, in place: mempool entries (height <= 0) first, then

--- a/src/services/wallet/transactionClassification.test.ts
+++ b/src/services/wallet/transactionClassification.test.ts
@@ -52,6 +52,7 @@ function createElectrum(transactions: Record<string, TxDetails>, history?: { tx_
     broadcastTransaction: vi.fn(),
     isConnectedToServer: vi.fn(() => true),
     connect: vi.fn(async () => {}),
+    waitForConnection: vi.fn(async () => {}),
   };
 }
 
@@ -587,6 +588,24 @@ describe('sync efficiency', () => {
     await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
 
     expect(await historyFor(WALLET_A)).toHaveLength(COUNT);
+  });
+
+  it('retries a fetch dropped mid-sync and still records the transaction', async () => {
+    await ownWallets(WALLET_A);
+    const electrum = createElectrum({
+      [TX_HASH]: { vin: [from(EXTERNAL)], vout: [out(WALLET_A, 3)] },
+    });
+    // Simulate a rate-limiting server dropping the first request; the retry succeeds.
+    electrum.getTransaction.mockRejectedValueOnce(new Error('Connection closed (code 1006)'));
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    const history = await historyFor(WALLET_A);
+    expect(history).toHaveLength(1);
+    expect(history[0].amount).toBe(3);
+    expect(electrum.waitForConnection).toHaveBeenCalled();
+    // Fetched at least twice: the dropped attempt plus the successful retry.
+    expect(electrum.getTransaction.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('fetches newest-first: unconfirmed, then highest block height', async () => {


### PR DESCRIPTION
Your diagnosis was right — public ElectrumX nodes rate-limit per connection and drop the socket under a burst, and the sync made it worse.

## The failure mode
1. The pool fired **12** `transaction.get` calls at once → node rate-limited → dropped the socket.
2. On close, the in-flight requests were **never rejected** — each hung to its own **30s timeout**, stalling the sync ~30s per drop.
3. **No retry** → the affected transactions were silently lost (incomplete history), and the pool kept firing into the dead/reconnecting socket.

## The fix
- **Transport** (`ElectrumService`): on socket close, `failPendingRequests` rejects every in-flight request immediately instead of hanging to 30s (`disconnect()` too). New `waitForConnection()` resolves once the close-handler's backoff reconnect succeeds.
- **Sync** (`WalletService`): concurrency **12 → 4** to stay under per-connection limits, and every fetch goes through `fetchTransactionWithRetry` — on failure it waits for reconnect, backs off, and retries (3 attempts), so a dropped request is **recovered, not lost**.

## wss vs tcp/ssl
Staying on **wss** — a browser can't open a raw `tcp/ssl` Electrum socket, and rate limiting is per-connection regardless of transport, so it wouldn't help even if it were possible.

## Tests
- A fetch dropped mid-sync is retried and the transaction still recorded.
- `waitForConnection` rejects cleanly after its timeout when the socket never returns.
- Typecheck + `pnpm build` clean.

## Version
Bumps **2.4.10 → 2.4.11**.