### PR TITLE
feat(assets): byte-exact asset transfer script builder/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.25",
+  "version": "2.4.26",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/assetScript.test.ts
+++ b/src/services/wallet/assetScript.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import * as bitcoin from 'bitcoinjs-lib';
+
+import { avianNetwork } from './WalletService';
+import { buildAssetTransferScript, parseAssetScript, ASSET_MARKER } from './assetScript';
+import { isAssetScript, OP_AVN_ASSET } from './psbt';
+
+/**
+ * Byte-exact asset transfer scripts. The golden vector below is assembled independently from the
+ * Avian Core format (assettypes.h / assets.cpp) — marker "rvn" ‖ 't' ‖ compactSize(name) ‖ name ‖
+ * int64LE(amount), wrapped as P2PKH ‖ OP_AVN_ASSET ‖ push ‖ OP_DROP — so it cross-checks the builder
+ * rather than merely round-tripping it. Getting this wrong builds unrecoverable assets, so it is the
+ * most safety-critical module in asset support.
+ */
+
+const ADDR = 'RJNi221gkDstBPUxeeJgtmDY4EXMEj6uvF';
+
+/** Independently construct the expected transfer script from first principles. */
+function expectedTransferScript(address: string, name: string, amount: bigint): Buffer {
+  const p2pkh = bitcoin.address.toOutputScript(address, avianNetwork);
+  const nameBuf = Buffer.from(name, 'ascii');
+  const amountBuf = Buffer.alloc(8);
+  amountBuf.writeBigInt64LE(amount);
+  const payload = Buffer.concat([
+    Buffer.from([0x72, 0x76, 0x6e]), // "rvn"
+    Buffer.from([0x74]), // 't'
+    Buffer.from([nameBuf.length]), // compactSize (names are short → 1 byte)
+    nameBuf,
+    amountBuf,
+  ]);
+  const push = Buffer.concat([Buffer.from([payload.length]), payload]); // direct push (<76 bytes)
+  return Buffer.concat([p2pkh, Buffer.from([OP_AVN_ASSET]), push, Buffer.from([0x75])]);
+}
+
+describe('buildAssetTransferScript', () => {
+  it('matches a byte-exact golden vector for a plain transfer', () => {
+    const built = buildAssetTransferScript(ADDR, 'SMAUG', 1000n);
+    expect(built.toString('hex')).toBe(expectedTransferScript(ADDR, 'SMAUG', 1000n).toString('hex'));
+  });
+
+  it('starts with a spendable 25-byte P2PKH and carries the rvn marker', () => {
+    const built = buildAssetTransferScript(ADDR, 'CRAIG_KINGDOM', 1n);
+    // The P2PKH prefix is exactly the plain output script for the address.
+    expect(built.subarray(0, 25).toString('hex')).toBe(
+      bitcoin.address.toOutputScript(ADDR, avianNetwork).toString('hex'),
+    );
+    expect(built[25]).toBe(OP_AVN_ASSET); // 0xc0
+    expect(isAssetScript(built)).toBe(true);
+    // The marker inside the pushed payload is "rvn", never "avn".
+    expect(built.includes(ASSET_MARKER)).toBe(true);
+    expect(built.includes(Buffer.from('avn', 'ascii'))).toBe(false);
+  });
+
+  it('encodes the amount as an 8-byte little-endian integer', () => {
+    const built = buildAssetTransferScript(ADDR, 'A', 0x0102030405n);
+    const parsed = parseAssetScript(built)!;
+    expect(parsed.amount).toBe(0x0102030405n);
+  });
+
+  it('rejects a bech32 (non-P2PKH) address — assets are legacy-address only', () => {
+    // A valid Avian bech32 address (P2WPKH) — not allowed to carry an asset.
+    const p2wpkh = bitcoin.payments.p2wpkh({
+      hash: Buffer.alloc(20, 7),
+      network: avianNetwork,
+    }).address!;
+    expect(() => buildAssetTransferScript(p2wpkh, 'SMAUG', 1n)).toThrow(/legacy P2PKH/);
+  });
+
+  it('rejects a non-positive amount', () => {
+    expect(() => buildAssetTransferScript(ADDR, 'SMAUG', 0n)).toThrow(/positive/);
+  });
+});
+
+describe('parseAssetScript', () => {
+  it('round-trips a transfer (type, name, amount, address)', () => {
+    const built = buildAssetTransferScript(ADDR, 'SMAUG', 1000n);
+    const parsed = parseAssetScript(built);
+    expect(parsed).toMatchObject({ type: 'transfer', name: 'SMAUG', amount: 1000n, address: ADDR });
+  });
+
+  it('round-trips unique (NAME#tag) and sub (PARENT/CHILD) names', () => {
+    for (const name of ['AVIANMEMECONTEST#7_OF_100', 'CRAIG_KINGDOM/SUB']) {
+      const parsed = parseAssetScript(buildAssetTransferScript(ADDR, name, 1n));
+      expect(parsed?.name).toBe(name);
+      expect(parsed?.type).toBe('transfer');
+    }
+  });
+
+  it('returns null for a plain (non-asset) P2PKH', () => {
+    const plain = bitcoin.address.toOutputScript(ADDR, avianNetwork);
+    expect(parseAssetScript(plain)).toBeNull();
+  });
+});

