### PR TITLE
feat(electrum): consume get_history_rich when the server offers it (+ v2.4.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/core/ElectrumService.ts
+++ b/src/services/core/ElectrumService.ts
@@ -45,6 +45,27 @@ interface ElectrumNotification {
   params: any[];
 }
 
+/** One pre-classified history row from the `get_history_rich` extension. Amounts are in satoshis. */
+export interface RichHistoryTx {
+  txid: string;
+  height: number;
+  time: number;
+  type: 'send' | 'receive';
+  amount: number;
+  counterparty: string;
+  fee: number;
+  confirmations: number;
+}
+
+/** One page of `get_history_rich` results, newest-first, with the total for pagination. */
+export interface RichHistoryPage {
+  total: number;
+  page: number;
+  page_size: number;
+  order: string;
+  txs: RichHistoryTx[];
+}
+
 import * as bitcoin from 'bitcoinjs-lib';
 import { electrumLogger } from '@/lib/Logger';
 
@@ -77,6 +98,9 @@ export class ElectrumService {
   private reconnectAttempts: number = 0;
   private maxReconnectAttempts: number = 5;
   private reconnectTimeout: NodeJS.Timeout | null = null;
+  // Whether the current server advertises our get_history_rich extension. null = not yet probed;
+  // reset whenever the server changes so a switch re-detects.
+  private richHistorySupported: boolean | null = null;
 
   constructor() {
     // Array of Avian ElectrumX servers
@@ -317,6 +341,7 @@ export class ElectrumService {
 
       // Update current server
       this.currentServer = this.servers[index];
+      this.richHistorySupported = null; // re-detect on the new server
       electrumLogger.debug(
         `Selected server: ${this.currentServer.host} (${this.currentServer.region || 'Unknown region'})`,
       );
@@ -341,6 +366,7 @@ export class ElectrumService {
 
       // Update current server
       this.currentServer = server;
+      this.richHistorySupported = null; // re-detect on the new server
       electrumLogger.debug(
         `Selected server by host: ${this.currentServer.host} (${this.currentServer.region || 'Unknown region'})`,
       );
@@ -516,6 +542,47 @@ export class ElectrumService {
       electrumLogger.error('Failed to get transaction history:', error);
       return [];
     }
+  }
+
+  /**
+   * Whether the current server advertises our `get_history_rich` extension (via a `avn_rich_history`
+   * flag in server.features). Memoised per connection; reset when the server changes. On any error,
+   * treated as unsupported so callers fall back to the standard reconstruction path.
+   */
+  async supportsRichHistory(): Promise<boolean> {
+    if (this.richHistorySupported !== null) {
+      return this.richHistorySupported;
+    }
+    try {
+      const features = await this.getServerFeatures();
+      // Cache the definitive answer (true, or false for a server that genuinely lacks it).
+      this.richHistorySupported = !!features?.avn_rich_history;
+      return this.richHistorySupported;
+    } catch {
+      // Transient failure (e.g. probed mid-disconnect): don't cache, so we re-detect next time
+      // rather than disabling the fast path for the whole session.
+      return false;
+    }
+  }
+
+  /**
+   * Fetch one page of pre-classified history from our `get_history_rich` extension. The server
+   * returns rows already resolved to direction/amount/counterparty, newest-first, so the client
+   * does not have to fetch each transaction and its inputs. `pageSize` is clamped to 1..100 because
+   * the server rejects anything outside that range.
+   */
+  async getRichHistoryPage(
+    address: string,
+    page: number,
+    pageSize: number,
+  ): Promise<RichHistoryPage> {
+    const scriptHash = this.addressToScriptHash(address);
+    const size = Math.min(100, Math.max(1, Math.floor(pageSize)));
+    return await this.makeRequest('blockchain.scripthash.get_history_rich', [
+      scriptHash,
+      Math.max(0, Math.floor(page)),
+      size,
+    ]);
   }
 
   async getTransaction(txHash: string, verbose: boolean = false): Promise<any> {

--- a/src/services/core/StorageService.ts
+++ b/src/services/core/StorageService.ts
@@ -44,7 +44,7 @@ interface WalletSwitchState {
   toId?: number;
 }
 
-interface TransactionData {
+export interface TransactionData {
   id?: number;
   txid: string;
   amount: number;

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -11,7 +11,7 @@ import * as ecc from 'tiny-secp256k1';
 import * as bip39 from 'bip39';
 import { BIP32Factory } from 'bip32';
 import { ElectrumService, type DetailedBalance } from '../core/ElectrumService';
-import { StorageService } from '../core/StorageService';
+import { StorageService, type TransactionData } from '../core/StorageService';
 import { walletLogger } from '@/lib/Logger';
 import { getExplorerUrl, openTransactionInExplorer } from '@/lib/explorer';
 import {
@@ -2356,6 +2356,133 @@ export class WalletService {
         });
     }
 
+    // Map one pre-classified get_history_rich row to a stored TransactionData. The server already
+    // resolved direction/amount/counterparty, so this is a pure shape conversion (satoshis -> AVN,
+    // unix seconds -> Date). `address` is the wallet's own address. Following TransactionData's
+    // convention, `address` holds the counterparty for both directions and `fromAddress` is the
+    // sender (the counterparty for a receive, us for a send).
+    private richRowToTransaction(
+        row: import('../core/ElectrumService').RichHistoryTx,
+        walletAddress: string,
+    ): Omit<TransactionData, 'id'> {
+        return {
+            txid: row.txid,
+            amount: row.amount / 100000000,
+            address: row.counterparty,
+            fromAddress: row.type === 'receive' ? row.counterparty : walletAddress,
+            walletAddress,
+            type: row.type,
+            timestamp: row.time ? new Date(row.time * 1000) : new Date(),
+            confirmations: row.confirmations ?? 0,
+            blockHeight: row.height > 0 ? row.height : undefined,
+        };
+    }
+
+    /**
+     * Sync history via the server's get_history_rich extension: page through the pre-classified
+     * rows (newest-first) and persist them. Far cheaper than the standard path — one request per
+     * page of up to 100 instead of one per transaction plus one per input. For an incremental
+     * refresh (onlyNewTransactions) it stops as soon as a whole page is already stored, since
+     * newest-first means every older page is stored too.
+     */
+    private async processTransactionHistoryRich(
+        address: string,
+        onProgress?: (processed: number, total: number, currentTx?: string) => void,
+        onlyNewTransactions: boolean = false,
+    ): Promise<void> {
+        const PAGE_SIZE = 100;
+
+        const existingTxs = (await StorageService.getTransactionHistory(address)).filter(
+            (tx) => tx.walletAddress === address,
+        );
+        const existingByKey = new Map(existingTxs.map((tx) => [`${tx.txid}-${tx.type}`, tx]));
+        const existingIds = new Set(existingTxs.map((tx) => tx.txid));
+
+        const first = await this.fetchRichPageWithRetry(address, 0, PAGE_SIZE);
+        const total = first.total ?? 0;
+        if (total === 0) {
+            onProgress?.(0, 0);
+            return;
+        }
+        const pageCount = Math.ceil(total / PAGE_SIZE);
+        let processed = 0;
+        onProgress?.(0, total);
+
+        // Persist a page; returns how many of its rows were new (for the incremental early-stop).
+        const handlePage = async (page: { txs: import('../core/ElectrumService').RichHistoryTx[] }) => {
+            let fresh = 0;
+            for (const row of page.txs) {
+                if (onlyNewTransactions && existingIds.has(row.txid)) {
+                    processed++;
+                    onProgress?.(processed, total, row.txid);
+                    continue;
+                }
+                fresh++;
+                const tx = this.richRowToTransaction(row, address);
+                const existing = existingByKey.get(`${row.txid}-${tx.type}`);
+                try {
+                    if (existing) {
+                        const needsUpdate =
+                            existing.amount !== tx.amount ||
+                            existing.address !== tx.address ||
+                            existing.fromAddress !== tx.fromAddress ||
+                            existing.confirmations !== tx.confirmations ||
+                            !existing.walletAddress;
+                        if (needsUpdate) {
+                            await StorageService.saveTransaction({ ...tx, id: existing.id } as any);
+                        }
+                    } else {
+                        await StorageService.saveTransaction(tx);
+                    }
+                } catch (error) {
+                    walletLogger.warn(`Failed to save rich transaction ${row.txid}:`, error);
+                }
+                processed++;
+                onProgress?.(processed, total, row.txid);
+            }
+            return fresh;
+        };
+
+        await handlePage(first);
+
+        for (let page = 1; page < pageCount; page++) {
+            const data = await this.fetchRichPageWithRetry(address, page, PAGE_SIZE);
+            const fresh = await handlePage(data);
+            // Incremental refresh: once a full page holds nothing new, every older page is already
+            // stored (newest-first), so stop.
+            if (onlyNewTransactions && fresh === 0) {
+                break;
+            }
+        }
+
+        onProgress?.(processed, total);
+    }
+
+    // Fetch a rich history page, retrying on a dropped connection the same way single-tx fetches do.
+    private async fetchRichPageWithRetry(
+        address: string,
+        page: number,
+        pageSize: number,
+    ): Promise<import('../core/ElectrumService').RichHistoryPage> {
+        for (let attempt = 1; attempt <= TX_FETCH_ATTEMPTS; attempt++) {
+            try {
+                return await this.electrum.getRichHistoryPage(address, page, pageSize);
+            } catch (error) {
+                if (attempt === TX_FETCH_ATTEMPTS) {
+                    throw error;
+                }
+                try {
+                    await this.electrum.waitForConnection();
+                } catch {
+                    // fall through to retry / final throw
+                }
+                await new Promise((resolve) => setTimeout(resolve, 300 * attempt));
+            }
+        }
+        // Unreachable: the loop either returns or throws on the last attempt.
+        throw new Error('rich history fetch failed');
+    }
+
     /**
      * Process transaction history for a wallet address
      * @param address - The wallet address
@@ -2368,6 +2495,21 @@ export class WalletService {
         onlyNewTransactions: boolean = false,
     ): Promise<void> {
         try {
+            // Fast path: if the server offers our get_history_rich extension it returns rows already
+            // classified (direction, amount, counterparty), so we skip the per-transaction and
+            // per-input reconstruction entirely. Any failure falls through to the standard path.
+            if (await this.electrum.supportsRichHistory()) {
+                try {
+                    await this.processTransactionHistoryRich(address, onProgress, onlyNewTransactions);
+                    return;
+                } catch (richError) {
+                    walletLogger.warn(
+                        'Rich history path failed; falling back to standard reconstruction',
+                        richError,
+                    );
+                }
+            }
+
             // Get transaction history from ElectrumX
             const txHistory = await this.electrum.getTransactionHistory(address);
 

--- a/src/services/wallet/transactionClassification.test.ts
+++ b/src/services/wallet/transactionClassification.test.ts
@@ -53,6 +53,9 @@ function createElectrum(transactions: Record<string, TxDetails>, history?: { tx_
     isConnectedToServer: vi.fn(() => true),
     connect: vi.fn(async () => {}),
     waitForConnection: vi.fn(async () => {}),
+    // Default: no rich-history extension, so the standard reconstruction path runs.
+    supportsRichHistory: vi.fn(async () => false),
+    getRichHistoryPage: vi.fn(),
   };
 }
 
@@ -647,5 +650,107 @@ describe('sync efficiency', () => {
     await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
 
     expect(electrum.getCurrentBlockHeight).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('rich history path', () => {
+  // When the server advertises get_history_rich, the client consumes pre-classified rows and skips
+  // the per-transaction / per-input reconstruction entirely.
+  const richElectrum = (
+    pages: Array<{ total: number; txs: any[] }>,
+  ) => {
+    const e = createElectrum({});
+    e.supportsRichHistory = vi.fn(async () => true);
+    e.getRichHistoryPage = vi.fn(async (_address: string, page: number) => {
+      const p = pages[page] ?? { total: pages[0].total, txs: [] };
+      return { total: p.total, page, page_size: 100, order: 'newest', txs: p.txs };
+    });
+    return e;
+  };
+
+  const richRow = (over: Partial<Record<string, unknown>> = {}) => ({
+    txid: 'f'.repeat(64),
+    height: 100,
+    time: 1_700_000_000,
+    type: 'receive',
+    amount: 500000000,
+    counterparty: EXTERNAL,
+    fee: 1000,
+    confirmations: 5,
+    ...over,
+  });
+
+  it('maps a receive row without fetching any transaction bodies', async () => {
+    await ownWallets(WALLET_A);
+    const electrum = richElectrum([{ total: 1, txs: [richRow()] }]);
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    expect(electrum.getTransaction).not.toHaveBeenCalled(); // no reconstruction
+    const history = await historyFor(WALLET_A);
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      type: 'receive',
+      amount: 5, // satoshis -> AVN
+      address: EXTERNAL, // counterparty
+      fromAddress: EXTERNAL, // sender, for a receive
+      walletAddress: WALLET_A,
+      confirmations: 5,
+    });
+  });
+
+  it('maps a send row with the wallet as the sender', async () => {
+    await ownWallets(WALLET_A);
+    const electrum = richElectrum([
+      { total: 1, txs: [richRow({ type: 'send', counterparty: EXTERNAL_2, amount: 250000000 })] },
+    ]);
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    const history = await historyFor(WALLET_A);
+    expect(history[0]).toMatchObject({
+      type: 'send',
+      amount: 2.5,
+      address: EXTERNAL_2, // recipient
+      fromAddress: WALLET_A, // us, for a send
+    });
+  });
+
+  it('pages through the whole history', async () => {
+    await ownWallets(WALLET_A);
+    const page0 = Array.from({ length: 100 }, (_, i) =>
+      richRow({ txid: i.toString(16).padStart(64, '0') }),
+    );
+    const page1 = Array.from({ length: 50 }, (_, i) =>
+      richRow({ txid: (100 + i).toString(16).padStart(64, '0') }),
+    );
+    const electrum = richElectrum([
+      { total: 150, txs: page0 },
+      { total: 150, txs: page1 },
+    ]);
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    expect(electrum.getRichHistoryPage).toHaveBeenCalledTimes(2); // page 0 and page 1
+    expect(await historyFor(WALLET_A)).toHaveLength(150);
+  });
+
+  it('falls back to the standard path when the rich page call fails', async () => {
+    await ownWallets(WALLET_A);
+    const electrum = createElectrum({
+      [TX_HASH]: { vin: [from(EXTERNAL)], vout: [out(WALLET_A, 7)] },
+    });
+    electrum.supportsRichHistory = vi.fn(async () => true);
+    electrum.getRichHistoryPage = vi.fn(async () => {
+      throw new Error('boom');
+    });
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    // Standard reconstruction still recorded the transaction.
+    const history = await historyFor(WALLET_A);
+    expect(history).toHaveLength(1);
+    expect(history[0].amount).toBe(7);
+    expect(electrum.getTransaction).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Implements the client side of [the rich-history proposal](docs/proposals/electrum-rich-history.md) — and I **verified it live against `electrum-eu.avn.network` first**, so the shape is confirmed, not assumed.

## Live probe confirmed
- `server.features` → `"avn_rich_history": 1`
- `get_history_rich(scripthash, page, page_size)` → `{ total: 5247, page, page_size, order: "newest", txs: [{ txid, height, time, type, amount(sats), counterparty, fee, confirmations }] }`
- newest-first; default page_size 25; **`>100` is a hard error**, so the client clamps.

## Client
- **`ElectrumService`**: `supportsRichHistory()` (memoises the definitive answer from `server.features`, re-probes after a *transient* failure so a blip doesn't disable the fast path, resets on server switch) and `getRichHistoryPage()` (clamps page_size 1..100). New `RichHistoryPage` / `RichHistoryTx` types.
- **`WalletService.processTransactionHistory`**: when the extension is present, page through the rich rows and map each straight to `TransactionData` — **no per-tx or per-input fetches, no client classification**. Incremental refresh stops as soon as a full page is already stored (newest-first). **Any failure falls back** to the standard reconstruction path, which also covers third-party servers.

## Impact
For the 5,247-tx address this turns **~5,000+ round-trips into ~53 page requests**, sidestepping the rate-limit burst entirely. Feature-detected, so inert on servers without the flag — but your servers already advertise it, so it engages immediately on deploy.

## Tests
Rich rows map correctly (send/receive, sats→AVN, counterparty), no tx bodies are fetched, pagination walks every page, and a failed rich call falls back to the standard path. Affected suites green; typecheck + `pnpm build` clean.

## Version
Bumps **2.4.11 → 2.4.12**.

> The standard path (concurrency/cache/retry from #45/#47/#52) stays as the fallback. Once this proves out on your servers, most of that machinery is only exercised for third-party servers — we could simplify later, but I'd leave it as the safety net for now.