### PR TITLE
feat(wallet): PSBT engine — summarize, sign & finalize with Avian FORKID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -25,6 +25,13 @@ import { randomBytes, createHash, createCipheriv, createDecipheriv, createHmac }
 import { secureEncrypt, secureDecrypt, decryptData, legacyDecrypt } from './encryption';
 import { runWithConcurrency } from './concurrency';
 import { estimateTxFee, DEFAULT_FEE_RATE_SAT_PER_VBYTE, DUST_THRESHOLD_SATS } from './fees';
+import {
+    SIGHASH_ALL_FORKID,
+    isAssetScript,
+    type PsbtSummary,
+    type PsbtInputSummary,
+    type PsbtOutputSummary,
+} from './psbt';
 
 // How many transaction.get requests to keep in flight while syncing history. Electrum matches
 // responses by id, so a small pool cuts the latency of a large sync ~N-fold. Kept deliberately low:
@@ -520,6 +527,247 @@ export class WalletService {
             networkRate = 0;
         }
         return Math.max(DEFAULT_FEE_RATE_SAT_PER_VBYTE, networkRate);
+    }
+
+    // --- PSBT (BIP174) -------------------------------------------------------------------------
+    // Avian PSBTs are stock BIP174; the only Avian detail is the 0x41 (ALL|FORKID) sighash, which
+    // bitcoinjs already produces for legacy and SegWit-v0 inputs when that type is set. So signing
+    // reuses the same path regular sends use. Asset inputs are never signed (that would burn them).
+
+    /** Decrypt the active wallet's key into an ECPair (throws on a missing/bad password). */
+    private async getActiveKeyPair(password?: string) {
+        const activeWallet = await StorageService.getActiveWallet();
+        if (!activeWallet) throw new Error('No active wallet found');
+        let wif = activeWallet.privateKey;
+        if (activeWallet.isEncrypted) {
+            if (!password) throw new Error('Password required for encrypted wallet');
+            try {
+                const { decrypted } = await decryptData(wif, password);
+                if (!decrypted) throw new Error('Invalid password');
+                wif = decrypted;
+            } catch {
+                throw new Error('Invalid password');
+            }
+        }
+        return ECPair.fromWIF(wif, avianNetwork);
+    }
+
+    /** Prevout {script,value} for a PSBT input, from its witnessUtxo or nonWitnessUtxo. */
+    private psbtPrevOut(psbt: bitcoin.Psbt, index: number): { script: Buffer; value: number } | null {
+        const data = psbt.data.inputs[index];
+        if (data.witnessUtxo) {
+            return { script: data.witnessUtxo.script, value: data.witnessUtxo.value };
+        }
+        if (data.nonWitnessUtxo) {
+            const prevTx = bitcoin.Transaction.fromBuffer(data.nonWitnessUtxo);
+            const out = prevTx.outs[psbt.txInputs[index].index];
+            return out ? { script: out.script, value: out.value } : null;
+        }
+        return null;
+    }
+
+    private scriptToAddress(script: Buffer): string | null {
+        try {
+            return bitcoin.address.fromOutputScript(script, avianNetwork);
+        } catch {
+            return null;
+        }
+    }
+
+    private inputSignedBy(data: any, pubkey: Buffer): boolean {
+        return !!data.partialSig?.some((ps: any) => Buffer.from(ps.pubkey).equals(pubkey));
+    }
+
+    private inputHasAnySig(data: any): boolean {
+        return !!(
+            data.finalScriptSig ||
+            data.finalScriptWitness ||
+            (data.partialSig && data.partialSig.length)
+        );
+    }
+
+    /**
+     * Decode a base64 PSBT and describe it — each input's prevout, ownership and asset status, each
+     * output, totals and fee, how many inputs this wallet can sign, and whether it is ready to
+     * finalize. No key access, so it is safe to show before authentication.
+     */
+    async summarizePsbt(psbtBase64: string, ownAddress?: string): Promise<PsbtSummary> {
+        const psbt = bitcoin.Psbt.fromBase64(psbtBase64, { network: avianNetwork });
+        const mine = ownAddress ?? (await StorageService.getActiveWallet())?.address ?? null;
+        const myScript = mine ? bitcoin.address.toOutputScript(mine, avianNetwork) : null;
+
+        const inputs: PsbtInputSummary[] = psbt.txInputs.map((txIn, i) => {
+            const prev = this.psbtPrevOut(psbt, i);
+            const script = prev?.script ?? null;
+            return {
+                txid: Buffer.from(txIn.hash).reverse().toString('hex'),
+                vout: txIn.index,
+                value: prev?.value ?? null,
+                address: script ? this.scriptToAddress(script) : null,
+                isMine: !!(script && myScript && script.equals(myScript)),
+                isAsset: !!(script && isAssetScript(script)),
+                signed: this.inputHasAnySig(psbt.data.inputs[i]),
+            };
+        });
+
+        const outputs: PsbtOutputSummary[] = psbt.txOutputs.map((out) => ({
+            address: this.scriptToAddress(out.script),
+            value: out.value,
+            isMine: !!(myScript && out.script.equals(myScript)),
+            isAsset: isAssetScript(out.script),
+        }));
+
+        const knownIn = inputs.every((i) => i.value !== null);
+        const totalIn = knownIn ? inputs.reduce((s, i) => s + (i.value ?? 0), 0) : null;
+        const totalOut = outputs.reduce((s, o) => s + o.value, 0);
+
+        return {
+            inputs,
+            outputs,
+            totalIn,
+            totalOut,
+            fee: totalIn !== null ? totalIn - totalOut : null,
+            signableByUs: inputs.filter((i) => i.isMine && !i.isAsset && !i.signed).length,
+            complete: inputs.every((i) => i.signed),
+            hasAsset: inputs.some((i) => i.isAsset) || outputs.some((o) => o.isAsset),
+        };
+    }
+
+    /** The unsigned global transaction of a PSBT (empty input scripts), for computing sighashes. */
+    private unsignedTxFromPsbt(psbt: bitcoin.Psbt): bitcoin.Transaction {
+        const tx = new bitcoin.Transaction();
+        tx.version = psbt.version;
+        tx.locktime = psbt.locktime;
+        for (const input of psbt.txInputs) tx.addInput(Buffer.from(input.hash), input.index, input.sequence);
+        for (const output of psbt.txOutputs) tx.addOutput(output.script, output.value);
+        return tx;
+    }
+
+    /** Whether a prevout script is a native P2WPKH (`OP_0 <20-byte hash>`). */
+    private isP2wpkhScript(script: Buffer): boolean {
+        return script.length === 22 && script[0] === 0x00 && script[1] === 0x14;
+    }
+
+    /** Serialize a witness stack (count + length-prefixed items) for a PSBT finalScriptWitness. */
+    private serializeWitnessStack(items: Buffer[]): Buffer {
+        const chunks: Buffer[] = [this.encodeVarint(items.length)];
+        for (const item of items) chunks.push(this.encodeVarint(item.length), item);
+        return Buffer.concat(chunks);
+    }
+
+    private encodeVarint(n: number): Buffer {
+        if (n < 0xfd) return Buffer.from([n]);
+        if (n <= 0xffff) {
+            const b = Buffer.allocUnsafe(3);
+            b[0] = 0xfd;
+            b.writeUInt16LE(n, 1);
+            return b;
+        }
+        const b = Buffer.allocUnsafe(5);
+        b[0] = 0xfe;
+        b.writeUInt32LE(n, 1);
+        return b;
+    }
+
+    /**
+     * Sign every input the active wallet owns — skipping asset inputs and any already signed — with
+     * the Avian FORKID sighash, and return the updated base64 PSBT. Does not finalize, so the result
+     * can be handed to another signer or exported.
+     *
+     * bitcoinjs-lib's own PSBT signer rejects the 0x41 (ALL|FORKID) sighash ("Invalid hashType 65"),
+     * so we compute the digest ourselves — legacy `hashForSignature` for P2PKH, BIP143
+     * `hashForWitnessV0` for native SegWit — exactly as the regular send path does, then inject the
+     * DER signature as a partialSig. This is the same signing that FlightDeck already broadcasts and
+     * confirms on mainnet, just carried through the PSBT container.
+     */
+    async signPsbt(
+        psbtBase64: string,
+        password?: string,
+    ): Promise<{ psbt: string; complete: boolean; signedInputs: number }> {
+        const psbt = bitcoin.Psbt.fromBase64(psbtBase64, { network: avianNetwork });
+        const keyPair = await this.getActiveKeyPair(password);
+        const pubkey = Buffer.from(keyPair.publicKey);
+        const p2pkhScript = bitcoin.payments.p2pkh({ pubkey, network: avianNetwork }).output!;
+        const p2wpkhScript = bitcoin.payments.p2wpkh({ pubkey, network: avianNetwork }).output!;
+        const unsigned = this.unsignedTxFromPsbt(psbt);
+
+        let signedInputs = 0;
+        for (let i = 0; i < psbt.inputCount; i++) {
+            const prev = this.psbtPrevOut(psbt, i);
+            if (!prev) continue;
+            if (isAssetScript(prev.script)) continue; // never sign an asset input — it would burn it
+            const isP2pkh = prev.script.equals(p2pkhScript);
+            const isP2wpkh = prev.script.equals(p2wpkhScript);
+            if (!isP2pkh && !isP2wpkh) continue; // not our key
+            if (this.inputSignedBy(psbt.data.inputs[i], pubkey)) continue;
+            try {
+                let digest: Buffer;
+                if (isP2wpkh) {
+                    // BIP143 sighash: the scriptCode is the equivalent P2PKH, amount is committed.
+                    const scriptCode = bitcoin.script.compile([
+                        bitcoin.opcodes.OP_DUP,
+                        bitcoin.opcodes.OP_HASH160,
+                        bitcoin.crypto.hash160(pubkey),
+                        bitcoin.opcodes.OP_EQUALVERIFY,
+                        bitcoin.opcodes.OP_CHECKSIG,
+                    ]);
+                    digest = unsigned.hashForWitnessV0(i, scriptCode, prev.value, SIGHASH_ALL_FORKID);
+                } else {
+                    // Legacy sighash: amount is not committed; the prevout script is the scriptCode.
+                    digest = unsigned.hashForSignature(i, prev.script, SIGHASH_ALL_FORKID);
+                }
+                const sig = this.encodeDERWithCustomHashType(
+                    Buffer.from(keyPair.sign(digest)),
+                    SIGHASH_ALL_FORKID,
+                );
+                psbt.updateInput(i, { partialSig: [{ pubkey, signature: sig }] });
+                signedInputs++;
+            } catch (error) {
+                walletLogger.warn(`Could not sign PSBT input ${i}:`, error);
+            }
+        }
+
+        return {
+            psbt: psbt.toBase64(),
+            complete: psbt.data.inputs.every((d) => this.inputHasAnySig(d)),
+            signedInputs,
+        };
+    }
+
+    /**
+     * Finalize a fully-signed PSBT and extract the raw transaction (hex + txid). bitcoinjs-lib's
+     * finalizer also rejects the 0x41 sighash on decode, so we build each input's finalScriptSig
+     * (legacy) or finalScriptWitness (SegWit) from its partialSig ourselves before extracting.
+     */
+    finalizePsbt(psbtBase64: string): { hex: string; txid: string } {
+        const psbt = bitcoin.Psbt.fromBase64(psbtBase64, { network: avianNetwork });
+        for (let i = 0; i < psbt.inputCount; i++) {
+            const data = psbt.data.inputs[i];
+            if (data.finalScriptSig || data.finalScriptWitness) continue; // already finalized
+            const partialSig = data.partialSig?.[0];
+            if (!partialSig) throw new Error(`PSBT input ${i} is not signed`);
+            const sig = Buffer.from(partialSig.signature);
+            const pub = Buffer.from(partialSig.pubkey);
+            const prev = this.psbtPrevOut(psbt, i);
+            if (prev && this.isP2wpkhScript(prev.script)) {
+                psbt.updateInput(i, { finalScriptWitness: this.serializeWitnessStack([sig, pub]) });
+            } else {
+                psbt.updateInput(i, { finalScriptSig: bitcoin.script.compile([sig, pub]) });
+            }
+        }
+        const tx = psbt.extractTransaction();
+        return { hex: tx.toHex(), txid: tx.getId() };
+    }
+
+    /** Sign the active wallet's inputs, finalize, and broadcast. Returns the txid. */
+    async signAndBroadcastPsbt(psbtBase64: string, password?: string): Promise<string> {
+        const signed = await this.signPsbt(psbtBase64, password);
+        const { hex, txid } = this.finalizePsbt(signed.psbt);
+        const result = await this.electrum.broadcastTransaction(hex);
+        if (!result || typeof result !== 'string') {
+            throw new Error('Transaction broadcast failed. Please try again later.');
+        }
+        return txid;
     }
 
     async sendTransaction(

--- a/src/services/wallet/psbt.test.ts
+++ b/src/services/wallet/psbt.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as bitcoin from 'bitcoinjs-lib';
+import { ECPairFactory } from 'ecpair';
+import * as ecc from 'tiny-secp256k1';
+
+import { WalletService, avianNetwork, deriveAddress, secureEncrypt } from './WalletService';
+import { isAssetScript, OP_AVN_ASSET, SIGHASH_ALL_FORKID } from './psbt';
+import { StorageService } from '@/services/core/StorageService';
+import { TEST_PASSWORD, resetStorage } from '@/test/helpers';
+
+/**
+ * PSBT engine. Avian uses stock BIP174 with a 0x41 (ALL|FORKID) sighash; these tests prove the
+ * engine parses/summarises a PSBT, signs our inputs with that sighash, finalises to a valid
+ * transaction, and refuses to touch asset inputs. Nothing is broadcast.
+ */
+
+const ECPair = ECPairFactory(ecc);
+const RECIPIENT = 'RJNi221gkDstBPUxeeJgtmDY4EXMEj6uvF';
+
+/** A previous P2PKH transaction paying `value` to `address`. */
+function fundingTx(address: string, value: number, seed: number) {
+  const tx = new bitcoin.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, seed), 0);
+  tx.addOutput(bitcoin.address.toOutputScript(address, avianNetwork), value);
+  return { hex: tx.toHex(), txid: tx.getId() };
+}
+
+async function createActiveWallet(addressType: 'p2pkh' | 'p2wpkh' = 'p2pkh') {
+  const keyPair = ECPair.makeRandom({ network: avianNetwork });
+  const address = deriveAddress(Buffer.from(keyPair.publicKey), addressType);
+  const encryptedKey = await secureEncrypt(keyPair.toWIF(), TEST_PASSWORD);
+  await StorageService.createWallet({
+    name: 'Spending',
+    address,
+    privateKey: encryptedKey,
+    isEncrypted: true,
+    addressType,
+  });
+  return { address, keyPair };
+}
+
+/** An unsigned single-input, single-output PSBT spending `funding` to RECIPIENT. */
+function buildPsbt(fundingHex: string, fundingTxid: string, sendValue: number) {
+  const psbt = new bitcoin.Psbt({ network: avianNetwork });
+  psbt.addInput({
+    hash: fundingTxid,
+    index: 0,
+    nonWitnessUtxo: Buffer.from(fundingHex, 'hex'),
+  });
+  psbt.addOutput({ address: RECIPIENT, value: sendValue });
+  return psbt.toBase64();
+}
+
+beforeEach(() => {
+  resetStorage();
+});
+
+describe('isAssetScript', () => {
+  it('is false for a bare 25-byte P2PKH', () => {
+    const script = bitcoin.address.toOutputScript(RECIPIENT, avianNetwork);
+    expect(script.length).toBe(25);
+    expect(isAssetScript(script)).toBe(false);
+  });
+
+  it('is true for a P2PKH with an OP_AVN_ASSET tail', () => {
+    const p2pkh = bitcoin.address.toOutputScript(RECIPIENT, avianNetwork);
+    const assetScript = Buffer.concat([p2pkh, Buffer.from([OP_AVN_ASSET, 0x04, 1, 2, 3, 4, 0x75])]);
+    expect(isAssetScript(assetScript)).toBe(true);
+  });
+});
+
+describe('summarizePsbt', () => {
+  it('describes inputs, outputs, fee and what we can sign', async () => {
+    const { address } = await createActiveWallet();
+    const { hex, txid } = fundingTx(address, 500_000, 1);
+    const psbtB64 = buildPsbt(hex, txid, 100_000);
+
+    const summary = await new WalletService({} as never).summarizePsbt(psbtB64, address);
+
+    expect(summary.inputs).toHaveLength(1);
+    expect(summary.inputs[0]).toMatchObject({
+      txid,
+      vout: 0,
+      value: 500_000,
+      address,
+      isMine: true,
+      isAsset: false,
+      signed: false,
+    });
+    expect(summary.outputs).toHaveLength(1);
+    expect(summary.outputs[0]).toMatchObject({ address: RECIPIENT, value: 100_000, isMine: false });
+    expect(summary.totalIn).toBe(500_000);
+    expect(summary.totalOut).toBe(100_000);
+    expect(summary.fee).toBe(400_000);
+    expect(summary.signableByUs).toBe(1);
+    expect(summary.complete).toBe(false);
+    expect(summary.hasAsset).toBe(false);
+  });
+});
+
+describe('signPsbt / finalizePsbt', () => {
+  it('signs our input with the FORKID sighash and finalises to a valid transaction', async () => {
+    const { address, keyPair } = await createActiveWallet('p2pkh');
+    const { hex, txid } = fundingTx(address, 500_000, 2);
+    const psbtB64 = buildPsbt(hex, txid, 100_000);
+    const wallet = new WalletService({} as never);
+
+    const signed = await wallet.signPsbt(psbtB64, TEST_PASSWORD);
+    expect(signed.signedInputs).toBe(1);
+    expect(signed.complete).toBe(true);
+
+    const { hex: rawHex, txid: finalTxid } = wallet.finalizePsbt(signed.psbt);
+    const tx = bitcoin.Transaction.fromHex(rawHex);
+    expect(tx.getId()).toBe(finalTxid);
+
+    // Legacy scriptSig = [signature, pubkey]; the signature's last byte is the sighash flag.
+    const [signature, pubkey] = bitcoin.script.decompile(tx.ins[0].script) as Buffer[];
+    expect(signature[signature.length - 1]).toBe(SIGHASH_ALL_FORKID); // 0x41
+    expect(Buffer.from(pubkey).toString('hex')).toBe(Buffer.from(keyPair.publicKey).toString('hex'));
+
+    // Output is preserved.
+    expect(tx.outs[0].value).toBe(100_000);
+  });
+
+  it('signs a native SegWit (P2WPKH) input via BIP143 and finalises to a witness', async () => {
+    const { address, keyPair } = await createActiveWallet('p2wpkh');
+    const { hex, txid } = fundingTx(address, 500_000, 6);
+    const psbtB64 = buildPsbt(hex, txid, 100_000);
+    const wallet = new WalletService({} as never);
+
+    const signed = await wallet.signPsbt(psbtB64, TEST_PASSWORD);
+    expect(signed.signedInputs).toBe(1);
+    expect(signed.complete).toBe(true);
+
+    const { hex: rawHex } = wallet.finalizePsbt(signed.psbt);
+    const tx = bitcoin.Transaction.fromHex(rawHex);
+
+    // Native SegWit: scriptSig is empty, the [signature, pubkey] live in the witness.
+    expect(tx.ins[0].script).toHaveLength(0);
+    expect(tx.ins[0].witness).toHaveLength(2);
+    const [signature, pubkey] = tx.ins[0].witness;
+    expect(signature[signature.length - 1]).toBe(SIGHASH_ALL_FORKID); // 0x41
+    expect(Buffer.from(pubkey).toString('hex')).toBe(Buffer.from(keyPair.publicKey).toString('hex'));
+  });
+
+  it('is a no-op on inputs that are not ours', async () => {
+    await createActiveWallet();
+    // Funding pays a different address, so our key cannot sign it.
+    const stranger = ECPair.makeRandom({ network: avianNetwork });
+    const strangerAddr = deriveAddress(Buffer.from(stranger.publicKey), 'p2pkh');
+    const { hex, txid } = fundingTx(strangerAddr, 500_000, 3);
+    const psbtB64 = buildPsbt(hex, txid, 100_000);
+
+    const signed = await new WalletService({} as never).signPsbt(psbtB64, TEST_PASSWORD);
+    expect(signed.signedInputs).toBe(0);
+    expect(signed.complete).toBe(false);
+  });
+
+  it('refuses to sign an asset input (never burns an asset)', async () => {
+    const { address } = await createActiveWallet();
+    // A prevout paying our P2PKH but with an OP_AVN_ASSET tail — an asset UTXO.
+    const p2pkh = bitcoin.address.toOutputScript(address, avianNetwork);
+    const assetScript = Buffer.concat([p2pkh, Buffer.from([OP_AVN_ASSET, 0x03, 9, 9, 9, 0x75])]);
+    const prev = new bitcoin.Transaction();
+    prev.version = 2;
+    prev.addInput(Buffer.alloc(32, 4), 0);
+    prev.addOutput(assetScript, 500_000);
+
+    const psbt = new bitcoin.Psbt({ network: avianNetwork });
+    psbt.addInput({ hash: prev.getId(), index: 0, nonWitnessUtxo: prev.toBuffer() });
+    psbt.addOutput({ address: RECIPIENT, value: 100_000 });
+
+    const summary = await new WalletService({} as never).summarizePsbt(psbt.toBase64(), address);
+    expect(summary.inputs[0].isAsset).toBe(true);
+    expect(summary.signableByUs).toBe(0);
+
+    const signed = await new WalletService({} as never).signPsbt(psbt.toBase64(), TEST_PASSWORD);
+    expect(signed.signedInputs).toBe(0);
+  });
+
+  it('round-trips an unsigned PSBT through base64 unchanged', async () => {
+    const { address } = await createActiveWallet();
+    const { hex, txid } = fundingTx(address, 500_000, 5);
+    const psbtB64 = buildPsbt(hex, txid, 100_000);
+
+    const reparsed = bitcoin.Psbt.fromBase64(psbtB64, { network: avianNetwork });
+    expect(reparsed.toBase64()).toBe(psbtB64);
+  });
+});

