### PR TITLE
feat(psbt): import UI + unsigned export + Avian Connect signPsbt (land on main)

### DIFF
--- a/docs/AVIAN_CONNECT.md
+++ b/docs/AVIAN_CONNECT.md
@@ -157,6 +157,27 @@ Nonce: 6f1a…
 Issued At: 2026-08-10T12:00:00Z
 ```
 
+### `signPsbt({ psbt })`
+
+- **params**: `{ psbt: string }` — a base64 PSBT (BIP174), at most 100000 characters
+- **result**: `{ psbt: string, complete: boolean, signedInputs: number }`
+
+**Sign-only.** The wallet signs the inputs the connected account owns with Avian's
+`SIGHASH_ALL | SIGHASH_FORKID` (`0x41`) sighash and hands the updated PSBT back. It **never
+broadcasts** on a site's behalf — the dApp finalises and broadcasts (or hands the PSBT on to
+another signer). `complete` is true when every input is now signed; `signedInputs` is how many
+this wallet added.
+
+Asset inputs are **never** signed (spending an Avian asset as a bare transfer would burn it), and
+they are surfaced in the approval screen.
+
+Requires an existing permission, an explicit per-request approval screen that **decodes the PSBT**
+— showing each input and output, the total moved, the network fee, any asset, and how many inputs
+the wallet will sign — and wallet authentication. There is no way to pre-approve signing. A PSBT
+that does not parse is rejected without a prompt. The wallet does not select inputs or set the fee
+for `signPsbt`; it signs exactly the transaction the dApp presents, so the dApp is responsible for
+building a correct PSBT (see the wallet's own unsigned-PSBT export for the format).
+
 ### `getNetwork()`
 
 - **params**: none
@@ -182,8 +203,8 @@ succeeds. In popup mode the wallet also emits a `disconnect` event.
 
 ### Unknown methods
 
-Any method not listed above — including `signPsbt`, `sendTransaction`, and asset operations —
-returns `UNSUPPORTED_METHOD`. These are phase 2+ work.
+Any method not listed above — including `sendTransaction` and asset operations — returns
+`UNSUPPORTED_METHOD`. These are phase 2+ work.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.21",
+  "version": "2.4.22",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.20",
+  "version": "2.4.21",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/connect/demo/page.tsx
+++ b/src/app/connect/demo/page.tsx
@@ -472,9 +472,11 @@ export default function ConnectDemoPage() {
                 <Button
                   disabled={busy}
                   variant="outline"
-                  onClick={() => runPopup('signPsbt', { psbt: 'deadbeef' })}
+                  // A valid but empty PSBT: the wallet shows the approval screen (nothing to sign
+                  // here). A real dApp passes an unsigned PSBT it built for the connected account.
+                  onClick={() => runPopup('signPsbt', { psbt: 'cHNidP8BAAoCAAAAAAAAAAAAAAAA' })}
                 >
-                  signPsbt() → unsupported
+                  signPsbt()
                 </Button>
               </div>
               <p className="text-xs text-muted-foreground">

--- a/src/app/connect/page.tsx
+++ b/src/app/connect/page.tsx
@@ -14,6 +14,8 @@ import ConnectApprovalDialog, {
   ConnectAccountOption,
 } from '@/components/connect/ConnectApprovalDialog';
 import SignMessageApprovalDialog from '@/components/connect/SignMessageApprovalDialog';
+import SignPsbtApprovalDialog from '@/components/connect/SignPsbtApprovalDialog';
+import type { PsbtSummary } from '@/services/wallet/psbt';
 
 import { useWallet } from '@/contexts/WalletContext';
 import { useSecurity } from '@/contexts/SecurityContext';
@@ -42,6 +44,12 @@ interface SignPrompt {
   message: string;
 }
 
+interface PsbtPrompt {
+  origin: string;
+  account: string;
+  summary: PsbtSummary;
+}
+
 /** Channel used by Settings → Connected Sites to tell a live session its grants changed. */
 const PERMISSION_CHANNEL = 'avian-connect';
 
@@ -60,6 +68,7 @@ function ConnectClient() {
   const [hasWallet, setHasWallet] = useState<boolean | null>(null);
   const [connectPromptOrigin, setConnectPromptOrigin] = useState<string | null>(null);
   const [signPrompt, setSignPrompt] = useState<SignPrompt | null>(null);
+  const [psbtPrompt, setPsbtPrompt] = useState<PsbtPrompt | null>(null);
   const [completed, setCompleted] = useState<{ origin: string; method: string } | null>(null);
 
   // Live values the (stable) provider host closures read from.
@@ -72,6 +81,7 @@ function ConnectClient() {
 
   const connectResolverRef = useRef<((decision: ConnectApprovalDecision) => void) | null>(null);
   const signResolverRef = useRef<((approved: boolean) => void) | null>(null);
+  const psbtResolverRef = useRef<((approved: boolean) => void) | null>(null);
   const providerRef = useRef<ProviderService | null>(null);
   const pendingIdsRef = useRef<Set<string>>(new Set());
   const answeredRef = useRef<Map<string, ConnectResponse>>(new Map());
@@ -151,6 +161,32 @@ function ConnectClient() {
     resolver?.(approved);
   }, []);
 
+  const requestSignPsbtApproval = useCallback(
+    async (origin: string, psbt: string, account: string) => {
+      // Decode the PSBT before showing the screen so the user sees exactly what they are signing.
+      // A PSBT that will not even parse is rejected without a prompt.
+      let summary: PsbtSummary;
+      try {
+        summary = await walletService.summarizePsbt(psbt, account);
+      } catch (error) {
+        providerLogger.warn('Rejected an unparseable PSBT from a site:', error);
+        return false;
+      }
+      return new Promise<boolean>((resolve) => {
+        psbtResolverRef.current = resolve;
+        setPsbtPrompt({ origin, account, summary });
+      });
+    },
+    [walletService],
+  );
+
+  const resolvePsbtPrompt = useCallback((approved: boolean) => {
+    setPsbtPrompt(null);
+    const resolver = psbtResolverRef.current;
+    psbtResolverRef.current = null;
+    resolver?.(approved);
+  }, []);
+
   // ---------------------------------------------------------------------
   // Provider host
   // ---------------------------------------------------------------------
@@ -203,6 +239,26 @@ function ConnectClient() {
         return signature;
       },
 
+      requestSignPsbtApproval,
+
+      signPsbt: async (account: string, psbt: string) => {
+        const wallet = await StorageService.getWalletByAddress(account);
+        if (!wallet?.privateKey) {
+          providerLogger.warn('No private key available for the requested account');
+          return null;
+        }
+
+        // Authenticated afresh — remembering a site never skips this.
+        const auth = await requireAuthRef.current(
+          `Authenticate to sign a transaction for ${pinnedOriginRef.current || 'this site'}`,
+        );
+        if (!auth.success) return null;
+
+        // Sign-only: return the updated PSBT. The wallet never broadcasts on a site's behalf.
+        const signed = await walletService.signPsbt(psbt, auth.password);
+        return { psbt: signed.psbt, complete: signed.complete, signedInputs: signed.signedInputs };
+      },
+
       getPublicKey: async (account: string) => {
         const publicKey = await StorageService.getKnownPublicKey(account);
         return publicKey || undefined;
@@ -212,7 +268,7 @@ function ConnectClient() {
 
       emit,
     }),
-    [emit, requestConnectApproval, requestSignApproval, walletService],
+    [emit, requestConnectApproval, requestSignApproval, requestSignPsbtApproval, walletService],
   );
 
   const pinOrigin = useCallback(
@@ -505,13 +561,13 @@ function ConnectClient() {
         )}
 
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          {completed && !connectPromptOrigin && !signPrompt ? (
+          {completed && !connectPromptOrigin && !signPrompt && !psbtPrompt ? (
             <CheckCircle2 className="h-4 w-4 text-primary" />
           ) : (
             <Loader2 className="h-4 w-4 animate-spin" />
           )}
           <span>
-            {completed && !connectPromptOrigin && !signPrompt
+            {completed && !connectPromptOrigin && !signPrompt && !psbtPrompt
               ? `Answered ${completed.method}. ${transport === 'popup' ? 'You can close this window.' : ''}`
               : status}
           </span>
@@ -550,6 +606,14 @@ function ConnectClient() {
         account={signPrompt?.account || ''}
         message={signPrompt?.message || ''}
         onDecision={resolveSignPrompt}
+      />
+
+      <SignPsbtApprovalDialog
+        open={psbtPrompt !== null}
+        origin={psbtPrompt?.origin || ''}
+        account={psbtPrompt?.account || ''}
+        summary={psbtPrompt?.summary || null}
+        onDecision={resolvePsbtPrompt}
       />
     </GradientBackground>
   );

--- a/src/app/settings/advanced/page.tsx
+++ b/src/app/settings/advanced/page.tsx
@@ -2,10 +2,11 @@
 
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Bug, Code, Eye, Trash2, FlaskConical } from 'lucide-react';
+import { Bug, Code, Eye, Trash2, FlaskConical, FileSignature } from 'lucide-react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import MessageUtilities from '@/components/MessageUtilities';
+import PsbtSigner from '@/components/PsbtSigner';
 import { InlineLogViewer } from '@/components/InlineLogViewer';
 import { DataWipePanel } from '@/components/DataWipePanel';
 import { AppLayout } from '@/components/AppLayout';
@@ -15,7 +16,7 @@ import RouteGuard from '@/components/RouteGuard';
 
 export default function AdvancedSettingsPage() {
     const router = useRouter();
-    const [activeSection, setActiveSection] = useState<'logs' | 'messages' | 'watched' | 'datawipe' | null>(null);
+    const [activeSection, setActiveSection] = useState<'logs' | 'messages' | 'psbt' | 'watched' | 'datawipe' | null>(null);
 
     const handleBack = () => {
         if (activeSection) {
@@ -39,6 +40,13 @@ export default function AdvancedSettingsPage() {
             description: 'Sign and verify messages with your wallet',
             icon: Code,
             action: () => setActiveSection('messages'),
+        },
+        {
+            id: 'psbt' as const,
+            title: 'Sign Transaction (PSBT)',
+            description: 'Import, review and sign a PSBT, then broadcast or hand it back',
+            icon: FileSignature,
+            action: () => setActiveSection('psbt'),
         },
         {
             id: 'watched' as const,
@@ -73,6 +81,21 @@ export default function AdvancedSettingsPage() {
 
         if (activeSection === 'messages') {
             return <MessageUtilities />;
+        }
+
+        if (activeSection === 'psbt') {
+            return (
+                <div className="space-y-6">
+                    <div>
+                        <h2 className="text-lg font-semibold mb-2">Sign Transaction (PSBT)</h2>
+                        <p className="text-muted-foreground">
+                            Import a partially-signed transaction from Avian Core or a co-signer, review exactly
+                            what it moves, sign the inputs this wallet owns, then broadcast it or share the signed PSBT.
+                        </p>
+                    </div>
+                    <PsbtSigner />
+                </div>
+            );
         }
 
         if (activeSection === 'datawipe') {
@@ -158,8 +181,9 @@ export default function AdvancedSettingsPage() {
                 headerProps={{
                     title: activeSection === 'logs' ? 'Debug Logs' :
                         activeSection === 'messages' ? 'Message Utilities' :
-                            activeSection === 'datawipe' ? 'Reset Application' :
-                                'Advanced Settings',
+                            activeSection === 'psbt' ? 'Sign Transaction (PSBT)' :
+                                activeSection === 'datawipe' ? 'Reset Application' :
+                                    'Advanced Settings',
                     showBackButton: true,
                     customBackAction: handleBack,
                     actions: <HeaderActions />

--- a/src/components/PsbtSigner.tsx
+++ b/src/components/PsbtSigner.tsx
@@ -1,0 +1,454 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  AlertTriangle,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Check,
+  Copy,
+  FileUp,
+  Info,
+  Lock,
+  Radio,
+  Search,
+  ShieldCheck,
+} from 'lucide-react';
+
+import { useWallet } from '@/contexts/WalletContext';
+import { WalletService } from '@/services/wallet/WalletService';
+import type { PsbtSummary } from '@/services/wallet/psbt';
+import { getExplorerUrl } from '@/lib/explorer';
+import AuthenticationDialog from './AuthenticationDialog';
+
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+
+const avn = (sats: number) => (sats / 1e8).toFixed(8);
+const shorten = (a: string) => (a.length > 24 ? `${a.slice(0, 12)}…${a.slice(-10)}` : a);
+
+/**
+ * Import a partially-signed transaction (PSBT) — from Avian Core, a co-signer, or a watch-only
+ * setup — review exactly what it moves, sign the inputs this wallet owns, then broadcast it or hand
+ * the signed PSBT back. Asset inputs are surfaced and never signed. See src/services/wallet/psbt.ts.
+ */
+export default function PsbtSigner() {
+  const { address, isEncrypted, refreshAfterTransaction } = useWallet();
+  const [walletService] = useState(() => new WalletService());
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [psbtText, setPsbtText] = useState('');
+  const [summary, setSummary] = useState<PsbtSummary | null>(null);
+  const [summaryError, setSummaryError] = useState('');
+  const [signedPsbt, setSignedPsbt] = useState('');
+  const [signedInputs, setSignedInputs] = useState(0);
+  const [complete, setComplete] = useState(false);
+  const [txid, setTxid] = useState('');
+  const [isBusy, setIsBusy] = useState(false);
+  const [showAuth, setShowAuth] = useState(false);
+  const [copied, setCopied] = useState<'psbt' | 'txid' | null>(null);
+
+  const reset = () => {
+    setSummary(null);
+    setSummaryError('');
+    setSignedPsbt('');
+    setSignedInputs(0);
+    setComplete(false);
+    setTxid('');
+  };
+
+  const onTextChange = (value: string) => {
+    setPsbtText(value);
+    if (summary || summaryError || signedPsbt || txid) reset();
+  };
+
+  const copy = async (text: string, which: 'psbt' | 'txid') => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(which);
+      setTimeout(() => setCopied(null), 2000);
+      toast.success('Copied to clipboard');
+    } catch {
+      toast.error('Copy failed');
+    }
+  };
+
+  const handleReview = async () => {
+    const text = psbtText.trim();
+    if (!text) return;
+    reset();
+    setIsBusy(true);
+    try {
+      const result = await walletService.summarizePsbt(text, address || undefined);
+      setSummary(result);
+    } catch (error) {
+      setSummaryError(
+        error instanceof Error ? error.message : 'This does not look like a valid base64 PSBT.',
+      );
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleFile = async (file: File) => {
+    const raw = (await file.text()).trim();
+    // A .psbt file may be binary; if it starts with the magic bytes, base64-encode it first.
+    let text = raw;
+    if (raw.startsWith('psbt\xff') || raw.charCodeAt(0) === 0x70) {
+      try {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        if (bytes[0] === 0x70 && bytes[1] === 0x73 && bytes[2] === 0x62 && bytes[3] === 0x74) {
+          text = btoa(String.fromCharCode(...bytes));
+        }
+      } catch {
+        /* fall back to the raw text */
+      }
+    }
+    setPsbtText(text);
+    reset();
+  };
+
+  const startSign = () => {
+    if (isEncrypted) {
+      setShowAuth(true);
+    } else {
+      void doSign();
+    }
+  };
+
+  const doSign = async (password?: string) => {
+    setShowAuth(false);
+    setIsBusy(true);
+    try {
+      const result = await walletService.signPsbt(psbtText.trim(), password);
+      setSignedPsbt(result.psbt);
+      setSignedInputs(result.signedInputs);
+      setComplete(result.complete);
+      // Re-summarise the signed PSBT so the panel reflects the new signatures.
+      setSummary(await walletService.summarizePsbt(result.psbt, address || undefined));
+      if (result.signedInputs > 0) {
+        toast.success(`Signed ${result.signedInputs} input${result.signedInputs === 1 ? '' : 's'}`);
+      } else {
+        toast.info('No inputs on this PSBT could be signed by this wallet');
+      }
+    } catch (error) {
+      toast.error('Signing failed', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleBroadcast = async () => {
+    setIsBusy(true);
+    try {
+      const { hex, txid: id } = walletService.finalizePsbt(signedPsbt);
+      const broadcastId = await walletService.broadcastRawTransaction(hex);
+      const finalId = typeof broadcastId === 'string' ? broadcastId : id;
+      setTxid(finalId);
+      toast.success('Transaction broadcast');
+      void refreshAfterTransaction(1500);
+    } catch (error) {
+      toast.error('Broadcast failed', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const canSign = !!summary && summary.signableByUs > 0 && !signedPsbt;
+  const activePsbt = signedPsbt || psbtText;
+
+  return (
+    <Card className="w-full mt-2">
+      <CardContent className="space-y-4 py-6">
+        <div className="space-y-2">
+          <Label htmlFor="psbt-input">Partially-signed transaction (PSBT)</Label>
+          <Textarea
+            id="psbt-input"
+            value={psbtText}
+            onChange={(e) => onTextChange(e.target.value)}
+            placeholder="Paste a base64 PSBT (starts with cHNidP…) exported from Avian Core or a co-signer"
+            rows={5}
+            spellCheck={false}
+            className="font-mono text-xs"
+          />
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => fileRef.current?.click()}
+              className="gap-2"
+            >
+              <FileUp className="h-4 w-4" /> Upload .psbt
+            </Button>
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".psbt,.txt,text/plain,application/octet-stream"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) void handleFile(file);
+                e.target.value = '';
+              }}
+            />
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleReview}
+              disabled={isBusy || !psbtText.trim()}
+              className="gap-2"
+            >
+              <Search className="h-4 w-4" /> Review
+            </Button>
+          </div>
+        </div>
+
+        {summaryError && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>{summaryError}</AlertDescription>
+          </Alert>
+        )}
+
+        {summary && (
+          <div className="space-y-4">
+            {summary.hasAsset && (
+              <Alert className="border-amber-500/40 bg-amber-500/10">
+                <AlertTriangle className="h-4 w-4 text-amber-500" />
+                <AlertDescription>
+                  This transaction touches an Avian asset. Asset inputs are never signed here — doing
+                  so as a plain transfer would burn the asset.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <section className="rounded-lg border border-border">
+              <SectionHeader icon={<ArrowDownToLine className="h-3.5 w-3.5" />} label="Inputs" />
+              {summary.inputs.map((input, i) => (
+                <PartyRow
+                  key={`${input.txid}:${input.vout}`}
+                  address={input.address}
+                  valueSats={input.value}
+                  isMine={input.isMine}
+                  isAsset={input.isAsset}
+                  badge={input.signed ? 'Signed' : undefined}
+                  fallback={`Input ${i + 1}`}
+                />
+              ))}
+            </section>
+
+            <section className="rounded-lg border border-border">
+              <SectionHeader icon={<ArrowUpFromLine className="h-3.5 w-3.5" />} label="Outputs" />
+              {summary.outputs.map((output, i) => (
+                <PartyRow
+                  key={i}
+                  address={output.address}
+                  valueSats={output.value}
+                  isMine={output.isMine}
+                  isAsset={output.isAsset}
+                  fallback="Non-standard output"
+                />
+              ))}
+            </section>
+
+            <div className="rounded-lg border border-border">
+              <Row k="Total in" v={summary.totalIn === null ? 'Unknown' : `${avn(summary.totalIn)} AVN`} />
+              <Row k="Total out" v={`${avn(summary.totalOut)} AVN`} />
+              <Row
+                k="Network fee"
+                v={summary.fee === null ? 'Unknown' : `${avn(summary.fee)} AVN`}
+                strong
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              {complete || summary.complete ? (
+                <Badge className="gap-1 bg-emerald-500/15 text-emerald-600 hover:bg-emerald-500/15">
+                  <Check className="h-3 w-3" /> Fully signed
+                </Badge>
+              ) : summary.signableByUs > 0 ? (
+                <span>
+                  You can sign{' '}
+                  <span className="font-medium text-foreground">{summary.signableByUs}</span> input
+                  {summary.signableByUs === 1 ? '' : 's'}.
+                </span>
+              ) : (
+                <span>No inputs on this PSBT belong to this wallet.</span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {summary && !signedPsbt && (
+          <div className="flex items-start gap-2.5 rounded-lg border border-primary/25 bg-primary/5 p-3 text-sm">
+            <ShieldCheck className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
+            <span>
+              Signing opens authentication. Nothing is signed or broadcast until you authorise, and
+              only inputs this wallet owns are touched.
+            </span>
+          </div>
+        )}
+
+        {canSign && (
+          <Button onClick={startSign} disabled={isBusy} className="w-full gap-2">
+            <Lock className="h-4 w-4" />
+            {isBusy ? 'Signing…' : `Sign ${summary!.signableByUs} input${summary!.signableByUs === 1 ? '' : 's'}`}
+          </Button>
+        )}
+
+        {signedPsbt && !txid && (
+          <div className="space-y-3">
+            <Alert className="border-emerald-500/40 bg-emerald-500/10">
+              <Check className="h-4 w-4 text-emerald-600" />
+              <AlertDescription>
+                Signed {signedInputs} input{signedInputs === 1 ? '' : 's'}.{' '}
+                {complete
+                  ? 'The transaction is complete and ready to broadcast.'
+                  : 'More signatures are needed — share the signed PSBT with the other signer.'}
+              </AlertDescription>
+            </Alert>
+
+            {complete && (
+              <Button onClick={handleBroadcast} disabled={isBusy} className="w-full gap-2">
+                <Radio className="h-4 w-4" />
+                {isBusy ? 'Broadcasting…' : 'Broadcast transaction'}
+              </Button>
+            )}
+
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => copy(signedPsbt, 'psbt')}
+              className="w-full gap-2"
+            >
+              {copied === 'psbt' ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              Copy signed PSBT
+            </Button>
+          </div>
+        )}
+
+        {txid && (
+          <Alert className="border-emerald-500/40 bg-emerald-500/10">
+            <Check className="h-4 w-4 text-emerald-600" />
+            <AlertDescription className="space-y-2">
+              <p>Broadcast successfully.</p>
+              <div className="flex items-center gap-2">
+                <code className="break-all font-mono text-xs">{txid}</code>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-6 w-6 flex-shrink-0"
+                  onClick={() => copy(txid, 'txid')}
+                >
+                  {copied === 'txid' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                </Button>
+              </div>
+              <a
+                href={getExplorerUrl(txid)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block text-sm font-medium text-primary underline underline-offset-2"
+              >
+                View on explorer
+              </a>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {activePsbt && !summary && !summaryError && (
+          <p className="text-xs text-muted-foreground">Press Review to decode this PSBT.</p>
+        )}
+      </CardContent>
+
+      <CardFooter className="border-t p-4">
+        <Alert className="bg-muted/50">
+          <Info className="h-4 w-4" />
+          <AlertDescription>
+            PSBTs let an offline or watch-only wallet build a transaction that this wallet signs.
+            Avian uses standard BIP174 with the network&apos;s FORKID sighash, so PSBTs from Avian
+            Core round-trip here. Nothing leaves your device until you broadcast.
+          </AlertDescription>
+        </Alert>
+      </CardFooter>
+
+      <AuthenticationDialog
+        isOpen={showAuth}
+        onClose={() => setShowAuth(false)}
+        onAuthenticate={(password) => void doSign(password)}
+        title="Authenticate to sign PSBT"
+        message="Enter your wallet password to sign the inputs you own."
+        walletAddress={address}
+      />
+    </Card>
+  );
+}
+
+function SectionHeader({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <span className="text-primary">{icon}</span>
+      {label}
+    </div>
+  );
+}
+
+function PartyRow({
+  address,
+  valueSats,
+  isMine,
+  isAsset,
+  badge,
+  fallback,
+}: {
+  address: string | null;
+  valueSats: number | null;
+  isMine: boolean;
+  isAsset: boolean;
+  badge?: string;
+  fallback: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-border px-3 py-2.5 text-sm first:border-t-0">
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate font-mono text-xs">{address ? shorten(address) : fallback}</span>
+        <span className="mt-0.5 flex flex-wrap gap-1">
+          {isMine && (
+            <Badge variant="secondary" className="h-4 px-1.5 text-[10px]">
+              Yours
+            </Badge>
+          )}
+          {isAsset && (
+            <Badge className="h-4 bg-amber-500/15 px-1.5 text-[10px] text-amber-600 hover:bg-amber-500/15">
+              Asset
+            </Badge>
+          )}
+          {badge && (
+            <Badge variant="outline" className="h-4 px-1.5 text-[10px]">
+              {badge}
+            </Badge>
+          )}
+        </span>
+      </span>
+      <span className="flex-shrink-0 font-mono">{valueSats === null ? '—' : `${avn(valueSats)} AVN`}</span>
+    </div>
+  );
+}
+
+function Row({ k, v, strong }: { k: string; v: string; strong?: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-border px-3 py-2.5 text-sm first:border-t-0">
+      <span className="text-muted-foreground">{k}</span>
+      <span className={strong ? 'font-mono font-semibold' : 'font-mono'}>{v}</span>
+    </div>
+  );
+}

--- a/src/components/SendForm.tsx
+++ b/src/components/SendForm.tsx
@@ -11,6 +11,9 @@ import {
   UserCheck,
   Check,
   X,
+  ArrowUpFromLine,
+  Copy,
+  Download,
 } from 'lucide-react';
 import { useWallet } from '@/contexts/WalletContext';
 import { useSecurity } from '@/contexts/SecurityContext';
@@ -35,6 +38,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -88,6 +92,12 @@ export default function SendForm() {
   const [manuallySelectedUTXOs, setManuallySelectedUTXOs] = useState<EnhancedUTXO[]>([]);
   const [subtractFeeFromAmount, setSubtractFeeFromAmount] = useState(false);
   const [customChangeAddress, setCustomChangeAddress] = useState('');
+
+  // Unsigned-PSBT export (sign elsewhere — Avian Core, a co-signer — then broadcast).
+  const [exportBusy, setExportBusy] = useState(false);
+  const [exportedPsbt, setExportedPsbt] = useState('');
+  const [exportedInfo, setExportedInfo] = useState<{ fee: number; inputs: number } | null>(null);
+  const [copiedExport, setCopiedExport] = useState(false);
   const [availableChangeAddresses, setAvailableChangeAddresses] = useState<
     Array<{ address: string; path: string }>
   >([]);
@@ -120,6 +130,69 @@ export default function SendForm() {
 
   const openExplorer = (txid: string) => {
     WalletService.openTransactionInExplorer(txid);
+  };
+
+  // Export is only meaningful for the standard path — the shared planner selects from the main
+  // wallet address automatically, so a derived-address send or a manual UTXO pick isn't reflected.
+  const canExportUnsigned =
+    !fromDerivedAddress && utxoOptions.strategy !== CoinSelectionStrategy.MANUAL;
+
+  const handleExportUnsigned = async () => {
+    setError('');
+    setExportedPsbt('');
+    setExportedInfo(null);
+    if (!toAddress || !validateAddress(toAddress)) {
+      setError('Enter a valid recipient address before exporting a PSBT.');
+      return;
+    }
+    const amountSatoshis = Math.floor(parseFloat(amount) * 100000000);
+    if (!amountSatoshis || amountSatoshis <= 0) {
+      setError('Enter an amount before exporting a PSBT.');
+      return;
+    }
+    if (!isConnected || !electrum) {
+      setError('Not connected to the Avian network. Please check your connection.');
+      return;
+    }
+    setExportBusy(true);
+    try {
+      const service = new WalletService(electrum);
+      const result = await service.buildUnsignedPsbt(toAddress, amountSatoshis, {
+        strategy: utxoOptions.strategy,
+        feeRate: utxoOptions.feeRate,
+        changeAddress: customChangeAddress || undefined,
+        subtractFeeFromAmount,
+      });
+      setExportedPsbt(result.psbt);
+      setExportedInfo({ fee: result.fee, inputs: result.inputs });
+    } catch (err: any) {
+      setError(err?.message || 'Failed to build the unsigned PSBT.');
+    } finally {
+      setExportBusy(false);
+    }
+  };
+
+  const copyExportedPsbt = async () => {
+    try {
+      await navigator.clipboard.writeText(exportedPsbt);
+      setCopiedExport(true);
+      setTimeout(() => setCopiedExport(false), 2000);
+      toast.success('Unsigned PSBT copied');
+    } catch {
+      toast.error('Copy failed');
+    }
+  };
+
+  const downloadExportedPsbt = () => {
+    const blob = new Blob([exportedPsbt], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'avian-unsigned.psbt';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -1324,6 +1397,80 @@ export default function SendForm() {
           <Button type="submit" disabled={isSending || isLoading} className="w-full">
             {isSending ? 'Sending...' : 'Send Transaction'}
           </Button>
+
+          {canExportUnsigned && (
+            <div className="mt-3 space-y-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleExportUnsigned}
+                disabled={exportBusy || isSending || !isConnected}
+                className="w-full gap-2"
+              >
+                <ArrowUpFromLine className="h-4 w-4" />
+                {exportBusy ? 'Building…' : 'Export unsigned PSBT'}
+              </Button>
+              <p className="text-center text-xs text-muted-foreground">
+                Build this transaction without signing — sign it in Avian Core or with a co-signer,
+                then broadcast.
+              </p>
+            </div>
+          )}
+
+          {exportedPsbt && (
+            <Alert className="mt-4 border-primary/20 bg-primary/5">
+              <ArrowUpFromLine className="h-4 w-4 text-primary" />
+              <AlertTitle className="flex items-center justify-between text-foreground">
+                <span>Unsigned PSBT ready</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => {
+                    setExportedPsbt('');
+                    setExportedInfo(null);
+                  }}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </AlertTitle>
+              <AlertDescription className="space-y-3">
+                {exportedInfo && (
+                  <p className="text-sm text-muted-foreground">
+                    {exportedInfo.inputs} input{exportedInfo.inputs === 1 ? '' : 's'} · network fee ≈{' '}
+                    <span className="font-mono text-foreground">
+                      {(exportedInfo.fee / 100000000).toFixed(8)} AVN
+                    </span>
+                    . Signing elsewhere does not change these.
+                  </p>
+                )}
+                <Textarea
+                  readOnly
+                  value={exportedPsbt}
+                  rows={4}
+                  spellCheck={false}
+                  className="font-mono text-xs"
+                  onFocus={(e) => e.currentTarget.select()}
+                />
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" size="sm" onClick={copyExportedPsbt} className="gap-2">
+                    {copiedExport ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    {copiedExport ? 'Copied' : 'Copy'}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={downloadExportedPsbt}
+                    className="gap-2"
+                  >
+                    <Download className="h-4 w-4" /> Download .psbt
+                  </Button>
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
         </form>
 
         {/* Save Address Prompt */}

--- a/src/components/connect/SignPsbtApprovalDialog.tsx
+++ b/src/components/connect/SignPsbtApprovalDialog.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle, ArrowDownToLine, ArrowUpFromLine, FileSignature, Globe } from 'lucide-react';
+import { useMediaQuery } from '@/hooks/use-media-query';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import type { PsbtSummary } from '@/services/wallet/psbt';
+
+interface SignPsbtApprovalDialogProps {
+  open: boolean;
+  origin: string;
+  account: string;
+  summary: PsbtSummary | null;
+  onDecision: (approved: boolean) => void;
+}
+
+const avn = (sats: number) => (sats / 1e8).toFixed(8);
+const shorten = (a: string) => (a.length > 24 ? `${a.slice(0, 12)}…${a.slice(-10)}` : a);
+
+export default function SignPsbtApprovalDialog({
+  open,
+  origin,
+  account,
+  summary,
+  onDecision,
+}: SignPsbtApprovalDialogProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+
+  const body = (
+    <div className="space-y-4">
+      <div className="rounded-lg border bg-muted/40 p-4">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+          <Globe className="h-3.5 w-3.5" />
+          Requesting site
+        </div>
+        <p className="mt-1 break-all font-mono text-base font-semibold">{origin}</p>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Signing with</Label>
+        <p className="break-all rounded-md border bg-muted/20 p-2 font-mono text-xs">{account}</p>
+      </div>
+
+      {summary?.hasAsset && (
+        <Alert className="border-amber-500/40 bg-amber-500/10 [&>svg]:text-amber-500">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription className="text-xs">
+            This transaction touches an Avian asset. Asset inputs are never signed.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {summary && (
+        <ScrollArea className="max-h-64 rounded-md border">
+          <div className="space-y-3 p-3">
+            <PartyList
+              icon={<ArrowDownToLine className="h-3.5 w-3.5" />}
+              label="Inputs"
+              rows={summary.inputs.map((i) => ({
+                address: i.address,
+                value: i.value,
+                isMine: i.isMine,
+                isAsset: i.isAsset,
+                fallback: 'Unknown input',
+              }))}
+            />
+            <PartyList
+              icon={<ArrowUpFromLine className="h-3.5 w-3.5" />}
+              label="Outputs"
+              rows={summary.outputs.map((o) => ({
+                address: o.address,
+                value: o.value,
+                isMine: o.isMine,
+                isAsset: o.isAsset,
+                fallback: 'Non-standard output',
+              }))}
+            />
+          </div>
+        </ScrollArea>
+      )}
+
+      {summary && (
+        <div className="rounded-lg border">
+          <SummaryRow k="Total out" v={`${avn(summary.totalOut)} AVN`} />
+          <SummaryRow
+            k="Network fee"
+            v={summary.fee === null ? 'Unknown' : `${avn(summary.fee)} AVN`}
+            strong
+          />
+          <SummaryRow k="Inputs we'll sign" v={String(summary.signableByUs)} />
+        </div>
+      )}
+
+      <Alert className="border-caution/30 bg-caution/10 [&>svg]:text-caution">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertDescription className="text-xs">
+          This site is asking you to sign a transaction that spends your coins. The wallet signs only
+          — it never broadcasts on the site&apos;s behalf. Check the amounts and fee before you sign.
+        </AlertDescription>
+      </Alert>
+
+      <div className="flex gap-2 pt-1">
+        <Button variant="outline" className="flex-1" onClick={() => onDecision(false)}>
+          Reject
+        </Button>
+        <Button
+          className="flex-1"
+          onClick={() => onDecision(true)}
+          disabled={!summary || summary.signableByUs === 0}
+        >
+          <FileSignature className="mr-2 h-4 w-4" />
+          Sign
+        </Button>
+      </div>
+    </div>
+  );
+
+  const title = 'Transaction signature request';
+  const description = 'A site is asking you to sign an Avian transaction (PSBT).';
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={(next) => !next && onDecision(false)}>
+        <DrawerContent className="max-h-[95vh]">
+          <DrawerHeader className="text-left">
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+          <div className="overflow-y-auto px-4 pb-6">{body}</div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onDecision(false)}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        {body}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface PartyRowData {
+  address: string | null;
+  value: number | null;
+  isMine: boolean;
+  isAsset: boolean;
+  fallback: string;
+}
+
+function PartyList({
+  icon,
+  label,
+  rows,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  rows: PartyRowData[];
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <span className="text-primary">{icon}</span>
+        {label}
+      </div>
+      <div className="rounded-md border">
+        {rows.map((row, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between gap-3 border-t px-2.5 py-2 text-sm first:border-t-0"
+          >
+            <span className="flex min-w-0 items-center gap-1.5">
+              <span className="truncate font-mono text-xs">
+                {row.address ? shorten(row.address) : row.fallback}
+              </span>
+              {row.isMine && (
+                <Badge variant="secondary" className="h-4 px-1.5 text-[10px]">
+                  Yours
+                </Badge>
+              )}
+              {row.isAsset && (
+                <Badge className="h-4 bg-amber-500/15 px-1.5 text-[10px] text-amber-600 hover:bg-amber-500/15">
+                  Asset
+                </Badge>
+              )}
+            </span>
+            <span className="flex-shrink-0 font-mono text-xs">
+              {row.value === null ? '—' : `${avn(row.value)} AVN`}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SummaryRow({ k, v, strong }: { k: string; v: string; strong?: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-t px-3 py-2 text-sm first:border-t-0">
+      <span className="text-muted-foreground">{k}</span>
+      <span className={strong ? 'font-mono font-semibold' : 'font-mono'}>{v}</span>
+    </div>
+  );
+}

--- a/src/services/provider/ProviderService.test.ts
+++ b/src/services/provider/ProviderService.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { OriginPermission } from '@/types/avianConnect';
+import { OriginPermission, SignPsbtResult } from '@/types/avianConnect';
 import { grantPermission, revokePermission, touchPermission } from './permissions';
 // vi.mock below is hoisted above this import, so ProviderService picks up the stub.
 import { ProviderService } from './ProviderService';
@@ -33,6 +33,9 @@ const ORIGIN = 'https://realm.example';
 const ADDRESS = 'RAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const PUBLIC_KEY = '02'.padEnd(66, 'a');
 const SIGNATURE = 'H9base64signature==';
+// Base64-charset placeholder; the host is mocked so the bytes never get decoded.
+const PSBT = 'cHNidP8BAAoAAAAAAAAAAAAA';
+const SIGNED_PSBT: SignPsbtResult = { psbt: PSBT, complete: true, signedInputs: 1 };
 
 const createHost = (overrides: Partial<ReturnType<typeof baseHost>> = {}) => ({
   ...baseHost(),
@@ -49,6 +52,8 @@ function baseHost() {
     })),
     requestSignApproval: vi.fn(async () => true),
     signMessage: vi.fn(async () => SIGNATURE as string | null),
+    requestSignPsbtApproval: vi.fn(async () => true),
+    signPsbt: vi.fn(async () => SIGNED_PSBT as SignPsbtResult | null),
     getPublicKey: vi.fn(async () => undefined as string | undefined),
     getNetwork: vi.fn(async () => ({ network: 'mainnet' as const, genesisHash: null })),
     emit: vi.fn(),
@@ -86,7 +91,7 @@ describe('envelope handling', () => {
 });
 
 describe('unsupported methods', () => {
-  it.each(['signPsbt', 'sendTransaction', 'issueAsset', 'eth_requestAccounts'])(
+  it.each(['sendTransaction', 'issueAsset', 'eth_requestAccounts'])(
     'refuses %s',
     async (method) => {
       const host = createHost();
@@ -303,6 +308,103 @@ describe('signMessage', () => {
 
     const response = await provider.handle(request('signMessage', { message: 'hi' }));
     expect(response.error?.code).toBe('ORIGIN_NOT_APPROVED');
+  });
+});
+
+describe('signPsbt', () => {
+  const connectFirst = async (host: ReturnType<typeof baseHost>) => {
+    const provider = new ProviderService(ORIGIN, host);
+    await provider.handle(request('connect'));
+    return provider;
+  };
+
+  it('requires a permission', async () => {
+    const host = createHost();
+    const response = await new ProviderService(ORIGIN, host).handle(
+      request('signPsbt', { psbt: PSBT }),
+    );
+
+    expect(response.error?.code).toBe('ORIGIN_NOT_APPROVED');
+    expect(host.requestSignPsbtApproval).not.toHaveBeenCalled();
+    expect(host.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it('reports WALLET_LOCKED before anything else', async () => {
+    const host = createHost();
+    const provider = await connectFirst(host);
+    host.isLocked.mockReturnValue(true);
+
+    const response = await provider.handle(request('signPsbt', { psbt: PSBT }));
+
+    expect(response.error?.code).toBe('WALLET_LOCKED');
+    expect(host.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it('always shows the approval screen, even for a remembered origin', async () => {
+    const host = createHost();
+    const provider = await connectFirst(host);
+
+    const response = await provider.handle(request('signPsbt', { psbt: PSBT }));
+
+    expect(host.requestSignPsbtApproval).toHaveBeenCalledWith(ORIGIN, PSBT, ADDRESS);
+    expect(response.result).toEqual(SIGNED_PSBT);
+  });
+
+  it('never signs when the user rejects the approval screen', async () => {
+    const host = createHost({ requestSignPsbtApproval: vi.fn(async () => false) });
+    const provider = await connectFirst(host);
+
+    const response = await provider.handle(request('signPsbt', { psbt: PSBT }));
+
+    expect(response.error?.code).toBe('USER_REJECTED');
+    expect(host.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it('treats cancelled authentication as a rejection', async () => {
+    const host = createHost({ signPsbt: vi.fn(async () => null) });
+    const provider = await connectFirst(host);
+
+    const response = await provider.handle(request('signPsbt', { psbt: PSBT }));
+
+    expect(response.error?.code).toBe('USER_REJECTED');
+    expect(response.result).toBeUndefined();
+  });
+
+  it.each([
+    ['no params', undefined],
+    ['an empty psbt', { psbt: '' }],
+    ['a non-string psbt', { psbt: 42 }],
+    ['a non-base64 psbt', { psbt: 'not valid base64!!' }],
+  ])('rejects %s as INVALID_REQUEST', async (_label, params) => {
+    const host = createHost();
+    const provider = await connectFirst(host);
+
+    const response = await provider.handle(request('signPsbt', params));
+
+    expect(response.error?.code).toBe('INVALID_REQUEST');
+    expect(host.requestSignPsbtApproval).not.toHaveBeenCalled();
+  });
+
+  it('returns exactly the signed PSBT, complete flag and count — nothing else', async () => {
+    const provider = await connectFirst(createHost());
+    const response = await provider.handle(request('signPsbt', { psbt: PSBT }));
+
+    expect(Object.keys(response.result as object).sort()).toEqual([
+      'complete',
+      'psbt',
+      'signedInputs',
+    ]);
+  });
+
+  it('never broadcasts — the wallet only hands back a signed PSBT', async () => {
+    const host = createHost();
+    const provider = await connectFirst(host);
+
+    await provider.handle(request('signPsbt', { psbt: PSBT }));
+
+    // The host exposes no broadcast path to the engine; signing is all it can do.
+    expect(host.signPsbt).toHaveBeenCalledWith(ADDRESS, PSBT);
+    expect(host).not.toHaveProperty('broadcast');
   });
 });
 

--- a/src/services/provider/ProviderService.ts
+++ b/src/services/provider/ProviderService.ts
@@ -16,10 +16,17 @@ import {
   NetworkResult,
   OriginPermission,
   SignMessageResult,
+  SignPsbtResult,
 } from '@/types/avianConnect';
 import { providerLogger } from '@/lib/Logger';
 import { PermissionService } from './PermissionService';
-import { makeError, makeResult, parseRequest, parseSignMessageParams } from './protocol';
+import {
+  makeError,
+  makeResult,
+  parseRequest,
+  parseSignMessageParams,
+  parseSignPsbtParams,
+} from './protocol';
 
 /** What the connect approval screen hands back. */
 export interface ConnectApprovalDecision {
@@ -45,6 +52,16 @@ export interface ProviderHost {
    * cancels authentication. Never resolves with anything but a base64 signature.
    */
   signMessage(account: string, message: string): Promise<string | null>;
+  /**
+   * Shows the origin and the decoded PSBT (what it moves, the fee, any asset) and resolves false
+   * when the user declines. The account is the one the origin is connected with.
+   */
+  requestSignPsbtApproval(origin: string, psbt: string, account: string): Promise<boolean>;
+  /**
+   * Authenticates the user and signs the wallet's inputs with Avian's FORKID sighash, returning the
+   * updated PSBT. Resolves null when the user cancels authentication. Never broadcasts.
+   */
+  signPsbt(account: string, psbt: string): Promise<SignPsbtResult | null>;
   getPublicKey(account: string): Promise<string | undefined>;
   getNetwork(): Promise<NetworkResult>;
   emit(event: ConnectEventName, data: unknown): void;
@@ -85,6 +102,8 @@ export class ProviderService {
           return await this.getAccounts(id);
         case 'signMessage':
           return await this.signMessage(id, params);
+        case 'signPsbt':
+          return await this.signPsbt(id, params);
         case 'getNetwork':
           return await this.getNetwork(id);
         case 'disconnect':
@@ -185,6 +204,44 @@ export class ProviderService {
 
     await PermissionService.touch(this.origin);
     const result: SignMessageResult = { signature };
+    return makeResult(id, result);
+  }
+
+  private async signPsbt(
+    id: string,
+    params: Record<string, unknown> | undefined,
+  ): Promise<ConnectResponse> {
+    if (this.host.isLocked()) {
+      return makeError(id, 'WALLET_LOCKED', 'The wallet is locked');
+    }
+
+    const accounts = await this.resolveAccounts();
+    if (accounts.length === 0) {
+      return makeError(id, 'ORIGIN_NOT_APPROVED', 'This site has not been granted account access');
+    }
+
+    const parsedParams = parseSignPsbtParams(params);
+    if (!parsedParams.ok) {
+      return { avianConnect: 1, id, error: parsedParams.error };
+    }
+
+    const account = accounts[0];
+
+    // Remembering a site skips the connect screen only: every signature is approved explicitly,
+    // and the approval screen decodes the PSBT so the user sees what they are signing.
+    const approved = await this.host.requestSignPsbtApproval(this.origin, parsedParams.psbt, account);
+    if (!approved) {
+      return makeError(id, 'USER_REJECTED', 'User rejected the PSBT signing request');
+    }
+
+    // The host performs requireAuth before touching the key; a cancelled prompt lands here.
+    const signed = await this.host.signPsbt(account, parsedParams.psbt);
+    if (!signed) {
+      return makeError(id, 'USER_REJECTED', 'Authentication was cancelled');
+    }
+
+    await PermissionService.touch(this.origin);
+    const result: SignPsbtResult = signed;
     return makeResult(id, result);
   }
 

--- a/src/services/provider/protocol.test.ts
+++ b/src/services/provider/protocol.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeOrigin,
   parseRequest,
   parseSignMessageParams,
+  parseSignPsbtParams,
   readResponseFromFragment,
   validateRedirectUri,
 } from './protocol';
@@ -108,6 +109,36 @@ describe('parseSignMessageParams', () => {
 
   it('accepts a message exactly at the limit', () => {
     expect(parseSignMessageParams({ message: 'x'.repeat(LIMITS.message) }).ok).toBe(true);
+  });
+});
+
+describe('parseSignPsbtParams', () => {
+  const PSBT = 'cHNidP8BAAoAAAAAAAAAAAAA'; // base64-charset placeholder
+
+  it('returns the psbt', () => {
+    expect(parseSignPsbtParams({ psbt: PSBT })).toEqual({ ok: true, psbt: PSBT });
+  });
+
+  it('rejects a missing, empty or non-string psbt', () => {
+    expect(parseSignPsbtParams(undefined).ok).toBe(false);
+    expect(parseSignPsbtParams({}).ok).toBe(false);
+    expect(parseSignPsbtParams({ psbt: '' }).ok).toBe(false);
+    expect(parseSignPsbtParams({ psbt: 123 }).ok).toBe(false);
+  });
+
+  it('rejects a psbt that is not base64', () => {
+    const result = parseSignPsbtParams({ psbt: 'not base64 !!' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('INVALID_REQUEST');
+  });
+
+  it('rejects an oversized psbt', () => {
+    expect(parseSignPsbtParams({ psbt: 'A'.repeat(LIMITS.psbt + 1) }).ok).toBe(false);
+  });
+
+  it('accepts a psbt exactly at the limit', () => {
+    expect(parseSignPsbtParams({ psbt: 'A'.repeat(LIMITS.psbt) }).ok).toBe(true);
   });
 });
 

--- a/src/services/provider/protocol.ts
+++ b/src/services/provider/protocol.ts
@@ -109,6 +109,34 @@ export function parseSignMessageParams(
   return { ok: true, message };
 }
 
+/** Extracts and bounds-checks the `psbt` param of signPsbt (a base64 string). */
+export function parseSignPsbtParams(
+  params: Record<string, unknown> | undefined,
+): { ok: true; psbt: string } | { ok: false; error: ConnectError } {
+  const psbt = params?.psbt;
+  if (typeof psbt !== 'string' || psbt.length === 0) {
+    return {
+      ok: false,
+      error: { code: 'INVALID_REQUEST', message: 'signPsbt requires a non-empty base64 psbt string' },
+    };
+  }
+  if (psbt.length > LIMITS.psbt) {
+    return {
+      ok: false,
+      error: { code: 'INVALID_REQUEST', message: `PSBT exceeds the ${LIMITS.psbt} character limit` },
+    };
+  }
+  // Standard base64 alphabet with optional padding — reject anything else before it reaches the
+  // decoder so a hostile page can't probe the parser with junk.
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(psbt)) {
+    return {
+      ok: false,
+      error: { code: 'INVALID_REQUEST', message: 'signPsbt psbt must be valid base64' },
+    };
+  }
+  return { ok: true, psbt };
+}
+
 export function makeResult(id: string, result: unknown): ConnectResponse {
   return { avianConnect: AVIAN_CONNECT_VERSION, id, result };
 }

--- a/src/services/provider/signMessage.integration.test.ts
+++ b/src/services/provider/signMessage.integration.test.ts
@@ -49,6 +49,8 @@ describe('signMessage over Avian Connect', () => {
       requestSignApproval: async () => true,
       signMessage: (_account, message) =>
         wallet.signMessage(generated.privateKey, message, PASSWORD),
+      requestSignPsbtApproval: async () => true,
+      signPsbt: async () => null,
       getPublicKey: async () => undefined,
       getNetwork: async () => ({ network: 'mainnet', genesisHash: null }),
       emit: () => undefined,

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -759,14 +759,20 @@ export class WalletService {
         return { hex: tx.toHex(), txid: tx.getId() };
     }
 
-    /** Sign the active wallet's inputs, finalize, and broadcast. Returns the txid. */
-    async signAndBroadcastPsbt(psbtBase64: string, password?: string): Promise<string> {
-        const signed = await this.signPsbt(psbtBase64, password);
-        const { hex, txid } = this.finalizePsbt(signed.psbt);
+    /** Broadcast a raw transaction hex (e.g. from finalizePsbt) and return its txid. */
+    async broadcastRawTransaction(hex: string): Promise<string> {
         const result = await this.electrum.broadcastTransaction(hex);
         if (!result || typeof result !== 'string') {
             throw new Error('Transaction broadcast failed. Please try again later.');
         }
+        return result;
+    }
+
+    /** Sign the active wallet's inputs, finalize, and broadcast. Returns the txid. */
+    async signAndBroadcastPsbt(psbtBase64: string, password?: string): Promise<string> {
+        const signed = await this.signPsbt(psbtBase64, password);
+        const { hex, txid } = this.finalizePsbt(signed.psbt);
+        await this.broadcastRawTransaction(hex);
         return txid;
     }
 

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -776,6 +776,241 @@ export class WalletService {
         return txid;
     }
 
+    /**
+     * Plan a spend from a single address and build the *unsigned* PSBT: fetch and select UTXOs with
+     * an iterative size-based fee, split into recipient + change (folding sub-dust change into the
+     * fee), and add the inputs (nonWitnessUtxo for legacy, witnessUtxo for SegWit) and outputs.
+     *
+     * Shared by `sendTransaction` (which then signs) and `buildUnsignedPsbt` (which exports it), so
+     * selection and fee logic have a single source of truth. Needs no private key; pass `pubkey`
+     * only for P2SH-P2WPKH, whose redeemScript requires it.
+     */
+    private async planSpend(params: {
+        fromAddress: string;
+        walletAddrType: AddressType;
+        toAddress: string;
+        amount: number;
+        options?: {
+            strategy?: CoinSelectionStrategy;
+            feeRate?: number;
+            maxInputs?: number;
+            minConfirmations?: number;
+            changeAddress?: string;
+            subtractFeeFromAmount?: boolean;
+        };
+        pubkey?: Buffer;
+    }): Promise<{
+        psbt: bitcoin.Psbt;
+        selectedUTXOs: any[];
+        fee: number;
+        finalSendAmount: number;
+        finalChange: number;
+        changeAddress: string;
+    }> {
+        const { fromAddress, walletAddrType, toAddress, amount, options, pubkey } = params;
+
+        // Get UTXOs for the address
+        const rawUTXOs = await this.electrum.getUTXOs(fromAddress);
+        if (rawUTXOs.length === 0) {
+            throw new Error('No unspent transaction outputs found');
+        }
+
+        // Enhance UTXOs with additional metadata
+        const currentBlockHeight = await this.electrum.getCurrentBlockHeight();
+        const enhancedUTXOs: EnhancedUTXO[] = rawUTXOs.map((utxo) => ({
+            ...utxo,
+            confirmations: utxo.height ? Math.max(0, currentBlockHeight - utxo.height + 1) : 0,
+            isConfirmed: utxo.height ? currentBlockHeight - utxo.height + 1 >= 1 : false,
+            ageInBlocks: utxo.height ? currentBlockHeight - utxo.height + 1 : 0,
+            address: fromAddress,
+        }));
+
+        // Calculate total available amount
+        const totalAvailable = enhancedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
+
+        // Size-based fee: sat/vByte rate (caller override, else the node's rate, floored).
+        const subtractFee = options?.subtractFeeFromAmount ?? false;
+        const satPerVByte = await this.resolveFeeRate(options?.feeRate);
+
+        // Select optimal UTXOs using the selection service
+        const strategyRecommendation = UTXOSelectionService.getRecommendedStrategy(
+            amount,
+            enhancedUTXOs,
+            {
+                consolidateDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
+            },
+        );
+
+        // Get wallet's own address for dust consolidation
+        let selfAddress;
+        if (
+            strategyRecommendation.recommendSelfAddress ||
+            options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST
+        ) {
+            const wallet = await StorageService.getActiveWallet();
+            if (wallet) {
+                selfAddress = wallet.address;
+            }
+        }
+
+        // The fee depends on how many inputs get selected, and selection depends on the fee, so
+        // iterate: estimate a fee, select, re-estimate from the actual input count, and reselect
+        // if it grew. Converges in a pass or two because the fee is tiny next to the amounts.
+        let selectedUTXOs: any[] = [];
+        let totalSelected = 0;
+        let fee = estimateTxFee(1, 2, satPerVByte);
+        for (let iteration = 0; iteration < 4; iteration++) {
+            // For subtract-fee the recipient absorbs the fee, so the inputs only need to cover
+            // `amount`; otherwise they must cover `amount + fee`. This is what makes send-max
+            // with subtract-fee possible.
+            const selectionTarget = subtractFee ? Math.max(0, amount - fee) : amount;
+            const totalRequired = selectionTarget + fee;
+            if (totalAvailable < totalRequired) {
+                throw new Error(
+                    `Insufficient funds. Required: ${totalRequired} satoshis, Available: ${totalAvailable} satoshis`,
+                );
+            }
+
+            const selectionOptions: UTXOSelectionOptions = {
+                strategy: options?.strategy || strategyRecommendation.strategy,
+                targetAmount: selectionTarget,
+                feeRate: fee,
+                maxInputs: options?.maxInputs || 20,
+                minConfirmations: options?.minConfirmations || 0,
+                allowUnconfirmed: true,
+                includeDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
+                isAutoConsolidation: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
+                selfAddress: selfAddress,
+            };
+
+            const selectionResult = UTXOSelectionService.selectUTXOs(enhancedUTXOs, selectionOptions);
+            if (!selectionResult) {
+                throw new Error('Unable to select suitable UTXOs for transaction');
+            }
+            selectedUTXOs = selectionResult.selectedUTXOs;
+            totalSelected = selectedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
+
+            const recomputed = estimateTxFee(selectedUTXOs.length, 2, satPerVByte);
+            if (recomputed <= fee) {
+                fee = recomputed;
+                break;
+            }
+            fee = recomputed; // grew with the input count — reselect to cover the larger fee
+        }
+
+        // Split into recipient and change, folding sub-dust change into the fee rather than
+        // emitting an output the network would reject as dust.
+        const split = resolveSendAmounts(amount, fee, totalSelected, subtractFee);
+        const finalSendAmount = split.sendAmount;
+        if (finalSendAmount <= 0) {
+            throw new Error('Send amount is zero or negative after subtracting the fee');
+        }
+        if (split.change < 0) {
+            throw new Error('Insufficient funds to cover the network fee');
+        }
+        const finalChange = split.change >= DUST_THRESHOLD_SATS ? split.change : 0;
+
+        // Determine change address - use custom address if provided, otherwise sender's address
+        const changeAddress =
+            options?.changeAddress && options.changeAddress.trim() !== ''
+                ? options.changeAddress
+                : fromAddress;
+
+        // Build transaction using PSBT
+        const psbt = new bitcoin.Psbt({ network: avianNetwork });
+
+        // SegWit inputs (P2WPKH, P2SH-P2WPKH) use witnessUtxo; legacy P2PKH uses nonWitnessUtxo.
+        const isSegWit = walletAddrType === 'p2wpkh' || walletAddrType === 'p2sh-p2wpkh';
+
+        // Add inputs from selected UTXOs
+        for (const utxo of selectedUTXOs) {
+            const txHex = await this.electrum.getTransaction(utxo.txid, false);
+            const prevTx = bitcoin.Transaction.fromHex(txHex);
+            const prevOut = prevTx.outs[utxo.vout];
+
+            if (isSegWit) {
+                // SegWit inputs: provide witnessUtxo (the output being spent) so PSBT can compute
+                // the BIP143 sighash without the full previous transaction. Stamp sighashType so a
+                // signer knows Avian's 0x41 is expected.
+                const inputObj: any = {
+                    hash: utxo.txid,
+                    index: utxo.vout,
+                    sighashType: SIGHASH_ALL_FORKID,
+                    witnessUtxo: {
+                        script: prevOut.script,
+                        value: prevOut.value,
+                    },
+                };
+                // P2SH-P2WPKH also needs the redeemScript so the finaliser can build the input
+                // scriptSig (the push of the redeem script). Only available when we hold the pubkey.
+                if (walletAddrType === 'p2sh-p2wpkh' && pubkey) {
+                    const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network: avianNetwork });
+                    inputObj.redeemScript = p2wpkh.output!;
+                }
+                psbt.addInput(inputObj);
+            } else {
+                // Legacy P2PKH inputs: provide the full previous transaction hex.
+                psbt.addInput({
+                    hash: utxo.txid,
+                    index: utxo.vout,
+                    nonWitnessUtxo: Buffer.from(txHex, 'hex'),
+                });
+            }
+        }
+
+        // Add output for recipient
+        psbt.addOutput({ address: toAddress, value: finalSendAmount });
+
+        // Add change output if needed
+        if (finalChange > 0) {
+            psbt.addOutput({ address: changeAddress, value: finalChange });
+        }
+
+        return { psbt, selectedUTXOs, fee, finalSendAmount, finalChange, changeAddress };
+    }
+
+    /**
+     * Build an unsigned PSBT for a spend and return it as base64 — the same selection and fee logic
+     * as `sendTransaction`, but stopping before signing. Requires no password for P2PKH/P2WPKH
+     * wallets (no key needed to describe the inputs). Use it to sign the transaction elsewhere
+     * (Avian Core, a co-signer) and broadcast it there or via the PSBT import tool.
+     */
+    async buildUnsignedPsbt(
+        toAddress: string,
+        amount: number,
+        options?: {
+            strategy?: CoinSelectionStrategy;
+            feeRate?: number;
+            maxInputs?: number;
+            minConfirmations?: number;
+            changeAddress?: string;
+            subtractFeeFromAmount?: boolean;
+        },
+    ): Promise<{ psbt: string; fee: number; inputs: number; sendAmount: number; changeAmount: number }> {
+        const activeWallet = await StorageService.getActiveWallet();
+        if (!activeWallet) throw new Error('No active wallet found');
+        const walletAddrType: AddressType = activeWallet.addressType || 'p2pkh';
+        if (walletAddrType === 'p2sh-p2wpkh') {
+            // The redeemScript needs the public key, which we can't derive without decrypting; a
+            // wrapped-SegWit wallet should sign directly instead of exporting an unsigned PSBT.
+            throw new Error('Exporting an unsigned PSBT is not supported for wrapped-SegWit wallets');
+        }
+        const plan = await this.planSpend({
+            fromAddress: activeWallet.address,
+            walletAddrType,
+            toAddress,
+            amount,
+            options,
+        });
+        return {
+            psbt: plan.psbt.toBase64(),
+            fee: plan.fee,
+            inputs: plan.selectedUTXOs.length,
+            sendAmount: plan.finalSendAmount,
+            changeAmount: plan.finalChange,
+        };
+    }
+
     async sendTransaction(
         toAddress: string,
         amount: number,
@@ -818,179 +1053,21 @@ export class WalletService {
             const keyPair = ECPair.fromWIF(privateKeyWIF, avianNetwork);
             const fromAddress = activeWallet.address;
 
-            // Get UTXOs for the address
-            const rawUTXOs = await this.electrum.getUTXOs(fromAddress);
-            if (rawUTXOs.length === 0) {
-                throw new Error('No unspent transaction outputs found');
-            }
-
-            // Enhance UTXOs with additional metadata
-            const currentBlockHeight = await this.electrum.getCurrentBlockHeight();
-            const enhancedUTXOs: EnhancedUTXO[] = rawUTXOs.map((utxo) => ({
-                ...utxo,
-                confirmations: utxo.height ? Math.max(0, currentBlockHeight - utxo.height + 1) : 0,
-                isConfirmed: utxo.height ? currentBlockHeight - utxo.height + 1 >= 1 : false,
-                ageInBlocks: utxo.height ? currentBlockHeight - utxo.height + 1 : 0,
-                address: fromAddress,
-            }));
-
-            // Calculate total available amount
-            const totalAvailable = enhancedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
-
-            // Size-based fee: sat/vByte rate (caller override, else the node's rate, floored).
-            const subtractFee = options?.subtractFeeFromAmount ?? false;
-            const satPerVByte = await this.resolveFeeRate(options?.feeRate);
-
-            // Select optimal UTXOs using the selection service
-            const strategyRecommendation = UTXOSelectionService.getRecommendedStrategy(
-                amount,
-                enhancedUTXOs,
-                {
-                    consolidateDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
-                },
-            );
-
-            // Get wallet's own address for dust consolidation
-            let selfAddress;
-            if (
-                strategyRecommendation.recommendSelfAddress ||
-                options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST
-            ) {
-                const wallet = await StorageService.getActiveWallet();
-                if (wallet) {
-                    selfAddress = wallet.address;
-                }
-            }
-
-            // The fee depends on how many inputs get selected, and selection depends on the fee, so
-            // iterate: estimate a fee, select, re-estimate from the actual input count, and reselect
-            // if it grew. Converges in a pass or two because the fee is tiny next to the amounts.
-            let selectedUTXOs: any[] = [];
-            let totalSelected = 0;
-            let fee = estimateTxFee(1, 2, satPerVByte);
-            for (let iteration = 0; iteration < 4; iteration++) {
-                // For subtract-fee the recipient absorbs the fee, so the inputs only need to cover
-                // `amount`; otherwise they must cover `amount + fee`. This is what makes send-max
-                // with subtract-fee possible.
-                const selectionTarget = subtractFee ? Math.max(0, amount - fee) : amount;
-                const totalRequired = selectionTarget + fee;
-                if (totalAvailable < totalRequired) {
-                    throw new Error(
-                        `Insufficient funds. Required: ${totalRequired} satoshis, Available: ${totalAvailable} satoshis`,
-                    );
-                }
-
-                const selectionOptions: UTXOSelectionOptions = {
-                    strategy: options?.strategy || strategyRecommendation.strategy,
-                    targetAmount: selectionTarget,
-                    feeRate: fee,
-                    maxInputs: options?.maxInputs || 20,
-                    minConfirmations: options?.minConfirmations || 0,
-                    allowUnconfirmed: true,
-                    includeDust: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
-                    isAutoConsolidation: options?.strategy === CoinSelectionStrategy.CONSOLIDATE_DUST,
-                    selfAddress: selfAddress,
-                };
-
-                const selectionResult = UTXOSelectionService.selectUTXOs(enhancedUTXOs, selectionOptions);
-                if (!selectionResult) {
-                    throw new Error('Unable to select suitable UTXOs for transaction');
-                }
-                selectedUTXOs = selectionResult.selectedUTXOs;
-                totalSelected = selectedUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
-
-                const recomputed = estimateTxFee(selectedUTXOs.length, 2, satPerVByte);
-                if (recomputed <= fee) {
-                    fee = recomputed;
-                    break;
-                }
-                fee = recomputed; // grew with the input count — reselect to cover the larger fee
-            }
-
-            // Split into recipient and change, folding sub-dust change into the fee rather than
-            // emitting an output the network would reject as dust.
-            const split = resolveSendAmounts(amount, fee, totalSelected, subtractFee);
-            const finalSendAmount = split.sendAmount;
-            if (finalSendAmount <= 0) {
-                throw new Error('Send amount is zero or negative after subtracting the fee');
-            }
-            if (split.change < 0) {
-                throw new Error('Insufficient funds to cover the network fee');
-            }
-            const finalChange = split.change >= DUST_THRESHOLD_SATS ? split.change : 0;
-
-            // Determine change address - use custom address if provided, otherwise sender's address
-            const changeAddress =
-                options?.changeAddress && options.changeAddress.trim() !== ''
-                    ? options.changeAddress
-                    : fromAddress;
-
-            // Build transaction using PSBT
-            const psbt = new bitcoin.Psbt({ network: avianNetwork });
-
             // Avian requires SIGHASH_ALL | SIGHASH_FORKID (0x41) for all inputs.
-            // Declare here so the value can be stamped onto each PSBT input.
-            const SIGHASH_ALL = 0x01;
-            const SIGHASH_FORKID = 0x40;
-            const hashType = SIGHASH_ALL | SIGHASH_FORKID; // 0x41
-
-            // Determine the wallet's address type so we can populate the correct PSBT input fields.
-            // SegWit inputs (P2WPKH, P2SH-P2WPKH) use witnessUtxo; legacy P2PKH uses nonWitnessUtxo.
+            const hashType = SIGHASH_ALL_FORKID; // 0x41
             const walletAddrType: AddressType = activeWallet.addressType || 'p2pkh';
-            const isSegWit = walletAddrType === 'p2wpkh' || walletAddrType === 'p2sh-p2wpkh';
 
-            // Add inputs from selected UTXOs
-            for (const utxo of selectedUTXOs) {
-                const txHex = await this.electrum.getTransaction(utxo.txid, false);
-                const prevTx = bitcoin.Transaction.fromHex(txHex);
-                const prevOut = prevTx.outs[utxo.vout];
-
-                if (isSegWit) {
-                    // SegWit inputs: provide witnessUtxo (the output being spent) so PSBT can
-                    // compute the BIP143 sighash without the full previous transaction.
-                    // sighashType must be set on the input so bitcoinjs-lib signs with 0x41.
-                    const inputObj: any = {
-                        hash: utxo.txid,
-                        index: utxo.vout,
-                        sighashType: hashType,
-                        witnessUtxo: {
-                            script: prevOut.script,
-                            value: prevOut.value,
-                        },
-                    };
-                    // P2SH-P2WPKH also needs the redeemScript so the finaliser can build the
-                    // input scriptSig (the push of the redeem script).
-                    if (walletAddrType === 'p2sh-p2wpkh') {
-                        const p2wpkh = bitcoin.payments.p2wpkh({
-                            pubkey: Buffer.from(keyPair.publicKey),
-                            network: avianNetwork,
-                        });
-                        inputObj.redeemScript = p2wpkh.output!;
-                    }
-                    psbt.addInput(inputObj);
-                } else {
-                    // Legacy P2PKH inputs: provide the full previous transaction hex.
-                    psbt.addInput({
-                        hash: utxo.txid,
-                        index: utxo.vout,
-                        nonWitnessUtxo: Buffer.from(txHex, 'hex'),
-                    });
-                }
-            }
-
-            // Add output for recipient
-            psbt.addOutput({
-                address: toAddress,
-                value: finalSendAmount,
-            });
-
-            // Add change output if needed
-            if (finalChange > 0) {
-                psbt.addOutput({
-                    address: changeAddress,
-                    value: finalChange,
+            // Select UTXOs, size the fee, and build the unsigned PSBT. Shared with buildUnsignedPsbt
+            // so selection and fee logic live in one place.
+            const { psbt, selectedUTXOs, finalSendAmount, finalChange, changeAddress } =
+                await this.planSpend({
+                    fromAddress,
+                    walletAddrType,
+                    toAddress,
+                    amount,
+                    options,
+                    pubkey: Buffer.from(keyPair.publicKey),
                 });
-            }
 
             // Create a compatible signer object with Avian fork ID support
             const signer = {

--- a/src/services/wallet/sendTransaction.test.ts
+++ b/src/services/wallet/sendTransaction.test.ts
@@ -557,3 +557,68 @@ describe('sendTransactionWithManualUTXOs', () => {
     expect(broadcast).not.toHaveBeenCalled();
   });
 });
+
+describe('buildUnsignedPsbt', () => {
+  const RATE = 1;
+  const feeFor = (inputs: number, outputs: number) => estimateTxFee(inputs, outputs, RATE);
+
+  it('exports an unsigned PSBT with the same selection and fee as a send — no key needed', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum } = createFakeElectrum(address, [500_000]);
+    const wallet = new WalletService(electrum as never);
+
+    // No password passed — building the unsigned PSBT must not need the private key.
+    const result = await wallet.buildUnsignedPsbt(RECIPIENT, 100_000, { feeRate: RATE });
+
+    expect(result.inputs).toBe(1);
+    expect(result.fee).toBe(feeFor(1, 2));
+    expect(result.sendAmount).toBe(100_000);
+    expect(result.changeAmount).toBe(500_000 - 100_000 - feeFor(1, 2));
+
+    const psbt = bitcoin.Psbt.fromBase64(result.psbt, { network: avianNetwork });
+    expect(psbt.inputCount).toBe(1);
+    // Unsigned: no input carries a signature yet.
+    expect(psbt.data.inputs.every((i) => !i.partialSig && !i.finalScriptSig)).toBe(true);
+    // Outputs: recipient + change back to us.
+    const outs = psbt.txOutputs.map((o) => ({ address: o.address, value: o.value }));
+    expect(outs).toContainEqual({ address: RECIPIENT, value: 100_000 });
+    expect(outs).toContainEqual({ address, value: 500_000 - 100_000 - feeFor(1, 2) });
+  });
+
+  it('round-trips: the exported PSBT signs and finalises to a valid FORKID transaction', async () => {
+    const { address, keyPair } = await createActiveWallet();
+    const { electrum } = createFakeElectrum(address, [500_000]);
+    const wallet = new WalletService(electrum as never);
+
+    const { psbt } = await wallet.buildUnsignedPsbt(RECIPIENT, 100_000, { feeRate: RATE });
+    const signed = await wallet.signPsbt(psbt, TEST_PASSWORD);
+    expect(signed.signedInputs).toBe(1);
+    expect(signed.complete).toBe(true);
+
+    const { hex } = wallet.finalizePsbt(signed.psbt);
+    const tx = bitcoin.Transaction.fromHex(hex);
+    const [signature, pubkey] = bitcoin.script.decompile(tx.ins[0].script) as Buffer[];
+    expect(signature[signature.length - 1]).toBe(SIGHASH_ALL_FORKID);
+    expect(Buffer.from(pubkey).toString('hex')).toBe(Buffer.from(keyPair.publicKey).toString('hex'));
+    expect(outputsOf(tx)).toContainEqual({ address: RECIPIENT, value: 100_000 });
+  });
+
+  it('refuses to export for a wrapped-SegWit wallet (needs the pubkey for a redeemScript)', async () => {
+    // Register a p2sh-p2wpkh active wallet directly so the export guard trips.
+    const keyPair = ECPair.makeRandom({ network: avianNetwork });
+    const address = deriveAddress(Buffer.from(keyPair.publicKey), 'p2pkh');
+    await StorageService.createWallet({
+      name: 'Wrapped',
+      address,
+      privateKey: await secureEncrypt(keyPair.toWIF(), TEST_PASSWORD),
+      isEncrypted: true,
+      addressType: 'p2sh-p2wpkh',
+    });
+    const { electrum } = createFakeElectrum(address, [500_000]);
+    const wallet = new WalletService(electrum as never);
+
+    await expect(wallet.buildUnsignedPsbt(RECIPIENT, 100_000, { feeRate: RATE })).rejects.toThrow(
+      /wrapped-SegWit/,
+    );
+  });
+});

--- a/src/types/avianConnect.ts
+++ b/src/types/avianConnect.ts
@@ -24,6 +24,7 @@ export const SUPPORTED_METHODS = [
   'connect',
   'getAccounts',
   'signMessage',
+  'signPsbt',
   'getNetwork',
   'disconnect',
 ] as const;
@@ -39,6 +40,8 @@ export const LIMITS = {
   id: 128,
   method: 64,
   message: 8192,
+  /** Base64 PSBT length. ~100 KB of base64 is ~75 KB of PSBT — far beyond any normal transaction. */
+  psbt: 100_000,
 } as const;
 
 export interface ConnectRequest {
@@ -76,6 +79,19 @@ export interface ConnectResult {
 
 export interface SignMessageResult {
   signature: string;
+}
+
+/**
+ * signPsbt is sign-only: the wallet signs the inputs it owns with Avian's FORKID sighash and hands
+ * the updated PSBT back. It never broadcasts on a site's behalf, so the dApp finalises/broadcasts.
+ */
+export interface SignPsbtResult {
+  /** The base64 PSBT with this wallet's signatures added. */
+  psbt: string;
+  /** Every input is now signed — the dApp can finalise and broadcast. */
+  complete: boolean;
+  /** How many inputs this wallet signed. */
+  signedInputs: number;
 }
 
 export interface NetworkResult {


### PR DESCRIPTION
## PSBT support — import/sign/broadcast, export, and Avian Connect signPsbt (lands on main)

The PSBT work was split into four stacked PRs. #62 (the engine) merged to `main`, but the stacked
#63 and #64 merged into their **parent branches** rather than `main`, so their code never reached
`main` (which is why the deploy stayed at 2.4.19). This PR brings everything still missing from
`main` — the import UI, the unsigned-PSBT export, and Avian Connect `signPsbt` — to `main` in one
shot. The engine (already on `main`) is not re-included.

Merge **this** PR into `main`; #63 and #64 can be closed.

### What lands here

**Import / review / sign / broadcast** (was #63) — Settings → Advanced → "Sign Transaction (PSBT)".
Paste a base64 PSBT or upload a `.psbt`, Review decodes it with no key access (inputs/outputs,
addresses, values, "Yours"/"Asset" badges, total in/out, fee, signable count), Sign authenticates
and signs only your non-asset inputs, then Broadcast in place or Copy the signed PSBT.

**Export unsigned PSBT** (was #64) — an "Export unsigned PSBT" action in the send flow builds the
exact transaction the wallet would send (same UTXO selection, size-based fee, change/dust handling)
but stops before signing, to copy or download and sign in Avian Core or with a co-signer. The
select→fee→build core is extracted into one shared `planSpend()` used by both `sendTransaction`
and `buildUnsignedPsbt`, so the two paths can't drift. No password needed to export.

**Avian Connect `signPsbt`** (new) — a connected dApp can have the wallet sign a transaction it
built. **Sign-only**: the wallet signs the inputs the account owns with the FORKID (`0x41`) sighash
and returns the updated PSBT; it never broadcasts for a site. Every request is approved explicitly
with a screen that **decodes the PSBT** (what moves, the fee, any asset, how many inputs get
signed) before authentication. Asset inputs are never signed.

### Why the engine needs custom signing
bitcoinjs-lib rejects Avian's `0x41` sighash on both encode (`Invalid hashType 65`) and
finalize-decode, so signing/finalizing compute the digest and assemble the scriptSig/witness the
same way FlightDeck's mainnet send path already does — legacy `hashForSignature` for P2PKH, BIP143
`hashForWitnessV0` for native SegWit — carried through the PSBT container.

### Tests & build
Engine 8, send/export 34 (incl. export↔send parity and a full export→sign→finalise round-trip),
Avian Connect provider 113 (incl. 8 new signPsbt dispatch cases + parser bounds). Full typecheck
clean; production static export builds. Bumps to 2.4.22.
