### PR TITLE
feat(assets): read-only asset balances on the dashboard

### DIFF
--- a/docs/proposals/avian-assets.md
+++ b/docs/proposals/avian-assets.md
@@ -1,0 +1,167 @@
+# Proposal: Avian assets in FlightDeck
+
+Status: draft for review · Author: (proposal) · Depends on: the Avian ElectrumX asset RPC surface
+
+## 1. Where we are
+
+FlightDeck is **asset-blind today.** There are no asset RPCs in `ElectrumService`, no asset
+handling in `UTXOSelectionService`, and no asset UI. The only asset-aware code is the defensive
+`isAssetScript` guard in the PSBT engine (`src/services/wallet/psbt.ts`), which refuses to sign an
+asset input.
+
+That blindness is *why* FlightDeck has been safe: Avian's ElectrumX segregates asset UTXOs from the
+plain `listunspent`, so ordinary AVN sends only ever see AVN and can't accidentally spend — and
+burn — an asset. Any asset support must preserve that guarantee explicitly rather than by accident.
+
+The gap: you hold assets (AVIANMEMECONTEST#7_OF_100, AVNELECTRUM, CRAIG_KINGDOM, SMAUG), Core shows
+them, and FlightDeck can't. Closing that is the largest remaining feature gap versus Core.
+
+## 2. Goals and non-goals
+
+**Phase 1 — Display (read-only).** See held assets, quantities (respecting divisibility), and
+metadata. Near-zero risk: you cannot burn what you only display.
+
+**Phase 2 — Transfer (send / receive).** Send an asset to an R-address; show received assets and
+asset history. This is the high-stakes phase (see §7).
+
+**Phase 3 — Issue / reissue (deferred).** Creating assets, sub-assets, unique tokens, reissue.
+Burns real AVN, has owner-token and type-zoo complexity. Out of scope until Phase 2 is proven; only
+if there is demand.
+
+Non-goals for now: restricted (`$NAME`) and qualifier (`#NAME`) assets beyond *displaying* them,
+messaging channels, rewards/snapshots, ANS.
+
+## 3. Avian asset facts (grounded in Avian Core, `c:\development\Avian`)
+
+- **Assets live on legacy P2PKH (`R…`) addresses only** — never bech32. See [[avian-network-facts]].
+- **Asset output script** = a normal 25-byte P2PKH followed by an asset tag:
+
+  ```
+  OP_DUP OP_HASH160 <20-byte pkh> OP_EQUALVERIFY OP_CHECKSIG   ← standard P2PKH (spendable)
+  OP_AVN_ASSET(0xc0) <push: marker ‖ payload> OP_DROP           ← the asset rider
+  ```
+
+  `OP_AVN_ASSET = 0xc0` (confirmed `script.h:216`). `isAssetScript` already keys on byte 25 == 0xc0.
+
+- **The marker is `rvn`, not `avn`.** `CAssetTransfer::ConstructTransaction` (`assets.cpp:1716`)
+  pushes `AVN_R, AVN_V, AVN_N, <type>` = `0x72 0x76 0x6e <type>` = **"rvn" + type byte**. The
+  constants are *named* `AVN_*` but their values spell `rvn` (retained Ravencoin compatibility).
+  **Building `avn…` scripts would produce invalid assets** — this is the #1 gotcha.
+
+- **Type byte:** `t` (0x74) transfer · `r` (0x72) issue/reissue · `o` (0x6f) owner · `q` (0x71)
+  qualifier.
+
+- **Payloads** (Core `CAssetTransfer` / `CNewAsset` serialization):
+  - Transfer: `name`, `nAmount` (int64, scaled by units) `[, nExpireTime]` for restricted.
+  - Issue: `name`, `nAmount`, `units` (0–8), `nReissuable`, `nHasIPFS` `[, ipfsHash]`.
+  - Owner token: the `NAME!` token minted on issue.
+
+- **Amounts & units:** an asset has `units` 0–8 (divisibility). On-chain amounts are integers scaled
+  by `10^units`; display must format accordingly (a 0-unit asset is whole-number only).
+
+- **Name types:** root `NAME`, sub `PARENT/CHILD`, unique `NAME#tag` (units 0, amount 1), restricted
+  `$NAME`, qualifier `#NAME`. Phase 2 send targets **root, sub, and unique** first.
+
+- **Issuing burns AVN** (~500 AVN for a root asset, per the observed `RXissueAsset` tx) and mints the
+  `NAME!` owner token. Phase 3 only.
+
+## 4. ElectrumX asset RPCs — verified, no server changes needed
+
+Inventoried directly from the Avian ElectrumX source (`C:\development\electrumx`,
+`electrumx/server/session.py`). **Everything Phase 1 and Phase 2 need is already exposed** — unlike
+`get_history_rich`, no server work is required. The relevant methods:
+
+- **`blockchain.scripthash.get_balance(scripthash, asset)`** — the `asset` arg (default `False`)
+  drives the shape:
+  - `False` → AVN only: `{confirmed, unconfirmed}` (integer sats). *This is what FlightDeck calls
+    today (`[scriptHash]` only) — which is exactly why it's AVN-only and safe.*
+  - `True` → **all balances in one call**, keyed by name:
+    `{ "rvn": {confirmed, unconfirmed}, "SMAUG": {…}, "CRAIG_KINGDOM": {…}, … }`. **Note the base
+    coin is keyed as `"rvn"`** (session.py:1486 maps the null asset → `'rvn'`) — alias it to AVN.
+  - `"SMAUG"` / `["A","B"]` → just those. Values are integers scaled by the asset's `divisions`.
+- **`blockchain.asset.get_meta(name)`** → `{ sats_in_circulation, divisions (0–8 = units), has_ipfs,
+  ipfs?, reissuable, source, … }` — units for formatting, IPFS for the image, reissuable badge.
+- **`blockchain.scripthash.listunspent(scripthash, asset)`** →
+  `[{ tx_hash, tx_pos, height, asset: <name|null>, value }]`.
+  - `False` (default) → AVN UTXOs only (asset=null). *FlightDeck's `getUTXOs` already relies on this.*
+  - `"SMAUG"` → that asset's UTXOs; `True` → all. Phase 2 uses `listunspent(sh, name)` for the asset
+    input and `listunspent(sh, False)` for the AVN fee inputs.
+- Broadcast: the existing `blockchain.transaction.broadcast` — asset txs are ordinary txs.
+
+Also available for later (freeze/restricted/qualifier/messaging): `blockchain.asset.get_meta_history`,
+`…is_frozen`, `…verifier_string`, `…broadcasts`, `…list_addresses_by_asset`,
+`…get_assets_with_prefix`, `blockchain.tag.*`, and asset/tag `…subscribe` variants.
+
+Net: Phase 1 is **pure client work** against `get_balance(asset=True)` + `get_meta`. No server
+dependency, so it can ship immediately.
+
+## 5. Client architecture
+
+- **`src/services/wallet/assetScript.ts` (pure, dependency-light, heavily tested).**
+  - `parseAssetScript(script) → { type, name, amount, units?, reissuable?, ipfs?, expiry? } | null`
+    — parse the `OP_AVN_ASSET` rider (marker check `rvn`, type byte, payload deserialize).
+  - `buildTransferScript(address, name, amount) → Buffer` — P2PKH(address) + `OP_AVN_ASSET` +
+    (`rvn` ‖ `t` ‖ serialize(name, amount)) + `OP_DROP`.
+  - Golden-vector tested against real Core output (§7). No network, no keys.
+
+- **`ElectrumService` additions** (thin, mirror existing methods): `getAssetBalances(address)`,
+  `getAssetMeta(name)`, `getAssetUTXOs(address)` — exact signatures pinned by the §4 inventory.
+
+- **`AssetService`** (or methods on WalletService): compose the above into a held-assets list with
+  formatted quantities + metadata, with the same caching/resilience the tx sync already uses.
+
+- **`WalletService.buildAssetTransfer(name, amount, toAddress, password)`** — a *separate*
+  asset-aware builder, NOT `planSpend`:
+  - Inputs: the asset UTXO(s) for `name` (covering `amount`), **plus** AVN UTXOs for the fee.
+  - Outputs: asset transfer to `toAddress` (`buildTransferScript`), asset **change** back to us if
+    the asset input over-covers, AVN change, and the AVN fee.
+  - Reuse `planSpend`/`fees.ts` for the AVN side; the asset side is new.
+  - Signs P2PKH inputs exactly as today (the asset rider doesn't change the sighash — the input is
+    still a standard P2PKH spend).
+
+- **PSBT:** the engine already refuses asset inputs. An asset-aware PSBT path can follow Phase 2 but
+  is not required for it; keep the refusal as the safe default until deliberately lifted.
+
+## 6. UI
+
+- **Phase 1:** an "Assets" surface (list like Core's home screen) — name, quantity formatted by
+  units, reissuable/units badges, IPFS image when `has_ipfs`. Search/filter as Core does.
+- **Phase 2:** Send Asset (choose asset, amount bounded by held qty and units, recipient R-address),
+  Receive (reuse the receive address; assets ride to any R-address), and assets in transaction
+  history.
+
+## 7. Burn-safety and test plan (non-negotiable)
+
+The failure mode is **permanent asset loss**: a malformed script, wrong marker, or spending an asset
+UTXO as plain AVN burns the asset. This phase gets *more* rigor than the fee/dust work.
+
+- **Golden vectors:** build each script type in `assetScript.ts` and assert byte-for-byte equality
+  against a transaction Core produced for the same asset/amount/address (via `createrawtransaction`
+  / `decoderawtransaction` on regtest). Round-trip: parse Core's script back to the same struct.
+- **Regtest first, then testnet, then a throwaway mainnet asset** — never a valuable asset on the
+  first live move.
+- **Never select asset UTXOs for AVN sends:** confirm the server segregates them, AND add a
+  client-side guard (`isAssetScript` on every selected prevout) as defense-in-depth.
+- **Explicit asset change:** verify asset-in == asset-out for every transfer test, so nothing is
+  silently dropped to fee.
+- Cross-wallet: build in FlightDeck → decode in Core; issue/transfer in Core → read in FlightDeck.
+
+## 8. Proposed PR sequence (small, individually verified)
+
+1. `assetScript.ts` — build/parse + golden-vector tests. Pure, no network. (ship)
+2. ElectrumX asset RPC inventory (+ server additions if needed) → `ElectrumService` reads +
+   `AssetService`. (ship)
+3. Read-only **Assets** UI — **Phase 1 complete.** (ship)
+4. `buildAssetTransfer` + regtest-validated tests. (ship)
+5. Send / Receive asset UI + asset history — **Phase 2 complete.** (ship)
+6. (deferred) issue / reissue.
+
+Each PR bumps `package.json` per [[version-bump-per-deploy]] and deploys via the main webhook
+([[deploy-on-main-webhook]]).
+
+## 9. Open questions
+
+1. ~~**ElectrumX surface**~~ — **Resolved (§4):** `get_balance(asset=True)`, `asset.get_meta`, and
+   `listunspent(asset=…)` cover Phase 1 and Phase 2 with no server changes.
+2. **v1 transfer scope** — root + sub + unique to start, with restricted/qualifier display-only?
+3. **Appetite** — ship Phase 1 (display) and reassess, or commit to Phase 2 (transfers) now?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.23",
+  "version": "2.4.24",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,6 +29,7 @@ const SendForm = dynamic(() => import('@/components/SendForm'), {
 import ReceiveContent from '@/components/ReceiveContent';
 import WalletSettingsDashboard from '@/components/WalletSettingsDashboard';
 import { TransactionHistory } from '@/components/TransactionHistory';
+import { AssetList } from '@/components/AssetList';
 import ConnectionStatus from '@/components/ConnectionStatus';
 import ThemeSwitcher from '@/components/ThemeSwitcher';
 import LandingPage from '@/components/LandingPage';
@@ -300,6 +301,9 @@ export default function Home() {
                     </Card>
                 </Tabs>
 
+                {/* Assets (renders only when the wallet holds assets) */}
+                <AssetList />
+
                 {/* Connection Status */}
                 <Card>
                     <CardContent className="p-0">
@@ -358,6 +362,8 @@ export default function Home() {
                                 </CardContent>
                             </Card>
                         </Tabs>
+
+                        <AssetList />
 
                         <TransactionHistory className="max-w-none" />
                     </div>

--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Coins, RefreshCw, Search } from 'lucide-react';
+
+import { useWallet } from '@/contexts/WalletContext';
+import { getHeldAssets, type HeldAsset } from '@/services/wallet/AssetService';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+/** The kind of Avian asset name, for a small type badge. */
+function assetKind(name: string): 'unique' | 'sub' | 'restricted' | 'qualifier' | null {
+  if (name.includes('#')) return name.startsWith('#') ? 'qualifier' : 'unique';
+  if (name.startsWith('$')) return 'restricted';
+  if (name.includes('/')) return 'sub';
+  return null;
+}
+
+/**
+ * Read-only list of Avian assets held by the active wallet, mirroring Core's Asset Balances panel.
+ * Renders nothing until we know the wallet holds assets, so an AVN-only wallet sees no extra chrome.
+ * Sending assets is a separate flow (see docs/proposals/avian-assets.md).
+ */
+export function AssetList({ className }: { className?: string }) {
+  const { electrum, address, isConnected } = useWallet();
+  const [assets, setAssets] = useState<HeldAsset[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const load = useCallback(async () => {
+    if (!electrum || !address) return;
+    setLoading(true);
+    try {
+      setAssets(await getHeldAssets(electrum, address));
+    } finally {
+      setLoading(false);
+      setLoaded(true);
+    }
+  }, [electrum, address]);
+
+  useEffect(() => {
+    if (isConnected && address) void load();
+  }, [isConnected, address, load]);
+
+  // Stay invisible until we know there is something to show — no empty card for AVN-only wallets.
+  if (!loaded && !loading) return null;
+  if (loaded && assets.length === 0) return null;
+
+  const filtered = query
+    ? assets.filter((a) => a.name.toLowerCase().includes(query.toLowerCase()))
+    : assets;
+
+  return (
+    <Card className={className}>
+      <CardHeader className="flex flex-row items-center justify-between gap-2 border-b border-border/60 bg-card px-4 py-3 text-foreground [&_svg]:text-primary rounded-t-md">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Coins className="h-5 w-5 flex-shrink-0" />
+          Assets
+          {assets.length > 0 && (
+            <span className="text-sm font-normal text-muted-foreground">({assets.length})</span>
+          )}
+        </CardTitle>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => void load()}
+          disabled={loading}
+          aria-label="Refresh assets"
+        >
+          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+        </Button>
+      </CardHeader>
+      <CardContent className="p-0">
+        {assets.length > 6 && (
+          <div className="relative border-b border-border/60 p-3">
+            <Search className="absolute left-5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search asset name…"
+              className="pl-9"
+            />
+          </div>
+        )}
+
+        {loading && assets.length === 0 ? (
+          <div className="space-y-2 p-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="h-12 animate-pulse rounded-md bg-muted/50" />
+            ))}
+          </div>
+        ) : (
+          <ul className="divide-y divide-border/60">
+            {filtered.map((asset) => {
+              const kind = assetKind(asset.name);
+              return (
+                <li
+                  key={asset.name}
+                  className="flex items-center justify-between gap-3 px-4 py-3"
+                >
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate font-medium">{asset.name}</span>
+                    <span className="mt-0.5 flex flex-wrap gap-1">
+                      {kind && (
+                        <Badge variant="secondary" className="h-4 px-1.5 text-[10px] capitalize">
+                          {kind}
+                        </Badge>
+                      )}
+                      {asset.meta?.reissuable && (
+                        <Badge variant="outline" className="h-4 px-1.5 text-[10px]">
+                          Reissuable
+                        </Badge>
+                      )}
+                      {asset.unconfirmedSats !== 0 && (
+                        <Badge className="h-4 bg-caution/15 px-1.5 text-[10px] text-caution hover:bg-caution/15">
+                          Pending
+                        </Badge>
+                      )}
+                    </span>
+                  </span>
+                  <span className="flex-shrink-0 font-mono text-sm">{asset.amount}</span>
+                </li>
+              );
+            })}
+            {filtered.length === 0 && (
+              <li className="px-4 py-6 text-center text-sm text-muted-foreground">
+                No assets match “{query}”.
+              </li>
+            )}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/services/core/ElectrumService.ts
+++ b/src/services/core/ElectrumService.ts
@@ -5,6 +5,21 @@ interface UTXO {
   height?: number;
 }
 
+/** An asset UTXO — a plain UTXO plus the asset name it carries (null for a base-coin UTXO). */
+export interface AssetUTXO extends UTXO {
+  asset: string | null;
+}
+
+/** Asset metadata from blockchain.asset.get_meta. `divisions` is the unit count (0–8). */
+export interface AssetMeta {
+  name: string;
+  divisions: number;
+  reissuable: boolean;
+  hasIpfs: boolean;
+  ipfs: string | null;
+  satsInCirculation: number;
+}
+
 /** Where a reported balance came from — see getBalanceDetailed. */
 export type BalanceSource = 'live' | 'cache' | 'stored' | 'unknown';
 
@@ -487,6 +502,66 @@ export class ElectrumService {
         height: utxo.height,
       }));
     } catch (error) {
+      return [];
+    }
+  }
+
+  /**
+   * Asset balances held at an address, keyed by asset name. Calls get_balance with asset=true, which
+   * returns every balance at once; the base coin comes back keyed as "rvn" (ElectrumX's null-asset
+   * alias) and is dropped here — AVN is the plain balance shown elsewhere. Amounts are integers
+   * scaled by the asset's divisions (see getAssetMeta); formatting is the caller's job.
+   */
+  async getAssetBalances(address: string): Promise<Record<string, { confirmed: number; unconfirmed: number }>> {
+    try {
+      const scriptHash = this.addressToScriptHash(address);
+      const response = await this.makeRequest('blockchain.scripthash.get_balance', [scriptHash, true]);
+      const balances: Record<string, { confirmed: number; unconfirmed: number }> = {};
+      for (const [name, bal] of Object.entries(response || {})) {
+        if (name === 'rvn') continue; // the base coin (AVN), shown as the ordinary balance
+        const b = bal as { confirmed?: number; unconfirmed?: number };
+        balances[name] = { confirmed: b.confirmed || 0, unconfirmed: b.unconfirmed || 0 };
+      }
+      return balances;
+    } catch (error) {
+      electrumLogger.debug(`Failed to get asset balances for ${address.substring(0, 5)}...:`, error);
+      return {};
+    }
+  }
+
+  /** Metadata for an asset: divisions (0–8 units), reissuable, IPFS, and total supply. */
+  async getAssetMeta(name: string): Promise<AssetMeta | null> {
+    try {
+      const response = await this.makeRequest('blockchain.asset.get_meta', [name]);
+      if (!response) return null;
+      return {
+        name,
+        divisions: typeof response.divisions === 'number' ? response.divisions : 0,
+        reissuable: !!response.reissuable,
+        hasIpfs: !!response.has_ipfs,
+        ipfs: response.has_ipfs ? response.ipfs || null : null,
+        satsInCirculation: response.sats_in_circulation || 0,
+      };
+    } catch (error) {
+      electrumLogger.debug(`Failed to get asset meta for ${name}:`, error);
+      return null;
+    }
+  }
+
+  /** UTXOs at an address for a specific asset (or, with `false`, the AVN-only UTXOs). */
+  async getAssetUTXOs(address: string, asset: string): Promise<AssetUTXO[]> {
+    try {
+      const scriptHash = this.addressToScriptHash(address);
+      const response = await this.makeRequest('blockchain.scripthash.listunspent', [scriptHash, asset]);
+      return (response || []).map((utxo: any) => ({
+        txid: utxo.tx_hash,
+        vout: utxo.tx_pos,
+        value: utxo.value,
+        height: utxo.height,
+        asset: utxo.asset ?? null,
+      }));
+    } catch (error) {
+      electrumLogger.debug(`Failed to get asset UTXOs for ${asset}:`, error);
       return [];
     }
   }

--- a/src/services/wallet/AssetService.test.ts
+++ b/src/services/wallet/AssetService.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatAssetAmount } from './AssetService';
+
+describe('formatAssetAmount', () => {
+  it('shows a 0-division asset as a whole number', () => {
+    expect(formatAssetAmount(1, 0)).toBe('1');
+    expect(formatAssetAmount(1500, 0)).toBe('1500');
+  });
+
+  it('scales by divisions and pads the fraction to full width', () => {
+    // 100000000 sats at 8 divisions = 1.00000000
+    expect(formatAssetAmount(100_000_000, 8)).toBe('1.00000000');
+    // 150000000 at 8 = 1.50000000
+    expect(formatAssetAmount(150_000_000, 8)).toBe('1.50000000');
+    // 1 sat at 8 divisions = 0.00000001
+    expect(formatAssetAmount(1, 8)).toBe('0.00000001');
+  });
+
+  it('handles other division counts', () => {
+    expect(formatAssetAmount(12345, 2)).toBe('123.45');
+    expect(formatAssetAmount(5, 3)).toBe('0.005');
+    expect(formatAssetAmount(1000, 3)).toBe('1.000');
+  });
+
+  it('formats a large (but JS-safe) amount without float drift', () => {
+    // 1,000,000 whole units at 8 divisions = 1e14 sats, well under Number.MAX_SAFE_INTEGER.
+    expect(formatAssetAmount(100_000_000_000_000, 8)).toBe('1000000.00000000');
+  });
+
+  it('clamps out-of-range divisions to 0..8', () => {
+    expect(formatAssetAmount(100_000_000, 8)).toBe('1.00000000');
+    expect(formatAssetAmount(5, -1)).toBe('5');
+  });
+});

--- a/src/services/wallet/AssetService.ts
+++ b/src/services/wallet/AssetService.ts
@@ -1,0 +1,56 @@
+// Avian asset reads: compose held-asset balances with their metadata into a display-ready list.
+// Assets are Ravencoin-style: an integer amount scaled by the asset's `divisions` (0–8). All the
+// formatting lives here so the UI never does raw scaling. Sending assets is a separate, higher-risk
+// concern (see docs/proposals/avian-assets.md) and is not in this module.
+
+import type { ElectrumService, AssetMeta } from '@/services/core/ElectrumService';
+
+export interface HeldAsset {
+  name: string;
+  /** Confirmed + unconfirmed, formatted with the asset's divisions. */
+  amount: string;
+  confirmedSats: number;
+  unconfirmedSats: number;
+  divisions: number;
+  meta: AssetMeta | null;
+}
+
+/**
+ * Format an integer asset amount (scaled by `10^divisions`) as a decimal string. A 0-division asset
+ * is whole-number only; otherwise the fractional part is shown to the full `divisions` width, the
+ * way Core displays asset quantities. Uses BigInt so large supplies never lose precision.
+ */
+export function formatAssetAmount(sats: number, divisions: number): string {
+  const units = Math.min(Math.max(divisions | 0, 0), 8);
+  const value = BigInt(Math.trunc(sats));
+  if (units === 0) return value.toString();
+  const divisor = 10n ** BigInt(units);
+  const whole = value / divisor;
+  const frac = (value % divisor).toString().padStart(units, '0');
+  return `${whole.toString()}.${frac}`;
+}
+
+/**
+ * Every asset held at `address`, sorted by name, each with its metadata (divisions, reissuable,
+ * IPFS) and a formatted quantity. The base coin (AVN) is excluded — it is the ordinary balance.
+ */
+export async function getHeldAssets(electrum: ElectrumService, address: string): Promise<HeldAsset[]> {
+  const balances = await electrum.getAssetBalances(address);
+  const names = Object.keys(balances).sort((a, b) => a.localeCompare(b));
+
+  const metas = await Promise.all(names.map((name) => electrum.getAssetMeta(name)));
+
+  return names.map((name, i) => {
+    const meta = metas[i];
+    const divisions = meta?.divisions ?? 0;
+    const { confirmed, unconfirmed } = balances[name];
+    return {
+      name,
+      confirmedSats: confirmed,
+      unconfirmedSats: unconfirmed,
+      divisions,
+      meta,
+      amount: formatAssetAmount(confirmed + unconfirmed, divisions),
+    };
+  });
+}


### PR DESCRIPTION
Phase 1 of Avian asset support — FlightDeck can now **see** the assets the active wallet holds (it was asset-blind before). No sending yet; that's Phase 2. Full plan: `docs/proposals/avian-assets.md` (included here).

## What it does
An "Assets" card on the dashboard (both mobile and desktop) listing held assets with a divisions-aware quantity, per-asset type (unique/sub/restricted/qualifier) and reissuable/pending badges, search, and refresh — mirroring Core's Asset Balances panel. It renders **only when the wallet holds assets**, so AVN-only wallets see no new chrome.

## No server work needed
Verified against the Avian ElectrumX source: everything is already exposed.
- `getAssetBalances` → `blockchain.scripthash.get_balance(sh, true)` (all balances at once; the base coin comes back keyed `"rvn"` and is dropped — AVN is the ordinary balance).
- `getAssetMeta` → `blockchain.asset.get_meta` (divisions 0–8, reissuable, IPFS, supply).
- `getAssetUTXOs` → asset-scoped `listunspent` (added now so the read layer is complete for Phase 2).

## Safe by construction
This only reads. The AVN send path still calls `listunspent` with no asset arg (server default = AVN-only), so asset UTXOs stay unselectable until the deliberate Phase 2 transfer builder — the same reason FlightDeck has never burned an asset.

## Tests
`formatAssetAmount` across divisions incl. a large JS-safe amount (BigInt, no float drift). Typecheck clean, production build passes. Bumps to 2.4.24.