--- a/src/services/wallet/psbt.ts
+++ b/src/services/wallet/psbt.ts
@@ -1,0 +1,62 @@
+// PSBT (BIP174) helpers. Avian Core uses stock BIP174 — the only Avian-specific detail is that
+// signatures carry SIGHASH_ALL | SIGHASH_FORKID (0x41), which bitcoinjs-lib already produces for
+// both legacy (hashForSignature) and SegWit v0 (hashForWitnessV0) inputs when that sighash type is
+// set. So PSBT signing reuses the same path regular sends use; this module holds the shared
+// constants, the asset-script guard, and the decoded-summary shapes.
+
+/** SIGHASH_ALL (0x01) | SIGHASH_FORKID (0x40). Every Avian signature must carry this. */
+export const SIGHASH_ALL_FORKID = 0x41;
+
+/** OP_AVN_ASSET — marks an Avian asset script. See Avian Core script/script.h. */
+export const OP_AVN_ASSET = 0xc0;
+
+/**
+ * Whether an output script carries an Avian asset. Asset scripts are a standard 25-byte P2PKH
+ * followed by `OP_AVN_ASSET <data> OP_DROP`, so the tell is a byte 0xc0 immediately after the P2PKH.
+ * A plain-AVN wallet must never sign an asset input or select it as a fee input — spending it as a
+ * bare transfer would burn the asset — so this errs toward caution.
+ */
+export function isAssetScript(script: Uint8Array): boolean {
+  // A bare P2PKH is exactly 25 bytes (76 a9 14 <20> 88 ac); anything longer with OP_AVN_ASSET right
+  // after it is an asset carrier. (A 0xc0 byte inside the 20-byte hash of a bare P2PKH is harmless
+  // because those scripts are exactly 25 bytes.)
+  return script.length > 25 && script[25] === OP_AVN_ASSET;
+}
+
+export interface PsbtInputSummary {
+  txid: string;
+  vout: number;
+  /** Prevout value in satoshis, or null if the PSBT didn't include it. */
+  value: number | null;
+  /** Prevout address, or null if the script isn't a standard address. */
+  address: string | null;
+  /** The prevout script belongs to this wallet (we can sign it). */
+  isMine: boolean;
+  /** The prevout carries an Avian asset — we refuse to sign it. */
+  isAsset: boolean;
+  /** This input already has a signature (ours or another party's). */
+  signed: boolean;
+}
+
+export interface PsbtOutputSummary {
+  address: string | null;
+  value: number;
+  isMine: boolean;
+  isAsset: boolean;
+}
+
+export interface PsbtSummary {
+  inputs: PsbtInputSummary[];
+  outputs: PsbtOutputSummary[];
+  /** Sum of input values, or null if any prevout value is unknown. */
+  totalIn: number | null;
+  totalOut: number;
+  /** totalIn − totalOut, or null if totalIn is unknown. */
+  fee: number | null;
+  /** How many inputs this wallet can sign (ours, non-asset, not already signed by us). */
+  signableByUs: number;
+  /** Every input is finalizable (fully signed) — ready to extract/broadcast. */
+  complete: boolean;
+  /** Any input or output touches an asset — surfaced as a warning. */
+  hasAsset: boolean;
+}


