### PR TITLE
fix(meta): set metadataBase so link-preview images load (+ v2.4.15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,6 +29,9 @@ const robotoMono = localFont({
 });
 
 export const metadata: Metadata = {
+  // Resolves relative Open Graph / Twitter image URLs against the real host. Without it a static
+  // export bakes in http://localhost:3000, so link-unfurl crawlers can't fetch the preview images.
+  metadataBase: new URL('https://flightdeck.avn.network'),
   title: 'Avian FlightDeck',
   description: 'Secure and user-friendly Avian cryptocurrency wallet for managing your digital assets',
   keywords: ['avian', 'cryptocurrency', 'wallet', 'blockchain', 'crypto', 'digital assets'],


### PR DESCRIPTION
Pasting `https://flightdeck.avn.network/` showed the title/description but **"Image failed to load"** for both preview images.

## Cause
The `og:image` / `twitter:image` URLs are relative, and there's no `metadataBase`. In a static export Next.js can't infer the host, so it baked in `http://localhost:3000` — the deployed HTML literally served:
```
<meta property="og:image" content="http://localhost:3000/screenshots/desktop-home.png"/>
```
Link-unfurl crawlers fetch `localhost` → fail → "Image failed to load."

## Fix
Set `metadataBase: new URL('https://flightdeck.avn.network')`. The export output now emits absolute URLs:
```
<meta property="og:image" content="https://flightdeck.avn.network/screenshots/desktop-home.png"/>
<meta property="og:image" content="https://flightdeck.avn.network/icons/icon-512x512.png"/>
<meta name="twitter:image" content="https://flightdeck.avn.network/screenshots/desktop-home.png"/>
```
Verified in `out/index.html`; the build's `metadataBase` warning is gone. The referenced images exist and are the refreshed UI (#57), so the unfurl now shows the real app. Build clean.

## Version
Bumps **2.4.14 → 2.4.15**.

> Note: some platforms cache unfurls — Discord/Slack/etc. may keep showing the old preview until their cache expires or you re-trigger it (e.g. a cache-busting query param once, or the platform's link-debugger).