--- a/src/services/wallet/assetScript.ts
+++ b/src/services/wallet/assetScript.ts
@@ -1,0 +1,132 @@
+// Avian asset script build/parse. This is the byte-exact, security-critical core of asset transfers:
+// a wrong marker or a mis-sized field builds an invalid — and unrecoverable — asset output. Grounded
+// in Avian Core (`src/assets/assettypes.h`, `assets.cpp`):
+//
+//   asset output = <25-byte P2PKH> OP_AVN_ASSET(0xc0) <push: marker ‖ type ‖ payload> OP_DROP(0x75)
+//
+// The marker is "rvn" (0x72 0x76 0x6e) — a retained Ravencoin-compatibility artifact, NOT "avn".
+// Type byte: 't' transfer · 'r' issue/reissue · 'o' owner · 'q' qualifier. A plain transfer payload
+// (no message/expiry) is: compactSize(nameLen) ‖ name(ASCII) ‖ int64LE(amount).
+//
+// This module only builds *transfers* (the Phase-2 scope: root, sub and unique assets — the transfer
+// script is identical for all three, only the name differs). It parses transfer and owner outputs so
+// history and PSBT review can label them. Issue/reissue are recognised but not built here.
+
+import * as bitcoin from 'bitcoinjs-lib';
+
+import { avianNetwork } from './WalletService';
+import { OP_AVN_ASSET, isAssetScript } from './psbt';
+
+/** The on-chain asset marker: "rvn" (0x72 0x76 0x6e). NOT "avn" — see the file header. */
+export const ASSET_MARKER = Buffer.from('rvn', 'ascii');
+
+export const ASSET_TYPE = {
+  transfer: 0x74, // 't'
+  issue: 0x72, // 'r'
+  owner: 0x6f, // 'o'
+  qualifier: 0x71, // 'q'
+} as const;
+
+export interface AssetScriptInfo {
+  /** 'transfer' | 'issue' | 'owner' | 'qualifier' | 'unknown' */
+  type: 'transfer' | 'issue' | 'owner' | 'qualifier' | 'unknown';
+  /** Address the P2PKH part pays to (null if it isn't a standard address). */
+  address: string | null;
+  name: string;
+  /** Transfer/issue amount in integer units (scaled by the asset's divisions); null for owner. */
+  amount: bigint | null;
+}
+
+function encodeCompactSize(n: number): Buffer {
+  if (n < 0xfd) return Buffer.from([n]);
+  if (n <= 0xffff) {
+    const b = Buffer.alloc(3);
+    b[0] = 0xfd;
+    b.writeUInt16LE(n, 1);
+    return b;
+  }
+  const b = Buffer.alloc(5);
+  b[0] = 0xfe;
+  b.writeUInt32LE(n, 1);
+  return b;
+}
+
+function readCompactSize(buf: Buffer, offset: number): { value: number; size: number } {
+  const first = buf[offset];
+  if (first < 0xfd) return { value: first, size: 1 };
+  if (first === 0xfd) return { value: buf.readUInt16LE(offset + 1), size: 3 };
+  if (first === 0xfe) return { value: buf.readUInt32LE(offset + 1), size: 5 };
+  // 0xff (8-byte) — asset names are short, so this never occurs in practice.
+  return { value: Number(buf.readBigUInt64LE(offset + 1)), size: 9 };
+}
+
+/**
+ * Build a transfer output that pays `amount` (integer units) of `name` to `address`. The address
+ * must be a legacy P2PKH (`R…`) — assets never live on bech32. Throws on a non-P2PKH address or a
+ * non-positive amount.
+ */
+export function buildAssetTransferScript(address: string, name: string, amount: bigint): Buffer {
+  if (amount <= 0n) throw new Error('Asset transfer amount must be positive');
+  const p2pkh = bitcoin.address.toOutputScript(address, avianNetwork);
+  if (p2pkh.length !== 25 || p2pkh[0] !== bitcoin.opcodes.OP_DUP) {
+    throw new Error('Asset transfers require a legacy P2PKH (R…) address');
+  }
+  const nameBuf = Buffer.from(name, 'ascii');
+  const amountBuf = Buffer.alloc(8);
+  amountBuf.writeBigInt64LE(amount);
+
+  const payload = Buffer.concat([
+    ASSET_MARKER,
+    Buffer.from([ASSET_TYPE.transfer]),
+    encodeCompactSize(nameBuf.length),
+    nameBuf,
+    amountBuf,
+  ]);
+
+  const tag = bitcoin.script.compile([OP_AVN_ASSET, payload, bitcoin.opcodes.OP_DROP]);
+  return Buffer.concat([p2pkh, tag]);
+}
+
+/** Decode an asset output script into its type, address, name and amount (null if not an asset). */
+export function parseAssetScript(script: Buffer): AssetScriptInfo | null {
+  if (!isAssetScript(script)) return null;
+
+  const chunks = bitcoin.script.decompile(script);
+  if (!chunks) return null;
+  const tagIndex = chunks.findIndex((c) => c === OP_AVN_ASSET);
+  if (tagIndex < 0) return null;
+  const payload = chunks[tagIndex + 1];
+  if (!Buffer.isBuffer(payload) || payload.length < 5) return null;
+  if (!payload.subarray(0, 3).equals(ASSET_MARKER)) return null;
+
+  const typeByte = payload[3];
+  let address: string | null = null;
+  try {
+    address = bitcoin.address.fromOutputScript(script.subarray(0, 25), avianNetwork);
+  } catch {
+    address = null;
+  }
+
+  let offset = 4;
+  const { value: nameLen, size } = readCompactSize(payload, offset);
+  offset += size;
+  if (offset + nameLen > payload.length) return null;
+  const name = payload.subarray(offset, offset + nameLen).toString('ascii');
+  offset += nameLen;
+
+  let type: AssetScriptInfo['type'] = 'unknown';
+  let amount: bigint | null = null;
+  if (typeByte === ASSET_TYPE.transfer) {
+    type = 'transfer';
+    if (offset + 8 <= payload.length) amount = payload.readBigInt64LE(offset);
+  } else if (typeByte === ASSET_TYPE.issue) {
+    type = 'issue';
+    if (offset + 8 <= payload.length) amount = payload.readBigInt64LE(offset);
+  } else if (typeByte === ASSET_TYPE.owner) {
+    type = 'owner';
+  } else if (typeByte === ASSET_TYPE.qualifier) {
+    type = 'qualifier';
+  }
+
+  return { type, address, name, amount };
+}