### PR DESCRIPTION
PR 1 of 4 for PSBT support. This is the client-side PSBT (BIP174) core that the import/sign/broadcast UI, unsigned-PSBT export, and Avian Connect `signPsbt` will build on. No UI yet — engine + tests only.

## Why it needs custom code
Avian Core uses **stock BIP174**. The one Avian-specific detail is the sighash: every signature carries `SIGHASH_ALL | SIGHASH_FORKID` (`0x41`). bitcoinjs-lib refuses that byte on both ends — `script_signature.encode` throws `Invalid hashType 65`, and its finalizer's `isCanonicalScriptSignature` rejects it on decode. So we cannot use its high-level PSBT signer/finalizer.

Instead we compute the digest and assemble the input ourselves, reusing the **exact path FlightDeck already broadcasts and confirms on mainnet**:
- **Legacy P2PKH** → `tx.hashForSignature(i, prevScript, 0x41)` (amount not committed)
- **Native SegWit v0** → `tx.hashForWitnessV0(i, scriptCode, value, 0x41)` (BIP143, amount committed)

The DER signature is injected as a `partialSig`; finalize builds `finalScriptSig` (legacy) / `finalScriptWitness` (SegWit) directly, then `extractTransaction()` (which does not re-validate signatures) yields the raw tx.

## Asset safety
`isAssetScript()` flags any prevout that is a 25-byte P2PKH followed by `OP_AVN_ASSET (0xc0)`. `signPsbt` **never signs an asset input** (spending one as a bare transfer would burn the asset) and `summarizePsbt` surfaces `hasAsset` / `signableByUs` so the UI can warn.

## API
- `summarizePsbt(psbtB64, ownAddress?)` — no key access; decodes inputs/outputs, per-input ownership + asset status, totals, fee, `signableByUs`, `complete`. Safe to show pre-auth.
- `signPsbt(psbtB64, password?)` — signs only our non-asset, not-yet-signed inputs; returns updated PSBT + `signedInputs` + `complete`.
- `finalizePsbt(psbtB64)` / `signAndBroadcastPsbt(psbtB64, password?)`

## Tests
8 tests: asset-script guard, summary (fee/ownership/asset), legacy sign->finalize (asserts `0x41` scriptSig), SegWit sign->finalize (asserts `0x41` in witness), not-ours no-op, asset-input refusal, base64 round-trip. Full suite: 346 wallet tests green, typecheck clean.

Bumps to 2.4.19.
