### PR TITLE
fix(tx): size-based fees, dust floor, send-max, correct history (+ v2.4.18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/SendForm.tsx
+++ b/src/components/SendForm.tsx
@@ -19,6 +19,7 @@ import { WalletService } from '@/services/wallet/WalletService';
 import { StorageService } from '@/services/core/StorageService';
 import { securityService } from '@/services/core/SecurityService';
 import { CoinSelectionStrategy, EnhancedUTXO } from '@/services/wallet/UTXOSelectionService';
+import { estimateTxFee, DEFAULT_FEE_RATE_SAT_PER_VBYTE } from '@/services/wallet/fees';
 import AddressInput from './AddressInput';
 import { QRScanResult } from '@/types/addressBook';
 import { UTXOSelectionSettings } from './UTXOSelectionSettings';
@@ -77,7 +78,7 @@ export default function SendForm() {
     minConfirmations?: number;
   }>({
     strategy: CoinSelectionStrategy.BEST_FIT,
-    feeRate: 10000,
+    feeRate: undefined, // undefined = use the wallet default (size-based) fee
     maxInputs: 100,
     minConfirmations: 6,
   });
@@ -154,7 +155,14 @@ export default function SendForm() {
     }
 
     const amountSatoshis = Math.floor(parseFloat(amount) * 100000000);
-    const fee = 10000; // 0.0001 AVN fee
+    // Estimated fee for the preflight guard only — the service computes the exact size-based fee.
+    // Assume a couple of inputs for automatic selection, or the actual count for manual.
+    const feeRateSatPerVb = utxoOptions.feeRate || DEFAULT_FEE_RATE_SAT_PER_VBYTE;
+    const estInputs =
+      utxoOptions.strategy === CoinSelectionStrategy.MANUAL
+        ? Math.max(1, manuallySelectedUTXOs.length)
+        : 2;
+    const fee = estimateTxFee(estInputs, 2, feeRateSatPerVb);
 
     if (amountSatoshis <= 0) {
       setError('Amount must be greater than 0');
@@ -179,15 +187,19 @@ export default function SendForm() {
     // Now check if we have enough funds to cover the fee
     if (balanceToCheck < fee) {
       setError(
-        `Insufficient funds to cover network fee (0.0001 AVN required). The address has ${balanceToCheck / 100000000} AVN.`,
+        `Insufficient funds to cover the network fee (~${(fee / 100000000).toFixed(8)} AVN). The address has ${balanceToCheck / 100000000} AVN.`,
       );
       return;
     }
 
-    // Check if we have enough for both the amount and fee
-    if (amountSatoshis + fee > balanceToCheck) {
+    // Enough for the amount plus fee. With "subtract fee" the fee comes out of the amount, so only
+    // the amount itself needs to fit.
+    const requiredSats = subtractFeeFromAmount ? amountSatoshis : amountSatoshis + fee;
+    if (requiredSats > balanceToCheck) {
       const maxSendable = Math.max(0, (balanceToCheck - fee) / 100000000);
-      setError(`Insufficient funds. Maximum sendable: ${maxSendable.toFixed(8)} AVN (after fee)`);
+      setError(
+        `Insufficient funds. Maximum sendable: ${maxSendable.toFixed(8)} AVN (or use "subtract fee" to send the full balance).`,
+      );
       return;
     }
 
@@ -466,14 +478,15 @@ export default function SendForm() {
     balanceToUse = balance;
   }
 
-  const maxAmount = Math.max(0, (balanceToUse - 10000) / 100000000); // Subtract fee
+  // Full balance — MAX enables "subtract fee", so the exact size-based fee comes out on send.
+  const maxAmount = balanceToUse / 100000000;
 
   // Debug balance information
 
   const resetUTXOSettings = () => {
     setUtxoOptions({
       strategy: CoinSelectionStrategy.BEST_FIT,
-      feeRate: 10000,
+      feeRate: undefined, // undefined = use the wallet default (size-based) fee
       maxInputs: 100,
       minConfirmations: 6,
     });
@@ -590,7 +603,7 @@ export default function SendForm() {
         setManuallySelectedUTXOs(selectedUTXOs);
         setUtxoOptions({
           strategy: CoinSelectionStrategy.MANUAL,
-          feeRate: 1000, // Low fee rate for consolidation
+          feeRate: undefined, // use the wallet default (size-based) fee
           maxInputs: Math.min(selectedUTXOs.length, 500), // Use all selected UTXOs up to Avian's limit
           minConfirmations: 1, // Lower confirmation requirement for consolidation
         });
@@ -942,7 +955,7 @@ export default function SendForm() {
           <Button
             variant={
               utxoOptions.strategy !== CoinSelectionStrategy.BEST_FIT ||
-                utxoOptions.feeRate !== 10000 ||
+                utxoOptions.feeRate != null ||
                 utxoOptions.maxInputs !== 100 ||
                 utxoOptions.minConfirmations !== 6
                 ? 'secondary'
@@ -955,7 +968,7 @@ export default function SendForm() {
             <Settings className="h-4 w-4 mr-2" />
             <span>Advanced</span>
             {(utxoOptions.strategy !== CoinSelectionStrategy.BEST_FIT ||
-              utxoOptions.feeRate !== 10000 ||
+              utxoOptions.feeRate != null ||
               utxoOptions.maxInputs !== 100 ||
               utxoOptions.minConfirmations !== 6) && (
                 <span className="absolute -top-1 -right-1 h-2 w-2 bg-caution rounded-full"></span>
@@ -967,7 +980,7 @@ export default function SendForm() {
       <CardContent className="pt-4">
         {/* UTXO Selection Status */}
         {(utxoOptions.strategy !== CoinSelectionStrategy.BEST_FIT ||
-          utxoOptions.feeRate !== 10000 ||
+          utxoOptions.feeRate != null ||
           utxoOptions.maxInputs !== 100 ||
           utxoOptions.minConfirmations !== 6) && (
             <div className="mb-4 p-3 bg-secondary/30 border rounded-lg">
@@ -1001,7 +1014,7 @@ export default function SendForm() {
                     Strategy: {utxoOptions.strategy?.replace(/_/g, ' ')}
                   </Badge>
                 )}
-                {utxoOptions.feeRate !== 10000 && (
+                {utxoOptions.feeRate != null && (
                   <Badge variant="outline" className="mr-2 mb-1">
                     Fee Rate: {utxoOptions.feeRate} sat/vB
                   </Badge>
@@ -1114,7 +1127,10 @@ export default function SendForm() {
                 type="button"
                 size="sm"
                 variant="ghost"
-                onClick={() => setAmount(maxAmount.toString())}
+                onClick={() => {
+                  setAmount(maxAmount.toString());
+                  setSubtractFeeFromAmount(true); // send the whole balance; fee comes out of it
+                }}
                 className="absolute right-1 top-1/2 transform -translate-y-1/2 h-6 text-xs px-2 text-primary"
                 disabled={isSending || maxAmount <= 0}
               >
@@ -1122,7 +1138,7 @@ export default function SendForm() {
               </Button>
             </div>
             <p className="text-xs text-muted-foreground mt-1.5 leading-relaxed">
-              Fee: 0.0001 AVN | Max sendable: {maxAmount.toFixed(8)} AVN
+              Max sendable: {maxAmount.toFixed(8)} AVN · fee deducted on send
               {utxoOptions.strategy === CoinSelectionStrategy.MANUAL &&
                 manuallySelectedUTXOs.length > 0 && (
                   <span className="block mt-1">
@@ -1423,7 +1439,12 @@ export default function SendForm() {
 
         {(() => {
           const amountSats = Math.floor(parseFloat(amount || '0') * 100000000);
-          const feeSats = 10000;
+          const feeRateSatPerVb = utxoOptions.feeRate || DEFAULT_FEE_RATE_SAT_PER_VBYTE;
+          const estInputs =
+            utxoOptions.strategy === CoinSelectionStrategy.MANUAL
+              ? Math.max(1, manuallySelectedUTXOs.length)
+              : 2;
+          const feeSats = estimateTxFee(estInputs, 2, feeRateSatPerVb);
           const totalSats = subtractFeeFromAmount ? amountSats : amountSats + feeSats;
           const recipientSats = subtractFeeFromAmount
             ? Math.max(0, amountSats - feeSats)
@@ -1506,7 +1527,7 @@ export default function SendForm() {
                       setManuallySelectedUTXOs([]);
                       setUtxoOptions({
                         strategy: CoinSelectionStrategy.BEST_FIT,
-                        feeRate: 10000,
+                        feeRate: undefined, // undefined = use the wallet default (size-based) fee
                         maxInputs: 100,
                         minConfirmations: 6,
                       });

--- a/src/services/core/ElectrumService.ts
+++ b/src/services/core/ElectrumService.ts
@@ -589,6 +589,29 @@ export class ElectrumService {
     ]);
   }
 
+  /**
+   * The network's fee rate in satoshis per vByte, from `blockchain.relayfee` (falling back to
+   * `estimatefee`). Both report coins per kB, so convert. Returns 0 if neither is available, letting
+   * the caller apply its own floor.
+   */
+  async getFeeRateSatPerVByte(): Promise<number> {
+    const toSatPerVByte = (coinsPerKb: unknown): number => {
+      const rate = (Number(coinsPerKb) * 100_000_000) / 1000;
+      return Number.isFinite(rate) && rate > 0 ? rate : 0;
+    };
+    try {
+      const relay = toSatPerVByte(await this.makeRequest('blockchain.relayfee', []));
+      if (relay > 0) return relay;
+    } catch {
+      /* fall through to estimatefee */
+    }
+    try {
+      return toSatPerVByte(await this.makeRequest('blockchain.estimatefee', [2]));
+    } catch {
+      return 0;
+    }
+  }
+
   async getTransaction(txHash: string, verbose: boolean = false): Promise<any> {
     try {
       const response = await this.makeRequest('blockchain.transaction.get', [txHash, verbose]);

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -24,6 +24,7 @@ import * as bitcoinMessage from 'bitcoinjs-message';
 import { randomBytes, createHash, createCipheriv, createDecipheriv, createHmac } from 'crypto';
 import { secureEncrypt, secureDecrypt, decryptData, legacyDecrypt } from './encryption';
 import { runWithConcurrency } from './concurrency';
+import { estimateTxFee, DEFAULT_FEE_RATE_SAT_PER_VBYTE, DUST_THRESHOLD_SATS } from './fees';
 
 // How many transaction.get requests to keep in flight while syncing history. Electrum matches
 // responses by id, so a small pool cuts the latency of a large sync ~N-fold. Kept deliberately low:
@@ -180,6 +181,14 @@ export function resolveSendAmounts(
     const change = totalInput - sendAmount - feeRate;
     return { sendAmount, change };
 }
+
+// Fee model lives in ./fees (dependency-free, shared with the UI so the two cannot drift apart).
+export {
+    estimateTxVBytes,
+    estimateTxFee,
+    DEFAULT_FEE_RATE_SAT_PER_VBYTE,
+    DUST_THRESHOLD_SATS,
+} from './fees';
 
 
 
@@ -495,6 +504,24 @@ export class WalletService {
         }
     }
 
+    /**
+     * The fee rate (sat/vByte) to use for a spend: a caller override if given, otherwise the node's
+     * reported rate but never below Avian Core's default (fee estimation is unavailable on this
+     * low-volume chain, so Core's default is the reliable floor).
+     */
+    private async resolveFeeRate(optionRate?: number): Promise<number> {
+        if (optionRate && optionRate > 0) {
+            return optionRate;
+        }
+        let networkRate = 0;
+        try {
+            networkRate = await this.electrum.getFeeRateSatPerVByte();
+        } catch {
+            networkRate = 0;
+        }
+        return Math.max(DEFAULT_FEE_RATE_SAT_PER_VBYTE, networkRate);
+    }
+
     async sendTransaction(
         toAddress: string,
         amount: number,
@@ -556,15 +583,9 @@ export class WalletService {
             // Calculate total available amount
             const totalAvailable = enhancedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
 
-            // Define transaction fee and options
-            const feeRate = options?.feeRate || 10000; // 0.0001 AVN = 10000 satoshis
-            const totalRequired = amount + feeRate;
-
-            if (totalAvailable < totalRequired) {
-                throw new Error(
-                    `Insufficient funds. Required: ${totalRequired} satoshis, Available: ${totalAvailable} satoshis`,
-                );
-            }
+            // Size-based fee: sat/vByte rate (caller override, else the node's rate, floored).
+            const subtractFee = options?.subtractFeeFromAmount ?? false;
+            const satPerVByte = await this.resolveFeeRate(options?.feeRate);
 
             // Select optimal UTXOs using the selection service
             const strategyRecommendation = UTXOSelectionService.getRecommendedStrategy(
@@ -587,35 +608,62 @@ export class WalletService {
                 }
             }
 
-            const selectionOptions: UTXOSelectionOptions = {
-                strategy: options?.strategy || strategyRecommendation.strategy,
-                targetAmount: amount,
-                feeRate: feeRate,
-                maxInputs: options?.maxInputs || 20,
-                minConfirmations: options?.minConfirmations || 0,
-                allowUnconfirmed: true,
-                includeDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
-                isAutoConsolidation: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
-                selfAddress: selfAddress,
-            };
+            // The fee depends on how many inputs get selected, and selection depends on the fee, so
+            // iterate: estimate a fee, select, re-estimate from the actual input count, and reselect
+            // if it grew. Converges in a pass or two because the fee is tiny next to the amounts.
+            let selectedUTXOs: any[] = [];
+            let totalSelected = 0;
+            let fee = estimateTxFee(1, 2, satPerVByte);
+            for (let iteration = 0; iteration < 4; iteration++) {
+                // For subtract-fee the recipient absorbs the fee, so the inputs only need to cover
+                // `amount`; otherwise they must cover `amount + fee`. This is what makes send-max
+                // with subtract-fee possible.
+                const selectionTarget = subtractFee ? Math.max(0, amount - fee) : amount;
+                const totalRequired = selectionTarget + fee;
+                if (totalAvailable < totalRequired) {
+                    throw new Error(
+                        `Insufficient funds. Required: ${totalRequired} satoshis, Available: ${totalAvailable} satoshis`,
+                    );
+                }
 
-            const selectionResult = UTXOSelectionService.selectUTXOs(enhancedUTXOs, selectionOptions);
+                const selectionOptions: UTXOSelectionOptions = {
+                    strategy: options?.strategy || strategyRecommendation.strategy,
+                    targetAmount: selectionTarget,
+                    feeRate: fee,
+                    maxInputs: options?.maxInputs || 20,
+                    minConfirmations: options?.minConfirmations || 0,
+                    allowUnconfirmed: true,
+                    includeDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
+                    isAutoConsolidation: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
+                    selfAddress: selfAddress,
+                };
 
-            if (!selectionResult) {
-                throw new Error('Unable to select suitable UTXOs for transaction');
+                const selectionResult = UTXOSelectionService.selectUTXOs(enhancedUTXOs, selectionOptions);
+                if (!selectionResult) {
+                    throw new Error('Unable to select suitable UTXOs for transaction');
+                }
+                selectedUTXOs = selectionResult.selectedUTXOs;
+                totalSelected = selectedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
+
+                const recomputed = estimateTxFee(selectedUTXOs.length, 2, satPerVByte);
+                if (recomputed <= fee) {
+                    fee = recomputed;
+                    break;
+                }
+                fee = recomputed; // grew with the input count — reselect to cover the larger fee
             }
 
-            const { selectedUTXOs } = selectionResult;
-
-            // Split into recipient and change. The miner fee stays feeRate either way;
-            // subtractFeeFromAmount only moves it from the sender onto the recipient.
-            const totalSelected = selectedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
-            const { sendAmount: finalSendAmount, change: finalChange } = resolveSendAmounts(
-                amount,
-                feeRate,
-                totalSelected,
-                options?.subtractFeeFromAmount ?? false,
-            );
+            // Split into recipient and change, folding sub-dust change into the fee rather than
+            // emitting an output the network would reject as dust.
+            const split = resolveSendAmounts(amount, fee, totalSelected, subtractFee);
+            const finalSendAmount = split.sendAmount;
+            if (finalSendAmount <= 0) {
+                throw new Error('Send amount is zero or negative after subtracting the fee');
+            }
+            if (split.change < 0) {
+                throw new Error('Insufficient funds to cover the network fee');
+            }
+            const finalChange = split.change >= DUST_THRESHOLD_SATS ? split.change : 0;
 
             // Determine change address - use custom address if provided, otherwise sender's address
             const changeAddress =
@@ -783,7 +831,7 @@ export class WalletService {
                 // Save transaction to local history
                 await StorageService.saveTransaction({
                     txid: txId,
-                    amount: amount / 100000000, // Convert satoshis to AVN
+                    amount: finalSendAmount / 100000000, // what the recipient received (net of fee if subtracted)
                     address: toAddress,
                     fromAddress: fromAddress,
                     walletAddress: fromAddress,
@@ -814,7 +862,7 @@ export class WalletService {
             // Save transaction to local history
             await StorageService.saveTransaction({
                 txid: txId,
-                amount: amount / 100000000, // Convert satoshis to AVN
+                amount: finalSendAmount / 100000000, // what the recipient received (net of fee if subtracted)
                 address: toAddress,
                 fromAddress: fromAddress,
                 walletAddress: fromAddress, // Add wallet address for proper multi-wallet support
@@ -858,8 +906,11 @@ export class WalletService {
 
             // Validate that we have sufficient funds
             const totalAvailable = manualUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
-            const feeRate = options?.feeRate || 10000; // Default fee
-            const totalRequired = amount + feeRate;
+            const subtractFee = options?.subtractFeeFromAmount ?? false;
+            const satPerVByte = await this.resolveFeeRate(options?.feeRate);
+            // Inputs are fixed here, so the fee is known directly (recipient + change ≈ 2 outputs).
+            const fee = estimateTxFee(manualUTXOs.length, 2, satPerVByte);
+            const totalRequired = subtractFee ? amount : amount + fee;
 
             if (totalAvailable < totalRequired) {
                 throw new Error(
@@ -959,19 +1010,26 @@ export class WalletService {
                 tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
             }
 
-            // Split into recipient and change via the shared rule (fee stays feeRate either way).
+            // Split into recipient and change via the shared rule.
             const totalInput = manualUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
             const { sendAmount: actualAmount, change } = resolveSendAmounts(
                 amount,
-                feeRate,
+                fee,
                 totalInput,
-                options?.subtractFeeFromAmount ?? false,
+                subtractFee,
             );
+            if (actualAmount <= 0) {
+                throw new Error('Send amount is zero or negative after subtracting the fee');
+            }
+            if (change < 0) {
+                throw new Error('Insufficient funds to cover the network fee');
+            }
 
             // Add outputs
             tx.addOutput(bitcoin.address.toOutputScript(toAddress, avianNetwork), actualAmount);
 
-            if (change > 0) {
+            // Fold sub-dust change into the fee rather than emit a rejected dust output.
+            if (change >= DUST_THRESHOLD_SATS) {
                 const changeAddress = options?.changeAddress || activeWallet.address;
                 tx.addOutput(bitcoin.address.toOutputScript(changeAddress, avianNetwork), change);
             }
@@ -4077,40 +4135,58 @@ export class WalletService {
             // Calculate total available amount
             const totalAvailable = enhancedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
 
-            // Define transaction fee and options
-            const feeRate = options?.feeRate || 10000; // Default to 10000 satoshis per KB
+            // Size-based fee: sat/vByte rate (caller override, else the node's rate, floored).
+            const subtractFee = options?.subtractFeeFromAmount ?? false;
+            const satPerVByte = await this.resolveFeeRate(options?.feeRate);
             const maxInputs = options?.maxInputs || 650; // Default: stay under ~100KB for standard txs
             const minConfirmations =
                 options?.minConfirmations !== undefined ? options?.minConfirmations : 6;
             const strategy = options?.strategy || CoinSelectionStrategy.BEST_FIT;
 
-            // Get selected UTXOs based on the chosen strategy
-            const selectionOptions: UTXOSelectionOptions = {
-                strategy: strategy,
-                targetAmount: amount,
-                feeRate: feeRate,
-                maxInputs: maxInputs,
-                minConfirmations: minConfirmations,
-                allowUnconfirmed: true,
-                includeDust: false,
-            };
-
-            const selectionResult = UTXOSelectionService.selectUTXOs(enhancedUTXOs, selectionOptions);
-
-            if (!selectionResult) {
-                throw new Error('Unable to select suitable UTXOs for transaction');
+            // Iterate so the fee tracks the selected input count (see sendTransaction for rationale).
+            let selectedUTXOs: any[] = [];
+            let totalSelected = 0;
+            let fee = estimateTxFee(1, 2, satPerVByte);
+            for (let iteration = 0; iteration < 4; iteration++) {
+                const selectionTarget = subtractFee ? Math.max(0, amount - fee) : amount;
+                if (totalAvailable < selectionTarget + fee) {
+                    throw new Error(
+                        `Insufficient funds. Required: ${selectionTarget + fee} satoshis, Available: ${totalAvailable} satoshis`,
+                    );
+                }
+                const selectionOptions: UTXOSelectionOptions = {
+                    strategy: strategy,
+                    targetAmount: selectionTarget,
+                    feeRate: fee,
+                    maxInputs: maxInputs,
+                    minConfirmations: minConfirmations,
+                    allowUnconfirmed: true,
+                    includeDust: false,
+                };
+                const selectionResult = UTXOSelectionService.selectUTXOs(enhancedUTXOs, selectionOptions);
+                if (!selectionResult) {
+                    throw new Error('Unable to select suitable UTXOs for transaction');
+                }
+                selectedUTXOs = selectionResult.selectedUTXOs;
+                totalSelected = selectedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
+                const recomputed = estimateTxFee(selectedUTXOs.length, 2, satPerVByte);
+                if (recomputed <= fee) {
+                    fee = recomputed;
+                    break;
+                }
+                fee = recomputed;
             }
 
-            const { selectedUTXOs } = selectionResult;
-
-            // Split into recipient and change via the shared rule (fee stays feeRate either way).
-            const totalSelected = selectedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
-            const { sendAmount: finalSendAmount, change: finalChangeAmount } = resolveSendAmounts(
-                amount,
-                feeRate,
-                totalSelected,
-                options?.subtractFeeFromAmount ?? false,
-            );
+            // Split into recipient and change, folding sub-dust change into the fee.
+            const split = resolveSendAmounts(amount, fee, totalSelected, subtractFee);
+            const finalSendAmount = split.sendAmount;
+            if (finalSendAmount <= 0) {
+                throw new Error('Send amount is zero or negative after subtracting the fee');
+            }
+            if (split.change < 0) {
+                throw new Error('Insufficient funds to cover the network fee');
+            }
+            const finalChangeAmount = split.change >= DUST_THRESHOLD_SATS ? split.change : 0;
 
             // Determine change address - use custom address if provided, otherwise sender's address
             const changeAddress =
@@ -4129,9 +4205,8 @@ export class WalletService {
             // Add output for recipient
             tx.addOutput(bitcoin.address.toOutputScript(toAddress, avianNetwork), finalSendAmount);
 
-            // Add change output if needed
-            if (finalChangeAmount > 600) {
-                // Only create change outputs above dust limit
+            // Add change output if needed (sub-dust change was already folded into the fee above).
+            if (finalChangeAmount > 0) {
                 tx.addOutput(
                     bitcoin.address.toOutputScript(changeAddress, avianNetwork),
                     finalChangeAmount,
@@ -4197,7 +4272,7 @@ export class WalletService {
             // Track this as a sent transaction in our history
             const txData = {
                 txid: txId,
-                amount: amount / 100000000, // Convert to AVN
+                amount: finalSendAmount / 100000000, // what the recipient received (net of fee if subtracted)
                 address: toAddress,
                 fromAddress: fromAddress,
                 walletAddress: fromAddress, // Use the derived address

--- a/src/services/wallet/fees.test.ts
+++ b/src/services/wallet/fees.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  estimateTxVBytes,
+  estimateTxFee,
+  DEFAULT_FEE_RATE_SAT_PER_VBYTE,
+  DUST_THRESHOLD_SATS,
+} from './fees';
+
+describe('fee model', () => {
+  it('sizes a legacy transaction as overhead + inputs*148 + outputs*34', () => {
+    expect(estimateTxVBytes(1, 2)).toBe(10 + 148 + 68); // 226
+    expect(estimateTxVBytes(3, 2)).toBe(10 + 3 * 148 + 68);
+  });
+
+  it('scales the fee with size at the given rate, rounded up', () => {
+    expect(estimateTxFee(1, 2, 1)).toBe(226);
+    expect(estimateTxFee(1, 2, 1025)).toBe(226 * 1025);
+    expect(estimateTxFee(3, 2, 1)).toBeGreaterThan(estimateTxFee(1, 2, 1));
+    // rounds up
+    expect(estimateTxFee(1, 2, 1.5)).toBe(Math.ceil(226 * 1.5));
+  });
+
+  it("defaults to Avian Core's send fee (0.01025 AVN/kB = 1025 sat/vByte)", () => {
+    expect(DEFAULT_FEE_RATE_SAT_PER_VBYTE).toBe(1025);
+    expect((DEFAULT_FEE_RATE_SAT_PER_VBYTE * 1000) / 100_000_000).toBeCloseTo(0.01025, 8);
+  });
+
+  it('uses a 1000-sat dust threshold', () => {
+    expect(DUST_THRESHOLD_SATS).toBe(1000);
+  });
+});

--- a/src/services/wallet/fees.ts
+++ b/src/services/wallet/fees.ts
@@ -1,0 +1,31 @@
+// Pure fee helpers, dependency-free so both WalletService (which builds transactions) and the UI
+// (which previews the fee) can share one source of truth — the flat-fee drift across paths is
+// exactly how the fee got wrong before.
+//
+// The miner fee scales with transaction size. We size a legacy P2PKH transaction (SegWit inputs are
+// smaller, ~68 vB, so this errs slightly high — safe, it never underpays) and multiply by a
+// per-vByte rate.
+
+const TX_OVERHEAD_VBYTES = 10;
+const INPUT_VBYTES = 148; // P2PKH input (upper bound; P2WPKH ≈ 68)
+const OUTPUT_VBYTES = 34;
+
+/** Approximate virtual size (bytes) of a transaction with the given input/output counts. */
+export function estimateTxVBytes(numInputs: number, numOutputs: number): number {
+  return TX_OVERHEAD_VBYTES + numInputs * INPUT_VBYTES + numOutputs * OUTPUT_VBYTES;
+}
+
+/** Total miner fee (satoshis, rounded up) for a transaction of this shape at `satPerVByte`. */
+export function estimateTxFee(numInputs: number, numOutputs: number, satPerVByte: number): number {
+  return Math.ceil(estimateTxVBytes(numInputs, numOutputs) * satPerVByte);
+}
+
+// Default fee rate. Avian Core's default send fee is 0.01025 AVN/kB and, because the network is
+// low-volume, `estimatefee` is effectively unavailable — so match Core's default rather than the
+// bare min-relay, so our transactions confirm like the reference wallet.
+// 0.01025 AVN/kB = 1,025,000 sat / 1000 vByte = 1025 sat/vByte.
+export const DEFAULT_FEE_RATE_SAT_PER_VBYTE = 1025;
+
+// Change (or a recipient output) below this is dust the network rejects; callers fold it into the
+// fee instead of emitting it. Matches UTXOSelectionService.DEFAULT_DUST_THRESHOLD.
+export const DUST_THRESHOLD_SATS = 1000;

--- a/src/services/wallet/sendTransaction.test.ts
+++ b/src/services/wallet/sendTransaction.test.ts
@@ -10,6 +10,7 @@ import {
   resolveSendAmounts,
   secureEncrypt,
 } from './WalletService';
+import { estimateTxFee } from './fees';
 import { CoinSelectionStrategy } from './UTXOSelectionService';
 import { StorageService } from '@/services/core/StorageService';
 import { TEST_PASSWORD, resetStorage } from '@/test/helpers';
@@ -63,6 +64,9 @@ function createFakeElectrum(address: string, values: number[], blockHeight = 100
       // Touched by other WalletService paths but irrelevant here.
       getBalance: vi.fn(async () => values.reduce((sum, value) => sum + value, 0)),
       getTransactionHistory: vi.fn(async () => []),
+      // 0 => WalletService falls back to its default rate; tests that assert fees pass an explicit
+      // low feeRate so the amounts stay small and the arithmetic is easy to check.
+      getFeeRateSatPerVByte: vi.fn(async () => 0),
       isConnectedToServer: vi.fn(() => true),
       connect: vi.fn(async () => {}),
       subscribeToAddress: vi.fn(async () => {}),
@@ -152,7 +156,8 @@ describe('resolveSendAmounts', () => {
 });
 
 describe('sendTransaction', () => {
-  const FEE = 10_000;
+  const RATE = 1; // sat/vByte — small so the test amounts and fee arithmetic stay simple
+  const feeFor = (inputs: number, outputs: number) => estimateTxFee(inputs, outputs, RATE);
 
   it('builds, signs and broadcasts a transaction that pays the recipient', async () => {
     const { address } = await createActiveWallet();
@@ -174,34 +179,66 @@ describe('sendTransaction', () => {
     const { electrum, broadcast } = createFakeElectrum(address, [500_000]);
     const wallet = new WalletService(electrum as never);
 
-    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD);
+    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, { feeRate: RATE });
 
     const outputs = outputsOf(broadcastTx(broadcast));
-    expect(outputs).toContainEqual({ address, value: 500_000 - 100_000 - FEE });
+    expect(outputs).toContainEqual({ address, value: 500_000 - 100_000 - feeFor(1, 2) });
   });
 
-  it('accounts for exactly the fee: inputs minus outputs is the fee rate', async () => {
+  it('accounts for exactly the fee: inputs minus outputs is the size-based fee', async () => {
     const { address } = await createActiveWallet();
     const { electrum, broadcast } = createFakeElectrum(address, [500_000]);
     const wallet = new WalletService(electrum as never);
 
-    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD);
+    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, { feeRate: RATE });
 
     const tx = broadcastTx(broadcast);
     const totalOut = tx.outs.reduce((sum, out) => sum + out.value, 0);
-    expect(500_000 - totalOut).toBe(FEE);
+    expect(500_000 - totalOut).toBe(feeFor(1, 2)); // 1 input, recipient + change
   });
 
-  it('honours a custom fee rate', async () => {
+  it('scales the fee with transaction size (more inputs cost more)', async () => {
+    // One input vs three: the fee must grow with the byte count, not stay flat.
+    const oneIn = createFakeElectrum(
+      (await createActiveWallet()).address,
+      [500_000],
+    );
+    await new WalletService(oneIn.electrum as never).sendTransaction(
+      RECIPIENT,
+      100_000,
+      TEST_PASSWORD,
+      { feeRate: RATE },
+    );
+    const feeOneInput =
+      500_000 - broadcastTx(oneIn.broadcast).outs.reduce((s, o) => s + o.value, 0);
+
+    resetStorage();
+    const { address } = await createActiveWallet();
+    const threeIn = createFakeElectrum(address, [60_000, 60_000, 60_000]);
+    await new WalletService(threeIn.electrum as never).sendTransaction(
+      RECIPIENT,
+      150_000, // needs all three 60k inputs
+      TEST_PASSWORD,
+      { feeRate: RATE, strategy: CoinSelectionStrategy.LARGEST_FIRST },
+    );
+    const txThree = broadcastTx(threeIn.broadcast);
+    const feeThreeInputs = 180_000 - txThree.outs.reduce((s, o) => s + o.value, 0);
+
+    expect(txThree.ins.length).toBe(3);
+    expect(feeThreeInputs).toBe(feeFor(3, 2));
+    expect(feeThreeInputs).toBeGreaterThan(feeOneInput);
+  });
+
+  it('honours a custom fee rate (sat/vByte)', async () => {
     const { address } = await createActiveWallet();
     const { electrum, broadcast } = createFakeElectrum(address, [500_000]);
     const wallet = new WalletService(electrum as never);
 
-    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, { feeRate: 25_000 });
+    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, { feeRate: 3 });
 
     const tx = broadcastTx(broadcast);
     const totalOut = tx.outs.reduce((sum, out) => sum + out.value, 0);
-    expect(500_000 - totalOut).toBe(25_000);
+    expect(500_000 - totalOut).toBe(estimateTxFee(1, 2, 3));
   });
 
   it('pays miners the same fee with subtractFeeFromAmount on as off', async () => {
@@ -216,6 +253,7 @@ describe('sendTransaction', () => {
     const off = await walletFor();
     await off.wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, {
       subtractFeeFromAmount: false,
+      feeRate: RATE,
     });
     const txOff = broadcastTx(off.broadcast);
 
@@ -223,33 +261,56 @@ describe('sendTransaction', () => {
     const on = await walletFor();
     await on.wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, {
       subtractFeeFromAmount: true,
+      feeRate: RATE,
     });
     const txOn = broadcastTx(on.broadcast);
 
     const feeOff = 500_000 - txOff.outs.reduce((sum, out) => sum + out.value, 0);
     const feeOn = 500_000 - txOn.outs.reduce((sum, out) => sum + out.value, 0);
 
-    expect(feeOff).toBe(FEE);
-    expect(feeOn).toBe(FEE);
+    expect(feeOff).toBe(feeFor(1, 2));
+    expect(feeOn).toBe(feeFor(1, 2));
 
     // And with the flag on, the recipient — not the sender — absorbed the fee.
     const recipientOut = (tx: bitcoin.Transaction) =>
       outputsOf(tx).find((out) => out.address === RECIPIENT)!.value;
     expect(recipientOut(txOff)).toBe(100_000);
-    expect(recipientOut(txOn)).toBe(90_000);
+    expect(recipientOut(txOn)).toBe(100_000 - feeFor(1, 2));
   });
 
-  it('omits the change output when there is nothing left over', async () => {
+  it('lets subtract-fee send the entire balance (send-max)', async () => {
     const { address } = await createActiveWallet();
-    // Exactly amount + fee, so change is zero.
-    const { electrum, broadcast } = createFakeElectrum(address, [110_000]);
+    const { electrum, broadcast } = createFakeElectrum(address, [500_000]);
     const wallet = new WalletService(electrum as never);
 
-    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD);
+    // Amount == full balance: only possible because the fee comes out of the amount.
+    await wallet.sendTransaction(RECIPIENT, 500_000, TEST_PASSWORD, {
+      subtractFeeFromAmount: true,
+      feeRate: RATE,
+    });
 
     const tx = broadcastTx(broadcast);
-    expect(tx.outs).toHaveLength(1);
+    const outputs = outputsOf(tx);
+    // Everything goes to the recipient minus the fee; no change output. (The fee is still sized for
+    // a 2-output tx, which is the conservative estimate the planner uses.)
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0]).toEqual({ address: RECIPIENT, value: 500_000 - feeFor(1, 2) });
+  });
+
+  it('folds sub-dust change into the fee instead of emitting a dust output', async () => {
+    const { address } = await createActiveWallet();
+    // Leave a few hundred sats of change — below the dust threshold — so it must be folded.
+    const funding = 100_000 + feeFor(1, 2) + 300;
+    const { electrum, broadcast } = createFakeElectrum(address, [funding]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, { feeRate: RATE });
+
+    const tx = broadcastTx(broadcast);
+    expect(tx.outs).toHaveLength(1); // no dust change output
     expect(outputsOf(tx)[0]).toEqual({ address: RECIPIENT, value: 100_000 });
+    // The 300 sats of would-be dust went to the miner, not to a rejected output.
+    expect(funding - 100_000).toBe(feeFor(1, 2) + 300);
   });
 
   it('sends change to a custom change address when one is given', async () => {
@@ -258,10 +319,10 @@ describe('sendTransaction', () => {
     const { electrum, broadcast } = createFakeElectrum(address, [500_000]);
     const wallet = new WalletService(electrum as never);
 
-    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, { changeAddress });
+    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, { changeAddress, feeRate: RATE });
 
     const outputs = outputsOf(broadcastTx(broadcast));
-    expect(outputs).toContainEqual({ address: changeAddress, value: 390_000 });
+    expect(outputs).toContainEqual({ address: changeAddress, value: 500_000 - 100_000 - feeFor(1, 2) });
     expect(outputs.map((out) => out.address)).not.toContain(address);
   });
 
@@ -270,7 +331,10 @@ describe('sendTransaction', () => {
     const { electrum, broadcast } = createFakeElectrum(address, [500_000]);
     const wallet = new WalletService(electrum as never);
 
-    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, { changeAddress: '   ' });
+    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, {
+      changeAddress: '   ',
+      feeRate: RATE,
+    });
 
     const outputs = outputsOf(broadcastTx(broadcast));
     expect(outputs.map((out) => out.address)).toContain(address);
@@ -283,6 +347,7 @@ describe('sendTransaction', () => {
 
     await wallet.sendTransaction(RECIPIENT, 150_000, TEST_PASSWORD, {
       strategy: CoinSelectionStrategy.LARGEST_FIRST,
+      feeRate: RATE,
     });
 
     const tx = broadcastTx(broadcast);
@@ -296,6 +361,7 @@ describe('sendTransaction', () => {
 
     await wallet.sendTransaction(RECIPIENT, 150_000, TEST_PASSWORD, {
       strategy: CoinSelectionStrategy.LARGEST_FIRST,
+      feeRate: RATE,
     });
 
     const tx = broadcastTx(broadcast);
@@ -339,6 +405,21 @@ describe('sendTransaction', () => {
       amount: 0.001,
       confirmations: 0,
     });
+  });
+
+  it('records what the recipient actually received when subtract-fee is on', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum } = createFakeElectrum(address, [500_000]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.sendTransaction(RECIPIENT, 100_000, TEST_PASSWORD, {
+      subtractFeeFromAmount: true,
+      feeRate: RATE,
+    });
+
+    const history = await StorageService.getTransactionHistory(address);
+    // Recipient got amount − fee, and that (not the gross amount) is what history records.
+    expect(history[0].amount).toBeCloseTo((100_000 - feeFor(1, 2)) / 100_000_000, 10);
   });
 
   it('builds a spendable-looking transaction for a native SegWit wallet', async () => {


### PR DESCRIPTION
Fixes the fund-safety cluster (review items 🔴 1–4). The fee was a flat constant mislabeled "sat/vB" — the root of several bugs.

## Changes
1. **Size-based fee** — `fee = vBytes × rate`. Rate comes from the node (`relayfee`/`estimatefee`) but defaults to **Avian Core's send fee, 0.01025 AVN/kB = 1025 sat/vByte**, since estimation is unavailable on this low-volume chain (so we confirm like the reference wallet). Threaded through all three send paths — selection **iterates** to size the fee to the actual input count — and the UI. **Fixes UTXO consolidation**, which built sub-min-relay transactions.
2. **Dust floor** — change below 1000 sats is folded into the fee instead of emitted as a rejected output (was `>0` in two paths, `>600` in a third).
3. **Subtract-fee send-max** — funds check + selection target account for `subtractFeeFromAmount`, so a wallet can be emptied in one tx. **MAX** now enables subtract-fee and offers the full balance.
4. **Correct history** — send records store what the recipient actually received (`amount − fee` when subtracted), consistently.

## Validated on mainnet ✅
- Normal send of 1000 AVN → recipient got exactly 1000; fee **0.00231650 AVN** (231 650 sat, size-based).
- Subtract-fee send-max → 192-vByte 1-in/1-out tx, correct fee, valid FORKID sighash, confirmed (block 5130487).
- Consolidation shares the same path (multi-input unit-tested); no dust on-chain to exercise it live.

## Structure & tests
- New dependency-free `fees.ts` — single source of truth shared by the service and UI so they can't drift again.
- `ElectrumService.getFeeRateSatPerVByte`.
- `sendTransaction.test.ts` reworked + `fees.test.ts`: fee scales with inputs, dust folded, subtract-fee send-max, history records the received amount. Full suite green; typecheck + build clean.

## Note
Fees rise for normal sends (old flat 10 000 sat → ~231 650 sat at Core's rate) — intentional, so txs confirm like Core; advanced users can set a lower sat/vByte.

## Version
Bumps **2.4.17 → 2.4.18**.