### PR TITLE
fix(assets): correct asset amount scaling; fix stale signPsbt e2e test

### DIFF
--- a/e2e/avian-connect-popup.spec.ts
+++ b/e2e/avian-connect-popup.spec.ts
@@ -137,12 +137,15 @@ test.describe('popup transport', () => {
     await expect(demoLog(walletPage)).toContainText('"network":"mainnet"');
   });
 
-  test('signPsbt() is refused as unsupported in this phase', async ({ walletPage }) => {
+  test('signPsbt() from a site that has not connected is refused', async ({ walletPage }) => {
     await openDemo(walletPage);
 
-    await callWithNewPopup(walletPage, 'signPsbt() → unsupported');
+    // signPsbt is supported now, but like signMessage it is permission-gated: an unconnected
+    // origin gets ORIGIN_NOT_APPROVED with no approval dialog ever shown.
+    const popup = await callWithNewPopup(walletPage, 'signPsbt()');
 
-    await expect(demoLog(walletPage)).toContainText('UNSUPPORTED_METHOD');
+    await expect(demoLog(walletPage)).toContainText('ORIGIN_NOT_APPROVED');
+    await expect(approvalDialog(popup)).toHaveCount(0);
   });
 
   test('a site that has not connected cannot ask for a signature', async ({ walletPage }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.24",
+  "version": "2.4.25",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/AssetService.test.ts
+++ b/src/services/wallet/AssetService.test.ts
@@ -3,33 +3,28 @@ import { describe, expect, it } from 'vitest';
 import { formatAssetAmount } from './AssetService';
 
 describe('formatAssetAmount', () => {
-  it('shows a 0-division asset as a whole number', () => {
-    expect(formatAssetAmount(1, 0)).toBe('1');
-    expect(formatAssetAmount(1500, 0)).toBe('1500');
+  // Asset amounts are always scaled by 10^8 (COIN); a quantity of 1 is on-chain 100000000.
+  it('shows a whole quantity of a 0-division asset as an integer', () => {
+    expect(formatAssetAmount(100_000_000, 0)).toBe('1'); // qty 1 — the reported bug
+    expect(formatAssetAmount(1_500_000_000, 0)).toBe('15'); // qty 15
+    expect(formatAssetAmount(100, 0)).toBe('0'); // sub-unit dust on a 0-division asset
   });
 
-  it('scales by divisions and pads the fraction to full width', () => {
-    // 100000000 sats at 8 divisions = 1.00000000
-    expect(formatAssetAmount(100_000_000, 8)).toBe('1.00000000');
-    // 150000000 at 8 = 1.50000000
-    expect(formatAssetAmount(150_000_000, 8)).toBe('1.50000000');
-    // 1 sat at 8 divisions = 0.00000001
-    expect(formatAssetAmount(1, 8)).toBe('0.00000001');
+  it('shows `divisions` decimal places for a divisible asset', () => {
+    expect(formatAssetAmount(100_000_000, 8)).toBe('1.00000000'); // qty 1, 8 divisions
+    expect(formatAssetAmount(150_000_000, 8)).toBe('1.50000000'); // qty 1.5
+    expect(formatAssetAmount(1, 8)).toBe('0.00000001'); // smallest unit at 8 divisions
+    expect(formatAssetAmount(150_000_000, 2)).toBe('1.50'); // qty 1.5 shown to 2 places
+    expect(formatAssetAmount(5_000_000, 3)).toBe('0.050'); // 0.05
   });
 
-  it('handles other division counts', () => {
-    expect(formatAssetAmount(12345, 2)).toBe('123.45');
-    expect(formatAssetAmount(5, 3)).toBe('0.005');
-    expect(formatAssetAmount(1000, 3)).toBe('1.000');
-  });
-
-  it('formats a large (but JS-safe) amount without float drift', () => {
-    // 1,000,000 whole units at 8 divisions = 1e14 sats, well under Number.MAX_SAFE_INTEGER.
+  it('formats a large (but JS-safe) quantity without float drift', () => {
+    // 1,000,000 whole units at 8 divisions = 1e14 on-chain, under Number.MAX_SAFE_INTEGER.
     expect(formatAssetAmount(100_000_000_000_000, 8)).toBe('1000000.00000000');
   });
 
   it('clamps out-of-range divisions to 0..8', () => {
     expect(formatAssetAmount(100_000_000, 8)).toBe('1.00000000');
-    expect(formatAssetAmount(5, -1)).toBe('5');
+    expect(formatAssetAmount(100_000_000, -1)).toBe('1');
   });
 });

--- a/src/services/wallet/AssetService.ts
+++ b/src/services/wallet/AssetService.ts
@@ -16,18 +16,19 @@ export interface HeldAsset {
 }
 
 /**
- * Format an integer asset amount (scaled by `10^divisions`) as a decimal string. A 0-division asset
- * is whole-number only; otherwise the fractional part is shown to the full `divisions` width, the
- * way Core displays asset quantities. Uses BigInt so large supplies never lose precision.
+ * Format an on-chain asset amount as a decimal string. Avian assets (Ravencoin model) store every
+ * quantity scaled by 10^8 (COIN), exactly like AVN — a quantity of "1" is on-chain `100000000`.
+ * `divisions` (0–8) only says how many of those decimal places are meaningful, so we always divide
+ * by 10^8 and then show `divisions` decimals (0 → a whole number). BigInt keeps large supplies exact.
  */
 export function formatAssetAmount(sats: number, divisions: number): string {
   const units = Math.min(Math.max(divisions | 0, 0), 8);
   const value = BigInt(Math.trunc(sats));
-  if (units === 0) return value.toString();
-  const divisor = 10n ** BigInt(units);
-  const whole = value / divisor;
-  const frac = (value % divisor).toString().padStart(units, '0');
-  return `${whole.toString()}.${frac}`;
+  const COIN = 100_000_000n; // asset amounts are scaled by 10^8, like AVN — not by 10^divisions
+  const whole = value / COIN;
+  if (units === 0) return whole.toString();
+  const frac8 = (value % COIN).toString().padStart(8, '0');
+  return `${whole.toString()}.${frac8.slice(0, units)}`;
 }
 
 /**


### PR DESCRIPTION
fix(assets): correct asset amount scaling; fix stale signPsbt e2e test

Two corrections to already-merged work on main.

1. Asset amounts (#67 landed the pre-fix version). Avian assets store every
   quantity scaled by 10^8 (COIN), like AVN — a quantity of "1" is on-chain
   100000000 — and `divisions` (0-8) only says how many decimals are
   meaningful. formatAssetAmount was dividing by 10^divisions, so held assets
   rendered as raw values (e.g. "100000000" instead of "1"). It now always
   divides by 10^8 and shows `divisions` decimal places.

2. Stale e2e test. `signPsbt() is refused as unsupported in this phase`
   predates Avian Connect signPsbt (#65/#66): signPsbt is supported now, and
   the demo button was renamed, so the test could not find the button and
   timed out — failing CI for every branch off main. Rewritten to assert the
   real behaviour: signPsbt from an unconnected origin is refused with
   ORIGIN_NOT_APPROVED and no approval dialog, mirroring the signMessage case.

Typecheck clean; formatter tests updated to the 10^8 model. Bumps to 2.4.25.
