### PR TITLE
fix(history): handle null counterparty (coinbase) from get_history_rich (+ v2.4.13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -515,8 +515,11 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
                           {tx.type === 'send' ? 'To: ' : 'From: '}
                           <span className="font-mono break-all">
                             {(() => {
+                              // Some transactions have no resolvable counterparty (e.g. mining
+                              // payouts) — never assume a string here or the whole list crashes.
                               const displayAddress =
-                                tx.type === 'send' ? tx.address : tx.fromAddress || tx.address;
+                                (tx.type === 'send' ? tx.address : tx.fromAddress || tx.address) ||
+                                'Unknown';
                               return displayAddress.length > 40
                                 ? `${displayAddress.slice(0, 20)}...${displayAddress.slice(-20)}`
                                 : displayAddress;

--- a/src/services/core/ElectrumService.ts
+++ b/src/services/core/ElectrumService.ts
@@ -52,7 +52,11 @@ export interface RichHistoryTx {
   time: number;
   type: 'send' | 'receive';
   amount: number;
-  counterparty: string;
+  /** The other party, or null when none resolves (e.g. a coinbase payout — see `coinbase`). */
+  counterparty: string | null;
+  /** True for a coinbase / mining payout. Optional: older servers omit it (infer from a null
+   *  counterparty on a receive instead). */
+  coinbase?: boolean;
   fee: number;
   confirmations: number;
 }

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -2365,11 +2365,16 @@ export class WalletService {
         row: import('../core/ElectrumService').RichHistoryTx,
         walletAddress: string,
     ): Omit<TransactionData, 'id'> {
+        // The server returns counterparty: null when there is no single resolvable other party. For
+        // a receive that means a coinbase / mining payout (a coinbase input has no prevout to
+        // resolve), which we label "Coinbase" to match the standard reconstruction path. Never let
+        // null reach storage — TransactionData.address is a string the UI relies on.
+        const counterparty = row.counterparty ?? (row.type === 'receive' ? 'Coinbase' : '');
         return {
             txid: row.txid,
             amount: row.amount / 100000000,
-            address: row.counterparty,
-            fromAddress: row.type === 'receive' ? row.counterparty : walletAddress,
+            address: counterparty,
+            fromAddress: row.type === 'receive' ? counterparty : walletAddress,
             walletAddress,
             type: row.type,
             timestamp: row.time ? new Date(row.time * 1000) : new Date(),

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -2365,11 +2365,13 @@ export class WalletService {
         row: import('../core/ElectrumService').RichHistoryTx,
         walletAddress: string,
     ): Omit<TransactionData, 'id'> {
-        // The server returns counterparty: null when there is no single resolvable other party. For
-        // a receive that means a coinbase / mining payout (a coinbase input has no prevout to
-        // resolve), which we label "Coinbase" to match the standard reconstruction path. Never let
-        // null reach storage — TransactionData.address is a string the UI relies on.
-        const counterparty = row.counterparty ?? (row.type === 'receive' ? 'Coinbase' : '');
+        // counterparty is null whenever there is no single address to show — a coinbase payout, but
+        // also an output to a non-standard script (OP_RETURN, bare multisig, an asset-tagging
+        // output). Only the server's explicit `coinbase` flag means "mined", which we label
+        // "Coinbase" to match the standard reconstruction path; every other null is just "no
+        // address", stored as "" so the UI shows a neutral placeholder. Never store null —
+        // TransactionData.address is a string the UI relies on.
+        const counterparty = row.coinbase === true ? 'Coinbase' : (row.counterparty ?? '');
         return {
             txid: row.txid,
             amount: row.amount / 100000000,

--- a/src/services/wallet/transactionClassification.test.ts
+++ b/src/services/wallet/transactionClassification.test.ts
@@ -699,18 +699,32 @@ describe('rich history path', () => {
     });
   });
 
-  it('labels a null-counterparty receive (a coinbase payout) as Coinbase, never null', async () => {
+  it('labels an explicit coinbase row as Coinbase', async () => {
     await ownWallets(WALLET_A);
     const electrum = richElectrum([
-      { total: 1, txs: [richRow({ type: 'receive', counterparty: null })] },
+      { total: 1, txs: [richRow({ type: 'receive', counterparty: null, coinbase: true })] },
     ]);
 
     await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
 
     const [entry] = await historyFor(WALLET_A);
-    expect(entry.type).toBe('receive');
-    expect(entry.address).toBe('Coinbase'); // coerced from null, matches the standard path
+    expect(entry.address).toBe('Coinbase');
     expect(entry.fromAddress).toBe('Coinbase');
+  });
+
+  it('stores a non-coinbase null counterparty as no address, not Coinbase', async () => {
+    // null also happens for OP_RETURN / bare multisig / asset-tagging outputs — only the coinbase
+    // flag means "mined", so these must not be mislabelled Coinbase.
+    await ownWallets(WALLET_A);
+    const electrum = richElectrum([
+      { total: 1, txs: [richRow({ type: 'receive', counterparty: null })] }, // no coinbase flag
+    ]);
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    const [entry] = await historyFor(WALLET_A);
+    expect(entry.address).toBe(''); // never null, but not "Coinbase" either
+    expect(entry.fromAddress).toBe('');
   });
 
   it('maps a send row with the wallet as the sender', async () => {

--- a/src/services/wallet/transactionClassification.test.ts
+++ b/src/services/wallet/transactionClassification.test.ts
@@ -699,6 +699,20 @@ describe('rich history path', () => {
     });
   });
 
+  it('labels a null-counterparty receive (a coinbase payout) as Coinbase, never null', async () => {
+    await ownWallets(WALLET_A);
+    const electrum = richElectrum([
+      { total: 1, txs: [richRow({ type: 'receive', counterparty: null })] },
+    ]);
+
+    await new WalletService(electrum as never).processTransactionHistory(WALLET_A);
+
+    const [entry] = await historyFor(WALLET_A);
+    expect(entry.type).toBe('receive');
+    expect(entry.address).toBe('Coinbase'); // coerced from null, matches the standard path
+    expect(entry.fromAddress).toBe('Coinbase');
+  });
+
   it('maps a send row with the wallet as the sender', async () => {
     await ownWallets(WALLET_A);
     const electrum = richElectrum([


### PR DESCRIPTION
Hotfix for the "Application Error / Cannot read properties of null (reading 'length')" crash when paging to certain transactions after #54.

## Cause
`get_history_rich` returns `counterparty: null` when there's no single resolvable other party — a **coinbase / mining payout** is the common case (you confirmed it: solo mining, coinbase tx, whose input has no prevout to resolve). The mapping passed that null into `TransactionData.address` / `fromAddress`, and the row render does `displayAddress.length`, so paging to a coinbase row took down the whole app. (67 of the first 100 rows on the test wallet were null — all mining rewards.)

## Fix
- **`richRowToTransaction`** — coerce a null counterparty to **"Coinbase"** for a receive (matching the standard reconstruction path's coinbase label) and `""` otherwise, so null never reaches storage.
- **`TransactionHistory`** — default the displayed address to **"Unknown"** instead of assuming a string, so any row already stored as null (from 2.4.12) renders instead of crashing the list; the next sync then overwrites it with the proper label.

Two layers on purpose: the mapping fixes new/re-synced data, the render guard rescues already-stored null rows immediately.

## Test
A null-counterparty receive is stored as `"Coinbase"`, never null. Typecheck + build clean.

## Version
Bumps **2.4.12 → 2.4.13**.

> Server-side nicety (optional, since you run them): having `get_history_rich` return `counterparty: "Coinbase"` for coinbase inputs would make it authoritative for any client — the client heuristic above is just a sensible fallback for the `null`.