### PR TITLE
feat(assets): asset transfer builder (sendAssetTransfer) — regtest-validate before UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.28",
+  "version": "2.4.30",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -32,6 +32,7 @@ import {
     type PsbtInputSummary,
     type PsbtOutputSummary,
 } from './psbt';
+import { buildAssetTransferScript } from './assetScript';
 
 // How many transaction.get requests to keep in flight while syncing history. Electrum matches
 // responses by id, so a small pool cuts the latency of a large sync ~N-fold. Kept deliberately low:
@@ -1023,6 +1024,153 @@ export class WalletService {
             sendAmount: plan.finalSendAmount,
             changeAmount: plan.finalChange,
         };
+    }
+
+    /**
+     * Send `amount` (on-chain integer units, scaled by 10^8) of an Avian asset to a legacy address.
+     *
+     * Asset accounting is a separate ledger from AVN: asset transfer outputs carry 0 AVN value, so
+     * the network fee is paid entirely by AVN inputs. We spend asset UTXOs for the asset (with asset
+     * change back to ourselves) and AVN UTXOs for the fee (with AVN change). ElectrumX segregates the
+     * two — getAssetUTXOs returns only the named asset's outputs and getUTXOs only AVN — so the two
+     * input sets are disjoint and a plain-AVN send can never touch an asset.
+     *
+     * Spending an asset UTXO is an ordinary P2PKH spend: OP_DROP discards the asset rider at
+     * execution, so the sighash is taken over the full asset script and the scriptSig is [sig,
+     * pubkey], signed with the Avian FORKID (0x41) exactly like every other input.
+     *
+     * NOTE: build/parse is byte-validated against Core (see assetScript.ts), but this end-to-end
+     * builder must be regtest-validated against Avian Core before it is wired into any UI.
+     */
+    async sendAssetTransfer(
+        assetName: string,
+        amount: bigint,
+        toAddress: string,
+        password?: string,
+        options?: { feeRate?: number; changeAddress?: string },
+    ): Promise<string> {
+        try {
+            if (amount <= 0n) throw new Error('Asset amount must be positive');
+
+            const activeWallet = await StorageService.getActiveWallet();
+            if (!activeWallet) throw new Error('No active wallet found');
+            if ((activeWallet.addressType || 'p2pkh') !== 'p2pkh') {
+                throw new Error('Assets can only be sent from a legacy (R…) address');
+            }
+
+            let privateKeyWIF = activeWallet.privateKey;
+            if (activeWallet.isEncrypted) {
+                if (!password) throw new Error('Password required for encrypted wallet');
+                try {
+                    const { decrypted } = await decryptData(privateKeyWIF, password);
+                    if (!decrypted) throw new Error('Invalid password');
+                    privateKeyWIF = decrypted;
+                } catch {
+                    throw new Error('Invalid password');
+                }
+            }
+
+            const keyPair = ECPair.fromWIF(privateKeyWIF, avianNetwork);
+            const pubkey = Buffer.from(keyPair.publicKey);
+            const fromAddress = activeWallet.address;
+            const changeAddress = options?.changeAddress?.trim() || fromAddress;
+
+            // --- Asset side: select asset UTXOs to cover the amount, with asset change to self. ---
+            const assetUTXOs = await this.electrum.getAssetUTXOs(fromAddress, assetName);
+            const sortedAssets = [...assetUTXOs].sort((a, b) => b.value - a.value);
+            const selectedAssets: typeof assetUTXOs = [];
+            let assetIn = 0n;
+            for (const utxo of sortedAssets) {
+                if (assetIn >= amount) break;
+                selectedAssets.push(utxo);
+                assetIn += BigInt(Math.trunc(utxo.value));
+            }
+            if (assetIn < amount) {
+                throw new Error(`Insufficient ${assetName}: have ${assetIn}, need ${amount}`);
+            }
+            const assetChange = assetIn - amount;
+
+            const transferScript = buildAssetTransferScript(toAddress, assetName, amount);
+            const assetChangeScript =
+                assetChange > 0n ? buildAssetTransferScript(fromAddress, assetName, assetChange) : null;
+
+            // --- AVN side: size the fee and select AVN UTXOs to cover it (iterating on input count). ---
+            const satPerVByte = await this.resolveFeeRate(options?.feeRate);
+            const avnUTXOs = await this.electrum.getUTXOs(fromAddress);
+            const sortedAvn = [...avnUTXOs].sort((a, b) => b.value - a.value);
+            const totalAvn = sortedAvn.reduce((sum, utxo) => sum + utxo.value, 0);
+
+            // Asset output scripts are larger than a plain 34-byte output; size them exactly (script
+            // length is always < 253, so its length prefix is one byte). Always budget an AVN change
+            // output (+34); if change turns out to be dust it is folded into the fee, costing nothing.
+            const assetOutputsVBytes =
+                (8 + 1 + transferScript.length) +
+                (assetChangeScript ? 8 + 1 + assetChangeScript.length : 0);
+            const sizeFor = (avnInputCount: number) =>
+                10 + (selectedAssets.length + avnInputCount) * 148 + assetOutputsVBytes + 34;
+
+            let selectedAvn: typeof avnUTXOs = [];
+            let avnIn = 0;
+            let fee = 0;
+            for (let iteration = 0; iteration < 6; iteration++) {
+                fee = Math.ceil(sizeFor(Math.max(selectedAvn.length, 1)) * satPerVByte);
+                if (totalAvn < fee) {
+                    throw new Error(`Insufficient AVN for the network fee (need ${fee} sat)`);
+                }
+                selectedAvn = [];
+                avnIn = 0;
+                for (const utxo of sortedAvn) {
+                    if (avnIn >= fee) break;
+                    selectedAvn.push(utxo);
+                    avnIn += utxo.value;
+                }
+                const recomputed = Math.ceil(sizeFor(selectedAvn.length) * satPerVByte);
+                if (avnIn >= recomputed && recomputed <= fee) {
+                    fee = recomputed;
+                    break;
+                }
+                fee = recomputed;
+            }
+            if (avnIn < fee) throw new Error('Insufficient AVN for the network fee');
+            const avnChange = avnIn - fee;
+            const finalAvnChange = avnChange >= DUST_THRESHOLD_SATS ? avnChange : 0;
+
+            // --- Build the transaction: asset inputs + AVN inputs; asset outputs (0 value) + AVN change. ---
+            const tx = new bitcoin.Transaction();
+            tx.version = 2;
+            tx.locktime = 0;
+            const allInputs = [...selectedAssets, ...selectedAvn];
+            for (const utxo of allInputs) {
+                tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
+            }
+            tx.addOutput(transferScript, 0);
+            if (assetChangeScript) tx.addOutput(assetChangeScript, 0);
+            if (finalAvnChange > 0) {
+                tx.addOutput(bitcoin.address.toOutputScript(changeAddress, avianNetwork), finalAvnChange);
+            }
+
+            // --- Sign every input as a legacy P2PKH spend with the FORKID sighash. ---
+            for (let i = 0; i < allInputs.length; i++) {
+                const utxo = allInputs[i];
+                const prevTxHex = await this.electrum.getTransaction(utxo.txid, false);
+                const prevOut = bitcoin.Transaction.fromHex(prevTxHex).outs[utxo.vout];
+                const digest = tx.hashForSignature(i, prevOut.script, SIGHASH_ALL_FORKID);
+                const derSignature = this.encodeDERWithCustomHashType(
+                    Buffer.from(keyPair.sign(digest)),
+                    SIGHASH_ALL_FORKID,
+                );
+                tx.ins[i].script = bitcoin.script.compile([derSignature, pubkey]);
+            }
+
+            const txHex = tx.toHex();
+            const txId = tx.getId();
+            await this.broadcastRawTransaction(txHex);
+            return txId;
+        } catch (error) {
+            walletLogger.error('Asset transfer failed:', error);
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Asset transfer failed: ${message}`);
+        }
     }
 
     async sendTransaction(

--- a/src/services/wallet/assetTransfer.test.ts
+++ b/src/services/wallet/assetTransfer.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as bitcoin from 'bitcoinjs-lib';
+import { ECPairFactory } from 'ecpair';
+import * as ecc from 'tiny-secp256k1';
+
+import { WalletService, avianNetwork, deriveAddress, secureEncrypt } from './WalletService';
+import { buildAssetTransferScript, parseAssetScript } from './assetScript';
+import { StorageService } from '@/services/core/StorageService';
+import { TEST_PASSWORD, resetStorage } from '@/test/helpers';
+
+/**
+ * Asset transfers against a stubbed network. The invariants that matter (and that regtest will
+ * confirm end-to-end against Core): the asset ledger is conserved (asset in == transfer + change),
+ * asset outputs carry 0 AVN, the fee is paid only by AVN inputs, and every input is signed with the
+ * FORKID sighash. Nothing is broadcast for real.
+ */
+
+const ECPair = ECPairFactory(ecc);
+const SIGHASH_ALL_FORKID = 0x41;
+const RECIPIENT = 'RJNi221gkDstBPUxeeJgtmDY4EXMEj6uvF';
+const ASSET = 'SMAUG';
+const COIN = 100_000_000n; // 1 whole unit
+
+/** A prevtx whose output[0] is an asset script paying `amount` of `ASSET` to `owner` (0 AVN value). */
+function assetFundingTx(owner: string, amount: bigint, seed: number) {
+  const tx = new bitcoin.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, seed), 0);
+  tx.addOutput(buildAssetTransferScript(owner, ASSET, amount), 0);
+  return { hex: tx.toHex(), txid: tx.getId() };
+}
+
+/** A prevtx whose output[0] is a plain P2PKH paying `value` AVN sats to `owner`. */
+function avnFundingTx(owner: string, value: number, seed: number) {
+  const tx = new bitcoin.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, seed), 0);
+  tx.addOutput(bitcoin.address.toOutputScript(owner, avianNetwork), value);
+  return { hex: tx.toHex(), txid: tx.getId() };
+}
+
+function createAssetElectrum(owner: string, assetAmounts: bigint[], avnValues: number[]) {
+  const txs = new Map<string, string>();
+  const assetUtxos = assetAmounts.map((amount, i) => {
+    const f = assetFundingTx(owner, amount, i + 1);
+    txs.set(f.txid, f.hex);
+    return { txid: f.txid, vout: 0, value: Number(amount), height: 100, asset: ASSET };
+  });
+  const avnUtxos = avnValues.map((value, i) => {
+    const f = avnFundingTx(owner, value, i + 50);
+    txs.set(f.txid, f.hex);
+    return { txid: f.txid, vout: 0, value, height: 100 };
+  });
+  const broadcast = vi.fn(async (hex: string) => bitcoin.Transaction.fromHex(hex).getId());
+  return {
+    assetUtxos,
+    avnUtxos,
+    broadcast,
+    electrum: {
+      getAssetUTXOs: vi.fn(async (_addr: string, name: string) => (name === ASSET ? assetUtxos : [])),
+      getUTXOs: vi.fn(async () => avnUtxos),
+      getTransaction: vi.fn(async (txid: string) => txs.get(txid)),
+      broadcastTransaction: broadcast,
+      getCurrentBlockHeight: vi.fn(async () => 100),
+      getFeeRateSatPerVByte: vi.fn(async () => 0), // fall back to the explicit feeRate the test passes
+      isConnectedToServer: vi.fn(() => true),
+    },
+  };
+}
+
+async function createActiveWallet() {
+  const keyPair = ECPair.makeRandom({ network: avianNetwork });
+  const address = deriveAddress(Buffer.from(keyPair.publicKey), 'p2pkh');
+  await StorageService.createWallet({
+    name: 'Assets',
+    address,
+    privateKey: await secureEncrypt(keyPair.toWIF(), TEST_PASSWORD),
+    isEncrypted: true,
+    addressType: 'p2pkh',
+  });
+  return { address, keyPair };
+}
+
+/** Classify a broadcast tx's outputs into asset entries and plain AVN outputs. */
+function classifyOutputs(tx: bitcoin.Transaction) {
+  const assets: { address: string | null; name: string; amount: bigint | null; value: number }[] = [];
+  const avn: { address: string; value: number }[] = [];
+  for (const out of tx.outs) {
+    const info = parseAssetScript(out.script as Buffer);
+    if (info) {
+      assets.push({ address: info.address, name: info.name, amount: info.amount, value: out.value });
+    } else {
+      avn.push({ address: bitcoin.address.fromOutputScript(out.script, avianNetwork), value: out.value });
+    }
+  }
+  return { assets, avn };
+}
+
+beforeEach(() => {
+  resetStorage();
+});
+
+describe('sendAssetTransfer', () => {
+  it('moves the asset to the recipient with asset change back to the sender', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createAssetElectrum(address, [3n * COIN], [1 * Number(COIN)]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.sendAssetTransfer(ASSET, 1n * COIN, RECIPIENT, TEST_PASSWORD, { feeRate: 1 });
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    const { assets, avn } = classifyOutputs(tx);
+
+    // Transfer output: 1 unit to the recipient, 0 AVN value.
+    expect(assets).toContainEqual({ address: RECIPIENT, name: ASSET, amount: 1n * COIN, value: 0 });
+    // Asset change: 2 units back to us, 0 AVN value.
+    expect(assets).toContainEqual({ address, name: ASSET, amount: 2n * COIN, value: 0 });
+    // Asset ledger is conserved.
+    expect(assets.reduce((s, a) => s + (a.amount ?? 0n), 0n)).toBe(3n * COIN);
+    // A single AVN change output back to us.
+    expect(avn).toHaveLength(1);
+    expect(avn[0].address).toBe(address);
+  });
+
+  it('emits no asset-change output when the amount matches the asset input exactly', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createAssetElectrum(address, [1n * COIN], [1 * Number(COIN)]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.sendAssetTransfer(ASSET, 1n * COIN, RECIPIENT, TEST_PASSWORD, { feeRate: 1 });
+
+    const { assets } = classifyOutputs(bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string));
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({ address: RECIPIENT, amount: 1n * COIN, value: 0 });
+  });
+
+  it('spends several asset UTXOs when one is not enough', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createAssetElectrum(address, [1n * COIN, 1n * COIN], [1 * Number(COIN)]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.sendAssetTransfer(ASSET, 3n * (COIN / 2n), RECIPIENT, TEST_PASSWORD, { feeRate: 1 });
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    const { assets } = classifyOutputs(tx);
+    // Two asset inputs spent; ledger conserved at 2 units (1.5 sent + 0.5 change).
+    expect(assets.reduce((s, a) => s + (a.amount ?? 0n), 0n)).toBe(2n * COIN);
+    expect(assets).toContainEqual({ address: RECIPIENT, name: ASSET, amount: 3n * (COIN / 2n), value: 0 });
+    expect(assets).toContainEqual({ address, name: ASSET, amount: COIN / 2n, value: 0 });
+  });
+
+  it('pays the fee from AVN inputs only, never underpaying', async () => {
+    const { address } = await createActiveWallet();
+    const avnValue = 1 * Number(COIN);
+    const { electrum, broadcast } = createAssetElectrum(address, [1n * COIN], [avnValue]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.sendAssetTransfer(ASSET, 1n * COIN, RECIPIENT, TEST_PASSWORD, { feeRate: 1 });
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    const { avn } = classifyOutputs(tx);
+    const avnChange = avn.reduce((s, o) => s + o.value, 0);
+    const fee = avnValue - avnChange; // the only AVN input funds fee + change
+    expect(fee).toBeGreaterThan(0);
+    // Never underpay: fee at 1 sat/vByte must cover the actual virtual size.
+    expect(fee).toBeGreaterThanOrEqual(tx.virtualSize());
+    // Two inputs: one asset, one AVN.
+    expect(tx.ins).toHaveLength(2);
+  });
+
+  it('signs every input with the FORKID sighash', async () => {
+    const { address, keyPair } = await createActiveWallet();
+    const { electrum, broadcast } = createAssetElectrum(address, [2n * COIN], [1 * Number(COIN)]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.sendAssetTransfer(ASSET, 1n * COIN, RECIPIENT, TEST_PASSWORD, { feeRate: 1 });
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    for (const input of tx.ins) {
+      const [signature, pubkey] = bitcoin.script.decompile(input.script) as Buffer[];
+      expect(signature[signature.length - 1]).toBe(SIGHASH_ALL_FORKID);
+      expect(Buffer.from(pubkey).toString('hex')).toBe(Buffer.from(keyPair.publicKey).toString('hex'));
+    }
+  });
+
+  it('refuses when the wallet lacks enough of the asset', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createAssetElectrum(address, [1n * COIN], [1 * Number(COIN)]);
+    const wallet = new WalletService(electrum as never);
+
+    await expect(
+      wallet.sendAssetTransfer(ASSET, 5n * COIN, RECIPIENT, TEST_PASSWORD, { feeRate: 1 }),
+    ).rejects.toThrow(/Insufficient SMAUG/);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it('refuses when there is no AVN to pay the fee', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createAssetElectrum(address, [1n * COIN], []); // no AVN UTXOs
+    const wallet = new WalletService(electrum as never);
+
+    await expect(
+      wallet.sendAssetTransfer(ASSET, 1n * COIN, RECIPIENT, TEST_PASSWORD, { feeRate: 1 }),
+    ).rejects.toThrow(/AVN for the network fee/);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
feat(assets): asset transfer builder (WalletService.sendAssetTransfer)

Phase 2 core (see docs/proposals/avian-assets.md): build, sign and broadcast an
Avian asset transfer. Not wired into any UI yet, so it is not user-reachable —
it is the engine the Send-asset flow will call, landed on its own for review and
regtest validation.

Asset accounting is a separate ledger from AVN. Asset transfer outputs carry 0
AVN value, so the network fee is paid entirely by AVN inputs:
- asset inputs (getAssetUTXOs, the named asset only) cover the amount, with asset
  change back to the sender;
- AVN inputs (getUTXOs, AVN only) cover a size-based fee, with AVN change.
ElectrumX segregates the two input sets, so a plain-AVN send can never touch an
asset, and this builder never selects an asset UTXO for the fee.

Spending an asset UTXO is an ordinary P2PKH spend — OP_DROP discards the asset
rider, the sighash is taken over the full asset script, the scriptSig is
[sig, pubkey], signed with FORKID (0x41) like every other input. No new crypto.

Tests (stubbed network): asset ledger conserved (in == transfer + change), asset
outputs are 0-value, fee comes only from AVN and never underpays the actual
vsize, every input carries the 0x41 sighash, and it refuses on insufficient
asset or no AVN for the fee. Full wallet suite (368) green, build passes.

IMPORTANT: build/parse is byte-validated against Core, but this end-to-end
builder must pass the regtest golden-vector loop against Avian Core before it is
wired into the Send UI. Bumps to 2.4.27.
