### PR TITLE
feat(brand): instrument mark in the sidebar header (+ v2.4.17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -194,12 +194,21 @@ export function AppSidebar({ children, ...props }: AppSidebarProps & React.Compo
                             className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                         >
                             <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#34F5C6] to-[#17A7B6] text-[#06232A]">
+                                {/* Aircraft reference symbol — the flight-deck instrument mark, matching the app icon */}
                                 <svg
                                     className="size-6"
                                     viewBox="0 0 64 64"
-                                    fill="currentColor"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="4.5"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
                                 >
-                                    <image href="/Avian_logo.svg" width="64" height="64" />
+                                    <line x1="9" y1="32" x2="23" y2="32" />
+                                    <line x1="41" y1="32" x2="55" y2="32" />
+                                    <line x1="23" y1="32" x2="27" y2="39" />
+                                    <line x1="41" y1="32" x2="37" y2="39" />
+                                    <circle cx="32" cy="32" r="5" />
                                 </svg>
                             </div>
                             <div className="grid flex-1 text-left text-sm leading-tight">


### PR DESCRIPTION
Follow-up to the new app icon (#59): the sidebar header still showed the old eagle, which now clashes with the attitude-indicator icon. Swapped it for the **aircraft reference symbol** on the mint tile — the same flight-deck motif, as the inverse of the app icon (dark mark on mint here; mint mark on dark in the icon).

- `AppSidebar.tsx` — replaced the `/Avian_logo.svg` `<image>` with the inline instrument glyph in `currentColor`. Verified the badge renders cleanly at size.
- Left the actual **Avian coin logo** (`/Avian_logo.svg`) in place where it represents the currency (send form, about) — that's the coin's brand, not the app's.

Build clean.

## Version
Bumps **2.4.16 → 2.4.17**.