### PR TITLE
feat(psbt): export an unsigned PSBT from the send flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.20",
+  "version": "2.4.21",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/SendForm.tsx
+++ b/src/components/SendForm.tsx
@@ -11,6 +11,9 @@ import {
   UserCheck,
   Check,
   X,
+  ArrowUpFromLine,
+  Copy,
+  Download,
 } from 'lucide-react';
 import { useWallet } from '@/contexts/WalletContext';
 import { useSecurity } from '@/contexts/SecurityContext';
@@ -35,6 +38,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -88,6 +92,12 @@ export default function SendForm() {
   const [manuallySelectedUTXOs, setManuallySelectedUTXOs] = useState<EnhancedUTXO[]>([]);
   const [subtractFeeFromAmount, setSubtractFeeFromAmount] = useState(false);
   const [customChangeAddress, setCustomChangeAddress] = useState('');
+
+  // Unsigned-PSBT export (sign elsewhere — Avian Core, a co-signer — then broadcast).
+  const [exportBusy, setExportBusy] = useState(false);
+  const [exportedPsbt, setExportedPsbt] = useState('');
+  const [exportedInfo, setExportedInfo] = useState<{ fee: number; inputs: number } | null>(null);
+  const [copiedExport, setCopiedExport] = useState(false);
   const [availableChangeAddresses, setAvailableChangeAddresses] = useState<
     Array<{ address: string; path: string }>
   >([]);
@@ -120,6 +130,69 @@ export default function SendForm() {
 
   const openExplorer = (txid: string) => {
     WalletService.openTransactionInExplorer(txid);
+  };
+
+  // Export is only meaningful for the standard path — the shared planner selects from the main
+  // wallet address automatically, so a derived-address send or a manual UTXO pick isn't reflected.
+  const canExportUnsigned =
+    !fromDerivedAddress && utxoOptions.strategy !== CoinSelectionStrategy.MANUAL;
+
+  const handleExportUnsigned = async () => {
+    setError('');
+    setExportedPsbt('');
+    setExportedInfo(null);
+    if (!toAddress || !validateAddress(toAddress)) {
+      setError('Enter a valid recipient address before exporting a PSBT.');
+      return;
+    }
+    const amountSatoshis = Math.floor(parseFloat(amount) * 100000000);
+    if (!amountSatoshis || amountSatoshis <= 0) {
+      setError('Enter an amount before exporting a PSBT.');
+      return;
+    }
+    if (!isConnected || !electrum) {
+      setError('Not connected to the Avian network. Please check your connection.');
+      return;
+    }
+    setExportBusy(true);
+    try {
+      const service = new WalletService(electrum);
+      const result = await service.buildUnsignedPsbt(toAddress, amountSatoshis, {
+        strategy: utxoOptions.strategy,
+        feeRate: utxoOptions.feeRate,
+        changeAddress: customChangeAddress || undefined,
+        subtractFeeFromAmount,
+      });
+      setExportedPsbt(result.psbt);
+      setExportedInfo({ fee: result.fee, inputs: result.inputs });
+    } catch (err: any) {
+      setError(err?.message || 'Failed to build the unsigned PSBT.');
+    } finally {
+      setExportBusy(false);
+    }
+  };
+
+  const copyExportedPsbt = async () => {
+    try {
+      await navigator.clipboard.writeText(exportedPsbt);
+      setCopiedExport(true);
+      setTimeout(() => setCopiedExport(false), 2000);
+      toast.success('Unsigned PSBT copied');
+    } catch {
+      toast.error('Copy failed');
+    }
+  };
+
+  const downloadExportedPsbt = () => {
+    const blob = new Blob([exportedPsbt], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'avian-unsigned.psbt';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -1324,6 +1397,80 @@ export default function SendForm() {
           <Button type="submit" disabled={isSending || isLoading} className="w-full">
             {isSending ? 'Sending...' : 'Send Transaction'}
           </Button>
+
+          {canExportUnsigned && (
+            <div className="mt-3 space-y-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleExportUnsigned}
+                disabled={exportBusy || isSending || !isConnected}
+                className="w-full gap-2"
+              >
+                <ArrowUpFromLine className="h-4 w-4" />
+                {exportBusy ? 'Building…' : 'Export unsigned PSBT'}
+              </Button>
+              <p className="text-center text-xs text-muted-foreground">
+                Build this transaction without signing — sign it in Avian Core or with a co-signer,
+                then broadcast.
+              </p>
+            </div>
+          )}
+
+          {exportedPsbt && (
+            <Alert className="mt-4 border-primary/20 bg-primary/5">
+              <ArrowUpFromLine className="h-4 w-4 text-primary" />
+              <AlertTitle className="flex items-center justify-between text-foreground">
+                <span>Unsigned PSBT ready</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => {
+                    setExportedPsbt('');
+                    setExportedInfo(null);
+                  }}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </AlertTitle>
+              <AlertDescription className="space-y-3">
+                {exportedInfo && (
+                  <p className="text-sm text-muted-foreground">
+                    {exportedInfo.inputs} input{exportedInfo.inputs === 1 ? '' : 's'} · network fee ≈{' '}
+                    <span className="font-mono text-foreground">
+                      {(exportedInfo.fee / 100000000).toFixed(8)} AVN
+                    </span>
+                    . Signing elsewhere does not change these.
+                  </p>
+                )}
+                <Textarea
+                  readOnly
+                  value={exportedPsbt}
+                  rows={4}
+                  spellCheck={false}
+                  className="font-mono text-xs"
+                  onFocus={(e) => e.currentTarget.select()}
+                />
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" size="sm" onClick={copyExportedPsbt} className="gap-2">
+                    {copiedExport ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    {copiedExport ? 'Copied' : 'Copy'}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={downloadExportedPsbt}
+                    className="gap-2"
+                  >
+                    <Download className="h-4 w-4" /> Download .psbt
+                  </Button>
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
         </form>
 
         {/* Save Address Prompt */}

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -776,6 +776,241 @@ export class WalletService {
         return txid;
     }
 
+    /**
+     * Plan a spend from a single address and build the *unsigned* PSBT: fetch and select UTXOs with
+     * an iterative size-based fee, split into recipient + change (folding sub-dust change into the
+     * fee), and add the inputs (nonWitnessUtxo for legacy, witnessUtxo for SegWit) and outputs.
+     *
+     * Shared by `sendTransaction` (which then signs) and `buildUnsignedPsbt` (which exports it), so
+     * selection and fee logic have a single source of truth. Needs no private key; pass `pubkey`
+     * only for P2SH-P2WPKH, whose redeemScript requires it.
+     */
+    private async planSpend(params: {
+        fromAddress: string;
+        walletAddrType: AddressType;
+        toAddress: string;
+        amount: number;
+        options?: {
+            strategy?: CoinSelectionStrategy;
+            feeRate?: number;
+            maxInputs?: number;
+            minConfirmations?: number;
+            changeAddress?: string;
+            subtractFeeFromAmount?: boolean;
+        };
+        pubkey?: Buffer;
+    }): Promise<{
+        psbt: bitcoin.Psbt;
+        selectedUTXOs: any[];
+        fee: number;
+        finalSendAmount: number;
+        finalChange: number;
+        changeAddress: string;
+    }> {
+        const { fromAddress, walletAddrType, toAddress, amount, options, pubkey } = params;
+
+        // Get UTXOs for the address
+        const rawUTXOs = await this.electrum.getUTXOs(fromAddress);
+        if (rawUTXOs.length === 0) {
+            throw new Error('No unspent transaction outputs found');
+        }
+
+        // Enhance UTXOs with additional metadata
+        const currentBlockHeight = await this.electrum.getCurrentBlockHeight();
+        const enhancedUTXOs: EnhancedUTXO[] = rawUTXOs.map((utxo) => ({
+            ...utxo,
+            confirmations: utxo.height ? Math.max(0, currentBlockHeight - utxo.height + 1) : 0,
+            isConfirmed: utxo.height ? currentBlockHeight - utxo.height + 1 >= 1 : false,
+            ageInBlocks: utxo.height ? currentBlockHeight - utxo.height + 1 : 0,
+            address: fromAddress,
+        }));
+
+        // Calculate total available amount
+        const totalAvailable = enhancedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
+
+        // Size-based fee: sat/vByte rate (caller override, else the node's rate, floored).
+        const subtractFee = options?.subtractFeeFromAmount ?? false;
+        const satPerVByte = await this.resolveFeeRate(options?.feeRate);
+
+        // Select optimal UTXOs using the selection service
+        const strategyRecommendation = UTXOSelectionService.getRecommendedStrategy(
+            amount,
+            enhancedUTXOs,
+            {
+                consolidateDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
+            },
+        );
+
+        // Get wallet's own address for dust consolidation
+        let selfAddress;
+        if (
+            strategyRecommendation.recommendSelfAddress ||
+            options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST
+        ) {
+            const wallet = await StorageService.getActiveWallet();
+            if (wallet) {
+                selfAddress = wallet.address;
+            }
+        }
+
+        // The fee depends on how many inputs get selected, and selection depends on the fee, so
+        // iterate: estimate a fee, select, re-estimate from the actual input count, and reselect
+        // if it grew. Converges in a pass or two because the fee is tiny next to the amounts.
+        let selectedUTXOs: any[] = [];
+        let totalSelected = 0;
+        let fee = estimateTxFee(1, 2, satPerVByte);
+        for (let iteration = 0; iteration < 4; iteration++) {
+            // For subtract-fee the recipient absorbs the fee, so the inputs only need to cover
+            // `amount`; otherwise they must cover `amount + fee`. This is what makes send-max
+            // with subtract-fee possible.
+            const selectionTarget = subtractFee ? Math.max(0, amount - fee) : amount;
+            const totalRequired = selectionTarget + fee;
+            if (totalAvailable < totalRequired) {
+                throw new Error(
+                    `Insufficient funds. Required: ${totalRequired} satoshis, Available: ${totalAvailable} satoshis`,
+                );
+            }
+
+            const selectionOptions: UTXOSelectionOptions = {
+                strategy: options?.strategy || strategyRecommendation.strategy,
+                targetAmount: selectionTarget,
+                feeRate: fee,
+                maxInputs: options?.maxInputs || 20,
+                minConfirmations: options?.minConfirmations || 0,
+                allowUnconfirmed: true,
+                includeDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
+                isAutoConsolidation: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
+                selfAddress: selfAddress,
+            };
+
+            const selectionResult = UTXOSelectionService.selectUTXOs(enhancedUTXOs, selectionOptions);
+            if (!selectionResult) {
+                throw new Error('Unable to select suitable UTXOs for transaction');
+            }
+            selectedUTXOs = selectionResult.selectedUTXOs;
+            totalSelected = selectedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
+
+            const recomputed = estimateTxFee(selectedUTXOs.length, 2, satPerVByte);
+            if (recomputed <= fee) {
+                fee = recomputed;
+                break;
+            }
+            fee = recomputed; // grew with the input count — reselect to cover the larger fee
+        }
+
+        // Split into recipient and change, folding sub-dust change into the fee rather than
+        // emitting an output the network would reject as dust.
+        const split = resolveSendAmounts(amount, fee, totalSelected, subtractFee);
+        const finalSendAmount = split.sendAmount;
+        if (finalSendAmount <= 0) {
+            throw new Error('Send amount is zero or negative after subtracting the fee');
+        }
+        if (split.change < 0) {
+            throw new Error('Insufficient funds to cover the network fee');
+        }
+        const finalChange = split.change >= DUST_THRESHOLD_SATS ? split.change : 0;
+
+        // Determine change address - use custom address if provided, otherwise sender's address
+        const changeAddress =
+            options?.changeAddress && options.changeAddress.trim() !== ''
+                ? options.changeAddress
+                : fromAddress;
+
+        // Build transaction using PSBT
+        const psbt = new bitcoin.Psbt({ network: avianNetwork });
+
+        // SegWit inputs (P2WPKH, P2SH-P2WPKH) use witnessUtxo; legacy P2PKH uses nonWitnessUtxo.
+        const isSegWit = walletAddrType === 'p2wpkh' || walletAddrType === 'p2sh-p2wpkh';
+
+        // Add inputs from selected UTXOs
+        for (const utxo of selectedUTXOs) {
+            const txHex = await this.electrum.getTransaction(utxo.txid, false);
+            const prevTx = bitcoin.Transaction.fromHex(txHex);
+            const prevOut = prevTx.outs[utxo.vout];
+
+            if (isSegWit) {
+                // SegWit inputs: provide witnessUtxo (the output being spent) so PSBT can compute
+                // the BIP143 sighash without the full previous transaction. Stamp sighashType so a
+                // signer knows Avian's 0x41 is expected.
+                const inputObj: any = {
+                    hash: utxo.txid,
+                    index: utxo.vout,
+                    sighashType: SIGHASH_ALL_FORKID,
+                    witnessUtxo: {
+                        script: prevOut.script,
+                        value: prevOut.value,
+                    },
+                };
+                // P2SH-P2WPKH also needs the redeemScript so the finaliser can build the input
+                // scriptSig (the push of the redeem script). Only available when we hold the pubkey.
+                if (walletAddrType === 'p2sh-p2wpkh' && pubkey) {
+                    const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network: avianNetwork });
+                    inputObj.redeemScript = p2wpkh.output!;
+                }
+                psbt.addInput(inputObj);
+            } else {
+                // Legacy P2PKH inputs: provide the full previous transaction hex.
+                psbt.addInput({
+                    hash: utxo.txid,
+                    index: utxo.vout,
+                    nonWitnessUtxo: Buffer.from(txHex, 'hex'),
+                });
+            }
+        }
+
+        // Add output for recipient
+        psbt.addOutput({ address: toAddress, value: finalSendAmount });
+
+        // Add change output if needed
+        if (finalChange > 0) {
+            psbt.addOutput({ address: changeAddress, value: finalChange });
+        }
+
+        return { psbt, selectedUTXOs, fee, finalSendAmount, finalChange, changeAddress };
+    }
+
+    /**
+     * Build an unsigned PSBT for a spend and return it as base64 — the same selection and fee logic
+     * as `sendTransaction`, but stopping before signing. Requires no password for P2PKH/P2WPKH
+     * wallets (no key needed to describe the inputs). Use it to sign the transaction elsewhere
+     * (Avian Core, a co-signer) and broadcast it there or via the PSBT import tool.
+     */
+    async buildUnsignedPsbt(
+        toAddress: string,
+        amount: number,
+        options?: {
+            strategy?: CoinSelectionStrategy;
+            feeRate?: number;
+            maxInputs?: number;
+            minConfirmations?: number;
+            changeAddress?: string;
+            subtractFeeFromAmount?: boolean;
+        },
+    ): Promise<{ psbt: string; fee: number; inputs: number; sendAmount: number; changeAmount: number }> {
+        const activeWallet = await StorageService.getActiveWallet();
+        if (!activeWallet) throw new Error('No active wallet found');
+        const walletAddrType: AddressType = activeWallet.addressType || 'p2pkh';
+        if (walletAddrType === 'p2sh-p2wpkh') {
+            // The redeemScript needs the public key, which we can't derive without decrypting; a
+            // wrapped-SegWit wallet should sign directly instead of exporting an unsigned PSBT.
+            throw new Error('Exporting an unsigned PSBT is not supported for wrapped-SegWit wallets');
+        }
+        const plan = await this.planSpend({
+            fromAddress: activeWallet.address,
+            walletAddrType,
+            toAddress,
+            amount,
+            options,
+        });
+        return {
+            psbt: plan.psbt.toBase64(),
+            fee: plan.fee,
+            inputs: plan.selectedUTXOs.length,
+            sendAmount: plan.finalSendAmount,
+            changeAmount: plan.finalChange,
+        };
+    }
+
     async sendTransaction(
         toAddress: string,
         amount: number,
@@ -818,179 +1053,21 @@ export class WalletService {
             const keyPair = ECPair.fromWIF(privateKeyWIF, avianNetwork);
             const fromAddress = activeWallet.address;
 
-            // Get UTXOs for the address
-            const rawUTXOs = await this.electrum.getUTXOs(fromAddress);
-            if (rawUTXOs.length === 0) {
-                throw new Error('No unspent transaction outputs found');
-            }
-
-            // Enhance UTXOs with additional metadata
-            const currentBlockHeight = await this.electrum.getCurrentBlockHeight();
-            const enhancedUTXOs: EnhancedUTXO[] = rawUTXOs.map((utxo) => ({
-                ...utxo,
-                confirmations: utxo.height ? Math.max(0, currentBlockHeight - utxo.height + 1) : 0,
-                isConfirmed: utxo.height ? currentBlockHeight - utxo.height + 1 >= 1 : false,
-                ageInBlocks: utxo.height ? currentBlockHeight - utxo.height + 1 : 0,
-                address: fromAddress,
-            }));
-
-            // Calculate total available amount
-            const totalAvailable = enhancedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
-
-            // Size-based fee: sat/vByte rate (caller override, else the node's rate, floored).
-            const subtractFee = options?.subtractFeeFromAmount ?? false;
-            const satPerVByte = await this.resolveFeeRate(options?.feeRate);
-
-            // Select optimal UTXOs using the selection service
-            const strategyRecommendation = UTXOSelectionService.getRecommendedStrategy(
-                amount,
-                enhancedUTXOs,
-                {
-                    consolidateDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
-                },
-            );
-
-            // Get wallet's own address for dust consolidation
-            let selfAddress;
-            if (
-                strategyRecommendation.recommendSelfAddress ||
-                options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST
-            ) {
-                const wallet = await StorageService.getActiveWallet();
-                if (wallet) {
-                    selfAddress = wallet.address;
-                }
-            }
-
-            // The fee depends on how many inputs get selected, and selection depends on the fee, so
-            // iterate: estimate a fee, select, re-estimate from the actual input count, and reselect
-            // if it grew. Converges in a pass or two because the fee is tiny next to the amounts.
-            let selectedUTXOs: any[] = [];
-            let totalSelected = 0;
-            let fee = estimateTxFee(1, 2, satPerVByte);
-            for (let iteration = 0; iteration < 4; iteration++) {
-                // For subtract-fee the recipient absorbs the fee, so the inputs only need to cover
-                // `amount`; otherwise they must cover `amount + fee`. This is what makes send-max
-                // with subtract-fee possible.
-                const selectionTarget = subtractFee ? Math.max(0, amount - fee) : amount;
-                const totalRequired = selectionTarget + fee;
-                if (totalAvailable < totalRequired) {
-                    throw new Error(
-                        `Insufficient funds. Required: ${totalRequired} satoshis, Available: ${totalAvailable} satoshis`,
-                    );
-                }
-
-                const selectionOptions: UTXOSelectionOptions = {
-                    strategy: options?.strategy || strategyRecommendation.strategy,
-                    targetAmount: selectionTarget,
-                    feeRate: fee,
-                    maxInputs: options?.maxInputs || 20,
-                    minConfirmations: options?.minConfirmations || 0,
-                    allowUnconfirmed: true,
-                    includeDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
-                    isAutoConsolidation: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
-                    selfAddress: selfAddress,
-                };
-
-                const selectionResult = UTXOSelectionService.selectUTXOs(enhancedUTXOs, selectionOptions);
-                if (!selectionResult) {
-                    throw new Error('Unable to select suitable UTXOs for transaction');
-                }
-                selectedUTXOs = selectionResult.selectedUTXOs;
-                totalSelected = selectedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
-
-                const recomputed = estimateTxFee(selectedUTXOs.length, 2, satPerVByte);
-                if (recomputed <= fee) {
-                    fee = recomputed;
-                    break;
-                }
-                fee = recomputed; // grew with the input count — reselect to cover the larger fee
-            }
-
-            // Split into recipient and change, folding sub-dust change into the fee rather than
-            // emitting an output the network would reject as dust.
-            const split = resolveSendAmounts(amount, fee, totalSelected, subtractFee);
-            const finalSendAmount = split.sendAmount;
-            if (finalSendAmount <= 0) {
-                throw new Error('Send amount is zero or negative after subtracting the fee');
-            }
-            if (split.change < 0) {
-                throw new Error('Insufficient funds to cover the network fee');
-            }
-            const finalChange = split.change >= DUST_THRESHOLD_SATS ? split.change : 0;
-
-            // Determine change address - use custom address if provided, otherwise sender's address
-            const changeAddress =
-                options?.changeAddress && options.changeAddress.trim() !== ''
-                    ? options.changeAddress
-                    : fromAddress;
-
-            // Build transaction using PSBT
-            const psbt = new bitcoin.Psbt({ network: avianNetwork });
-
             // Avian requires SIGHASH_ALL | SIGHASH_FORKID (0x41) for all inputs.
-            // Declare here so the value can be stamped onto each PSBT input.
-            const SIGHASH_ALL = 0x01;
-            const SIGHASH_FORKID = 0x40;
-            const hashType = SIGHASH_ALL | SIGHASH_FORKID; // 0x41
-
-            // Determine the wallet's address type so we can populate the correct PSBT input fields.
-            // SegWit inputs (P2WPKH, P2SH-P2WPKH) use witnessUtxo; legacy P2PKH uses nonWitnessUtxo.
+            const hashType = SIGHASH_ALL_FORKID; // 0x41
             const walletAddrType: AddressType = activeWallet.addressType || 'p2pkh';
-            const isSegWit = walletAddrType === 'p2wpkh' || walletAddrType === 'p2sh-p2wpkh';
 
-            // Add inputs from selected UTXOs
-            for (const utxo of selectedUTXOs) {
-                const txHex = await this.electrum.getTransaction(utxo.txid, false);
-                const prevTx = bitcoin.Transaction.fromHex(txHex);
-                const prevOut = prevTx.outs[utxo.vout];
-
-                if (isSegWit) {
-                    // SegWit inputs: provide witnessUtxo (the output being spent) so PSBT can
-                    // compute the BIP143 sighash without the full previous transaction.
-                    // sighashType must be set on the input so bitcoinjs-lib signs with 0x41.
-                    const inputObj: any = {
-                        hash: utxo.txid,
-                        index: utxo.vout,
-                        sighashType: hashType,
-                        witnessUtxo: {
-                            script: prevOut.script,
-                            value: prevOut.value,
-                        },
-                    };
-                    // P2SH-P2WPKH also needs the redeemScript so the finaliser can build the
-                    // input scriptSig (the push of the redeem script).
-                    if (walletAddrType === 'p2sh-p2wpkh') {
-                        const p2wpkh = bitcoin.payments.p2wpkh({
-                            pubkey: Buffer.from(keyPair.publicKey),
-                            network: avianNetwork,
-                        });
-                        inputObj.redeemScript = p2wpkh.output!;
-                    }
-                    psbt.addInput(inputObj);
-                } else {
-                    // Legacy P2PKH inputs: provide the full previous transaction hex.
-                    psbt.addInput({
-                        hash: utxo.txid,
-                        index: utxo.vout,
-                        nonWitnessUtxo: Buffer.from(txHex, 'hex'),
-                    });
-                }
-            }
-
-            // Add output for recipient
-            psbt.addOutput({
-                address: toAddress,
-                value: finalSendAmount,
-            });
-
-            // Add change output if needed
-            if (finalChange > 0) {
-                psbt.addOutput({
-                    address: changeAddress,
-                    value: finalChange,
+            // Select UTXOs, size the fee, and build the unsigned PSBT. Shared with buildUnsignedPsbt
+            // so selection and fee logic live in one place.
+            const { psbt, selectedUTXOs, finalSendAmount, finalChange, changeAddress } =
+                await this.planSpend({
+                    fromAddress,
+                    walletAddrType,
+                    toAddress,
+                    amount,
+                    options,
+                    pubkey: Buffer.from(keyPair.publicKey),
                 });
-            }
 
             // Create a compatible signer object with Avian fork ID support
             const signer = {

--- a/src/services/wallet/sendTransaction.test.ts
+++ b/src/services/wallet/sendTransaction.test.ts
@@ -557,3 +557,68 @@ describe('sendTransactionWithManualUTXOs', () => {
     expect(broadcast).not.toHaveBeenCalled();
   });
 });
+
+describe('buildUnsignedPsbt', () => {
+  const RATE = 1;
+  const feeFor = (inputs: number, outputs: number) => estimateTxFee(inputs, outputs, RATE);
+
+  it('exports an unsigned PSBT with the same selection and fee as a send — no key needed', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum } = createFakeElectrum(address, [500_000]);
+    const wallet = new WalletService(electrum as never);
+
+    // No password passed — building the unsigned PSBT must not need the private key.
+    const result = await wallet.buildUnsignedPsbt(RECIPIENT, 100_000, { feeRate: RATE });
+
+    expect(result.inputs).toBe(1);
+    expect(result.fee).toBe(feeFor(1, 2));
+    expect(result.sendAmount).toBe(100_000);
+    expect(result.changeAmount).toBe(500_000 - 100_000 - feeFor(1, 2));
+
+    const psbt = bitcoin.Psbt.fromBase64(result.psbt, { network: avianNetwork });
+    expect(psbt.inputCount).toBe(1);
+    // Unsigned: no input carries a signature yet.
+    expect(psbt.data.inputs.every((i) => !i.partialSig && !i.finalScriptSig)).toBe(true);
+    // Outputs: recipient + change back to us.
+    const outs = psbt.txOutputs.map((o) => ({ address: o.address, value: o.value }));
+    expect(outs).toContainEqual({ address: RECIPIENT, value: 100_000 });
+    expect(outs).toContainEqual({ address, value: 500_000 - 100_000 - feeFor(1, 2) });
+  });
+
+  it('round-trips: the exported PSBT signs and finalises to a valid FORKID transaction', async () => {
+    const { address, keyPair } = await createActiveWallet();
+    const { electrum } = createFakeElectrum(address, [500_000]);
+    const wallet = new WalletService(electrum as never);
+
+    const { psbt } = await wallet.buildUnsignedPsbt(RECIPIENT, 100_000, { feeRate: RATE });
+    const signed = await wallet.signPsbt(psbt, TEST_PASSWORD);
+    expect(signed.signedInputs).toBe(1);
+    expect(signed.complete).toBe(true);
+
+    const { hex } = wallet.finalizePsbt(signed.psbt);
+    const tx = bitcoin.Transaction.fromHex(hex);
+    const [signature, pubkey] = bitcoin.script.decompile(tx.ins[0].script) as Buffer[];
+    expect(signature[signature.length - 1]).toBe(SIGHASH_ALL_FORKID);
+    expect(Buffer.from(pubkey).toString('hex')).toBe(Buffer.from(keyPair.publicKey).toString('hex'));
+    expect(outputsOf(tx)).toContainEqual({ address: RECIPIENT, value: 100_000 });
+  });
+
+  it('refuses to export for a wrapped-SegWit wallet (needs the pubkey for a redeemScript)', async () => {
+    // Register a p2sh-p2wpkh active wallet directly so the export guard trips.
+    const keyPair = ECPair.makeRandom({ network: avianNetwork });
+    const address = deriveAddress(Buffer.from(keyPair.publicKey), 'p2pkh');
+    await StorageService.createWallet({
+      name: 'Wrapped',
+      address,
+      privateKey: await secureEncrypt(keyPair.toWIF(), TEST_PASSWORD),
+      isEncrypted: true,
+      addressType: 'p2sh-p2wpkh',
+    });
+    const { electrum } = createFakeElectrum(address, [500_000]);
+    const wallet = new WalletService(electrum as never);
+
+    await expect(wallet.buildUnsignedPsbt(RECIPIENT, 100_000, { feeRate: RATE })).rejects.toThrow(
+      /wrapped-SegWit/,
+    );
+  });
+});


### PR DESCRIPTION
feat(psbt): export an unsigned PSBT from the send flow

PR 3 of 4 for PSBT support. Adds an "Export unsigned PSBT" action to the send
form: fill in a recipient and amount, then build the exact transaction the
wallet would send — same UTXO selection, size-based fee, change and dust
handling — but stop before signing and hand back the base64 PSBT to copy or
download as a .psbt. Sign it in Avian Core or with a co-signer, then broadcast
there or via the PSBT import tool (PR #63). No password is needed to export
(describing P2PKH/P2WPKH inputs needs no key).

Single source of truth: the select -> fee -> split -> build-PSBT core is
extracted out of sendTransaction into one private planSpend(), used by both
sendTransaction (which then signs) and the new buildUnsignedPsbt() (which
returns base64 + fee/inputs/amounts). sendTransaction's behaviour is
unchanged — its 34 existing tests still pass — so selection and fee logic no
longer risk drifting between the send and export paths.

- WalletService.planSpend (private): shared selection + fee + unsigned build
- WalletService.buildUnsignedPsbt: export entry point; refuses wrapped-SegWit
  (its redeemScript needs the pubkey, which export has no key to derive)
- SendForm: "Export unsigned PSBT" button + result panel (copy / download),
  gated to the standard path (not derived-address or manual-UTXO sends)
- Tests: export matches a send's selection/fee, a full export -> sign ->
  finalise round-trip yields a valid 0x41 transaction, wrapped-SegWit refused

Bumps to 2.4.21.