### PR DESCRIPTION
feat(assets): byte-exact asset transfer script builder/parser

The security-critical primitive for Phase 2 asset transfers (see
docs/proposals/avian-assets.md): a wrong marker or mis-sized field builds an
invalid, unrecoverable asset output, so this is grounded byte-for-byte in Avian
Core (assettypes.h / assets.cpp) and validated against an independently-derived
golden vector, not just round-trip.

Asset output = <25-byte P2PKH> OP_AVN_ASSET(0xc0) <push: marker|type|payload>
OP_DROP(0x75). The marker is "rvn" (0x72 0x76 0x6e) — a retained Ravencoin
artifact, NOT "avn" (the constants are named AVN_* but spell rvn). A plain
transfer payload is compactSize(name) | name | int64LE(amount); a plain
transfer emits no IPFS/expiry bytes.

- buildAssetTransferScript: transfers only (root/sub/unique share one script);
  refuses a non-P2PKH (bech32) address and non-positive amounts
- parseAssetScript: decodes transfer/issue/owner/qualifier outputs (type,
  address, name, amount) so history and PSBT review can label assets
- 8 tests incl. a from-first-principles golden vector, a bech32-rejection guard,
  and an assertion that "avn" never appears in a built script

No wiring yet — the transfer tx builder that consumes this is the next PR, and
gets regtest golden-vector validation against Core before mainnet. Bumps to
2.4.25.
