### PR TITLE
fix(assets): correct asset type labels + real Core golden vectors + owner badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.26",
+  "version": "2.4.28",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -11,7 +11,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 /** The kind of Avian asset name, for a small type badge. */
-function assetKind(name: string): 'unique' | 'sub' | 'restricted' | 'qualifier' | null {
+function assetKind(name: string): 'owner' | 'unique' | 'sub' | 'restricted' | 'qualifier' | null {
+  if (name.endsWith('!')) return 'owner'; // administrative token — grants reissue/management rights
   if (name.includes('#')) return name.startsWith('#') ? 'qualifier' : 'unique';
   if (name.startsWith('$')) return 'restricted';
   if (name.includes('/')) return 'sub';

--- a/src/services/wallet/assetScript.test.ts
+++ b/src/services/wallet/assetScript.test.ts
@@ -133,4 +133,23 @@ describe('real mainnet Core golden vectors', () => {
     expect(built.includes(nameAndAmount)).toBe(true);
     expect(issueScript.includes(nameAndAmount)).toBe(true);
   });
+
+  it('builds a transfer byte-identical to a real Core SMAUG transfer output', () => {
+    // The transfer output of a real Avian Core SMAUG transfer (1.0 SMAUG, type 't'). This is the
+    // definitive check: our builder must reproduce Core's transfer script exactly, or an asset move
+    // could be malformed and unrecoverable.
+    const RECIPIENT_ADDR = 'RWdrtiny9B5zGcyVzjyZtj4sLhZpn2XQfL';
+    const realTransfer =
+      '76a914ea435c63940947432bfa2c53263c6d9ad82a163788acc01272766e7405534d41554700e1f5050000000075';
+
+    expect(parseAssetScript(Buffer.from(realTransfer, 'hex'))).toEqual({
+      type: 'transfer',
+      address: RECIPIENT_ADDR,
+      name: 'SMAUG',
+      amount: 100_000_000n, // 1.0 SMAUG
+    });
+    expect(buildAssetTransferScript(RECIPIENT_ADDR, 'SMAUG', 100_000_000n).toString('hex')).toBe(
+      realTransfer,
+    );
+  });
 });

--- a/src/services/wallet/assetScript.test.ts
+++ b/src/services/wallet/assetScript.test.ts
@@ -91,3 +91,46 @@ describe('parseAssetScript', () => {
     expect(parseAssetScript(plain)).toBeNull();
   });
 });
+
+describe('real mainnet Core golden vectors', () => {
+  // Output scripts lifted from a real Avian Core asset-issuance transaction (creating FLIGHTDECK).
+  // These pin the parser to what Core actually emits on mainnet.
+  const OWNER = 'RXt29uFKBr8RnyUqyp7m71S4DXPtauYyXm';
+  const ownerScript = Buffer.from(
+    '76a914f7e90a9c1fd4bacfd771b70152e3ecf775697f2b88acc01072766e6f0b464c494748544445434b2175',
+    'hex',
+  );
+  const issueScript = Buffer.from(
+    '76a914f7e90a9c1fd4bacfd771b70152e3ecf775697f2b88acc01b72766e710a464c494748544445434b00e1f505000000000001000075',
+    'hex',
+  );
+
+  it('parses a real owner token (type o, no amount)', () => {
+    expect(parseAssetScript(ownerScript)).toEqual({
+      type: 'owner',
+      address: OWNER,
+      name: 'FLIGHTDECK!',
+      amount: null,
+    });
+  });
+
+  it('parses a real new-asset issuance (type q, with amount)', () => {
+    // 'q' (0x71) is issuance — the label the parser bug used to get wrong.
+    expect(parseAssetScript(issueScript)).toEqual({
+      type: 'issue',
+      address: OWNER,
+      name: 'FLIGHTDECK',
+      amount: 100_000_000n, // qty 1, scaled by 10^8
+    });
+  });
+
+  it('builds a transfer whose name+amount bytes match Core’s real encoding', () => {
+    // The issuance payload is "rvn" ‖ 'q' ‖ compactSize(name) ‖ name ‖ int64LE(amount) ‖ …extra.
+    // A transfer is "rvn" ‖ 't' ‖ compactSize(name) ‖ name ‖ int64LE(amount) — the name+amount run
+    // is identical, so our builder must produce exactly those bytes.
+    const built = buildAssetTransferScript(OWNER, 'FLIGHTDECK', 100_000_000n);
+    const nameAndAmount = Buffer.from('0a464c494748544445434b00e1f50500000000', 'hex');
+    expect(built.includes(nameAndAmount)).toBe(true);
+    expect(issueScript.includes(nameAndAmount)).toBe(true);
+  });
+});

--- a/src/services/wallet/assetScript.ts
+++ b/src/services/wallet/assetScript.ts
@@ -20,20 +20,21 @@ import { OP_AVN_ASSET, isAssetScript } from './psbt';
 /** The on-chain asset marker: "rvn" (0x72 0x76 0x6e). NOT "avn" — see the file header. */
 export const ASSET_MARKER = Buffer.from('rvn', 'ascii');
 
+// Type byte after the "rvn" marker. Confirmed against a real mainnet Core issuance tx: 'q' is a new
+// asset, 'r' is a reissue (they are NOT the other way round), 't' a transfer, 'o' an owner token.
 export const ASSET_TYPE = {
   transfer: 0x74, // 't'
-  issue: 0x72, // 'r'
+  issue: 0x71, // 'q' — new asset issuance
+  reissue: 0x72, // 'r'
   owner: 0x6f, // 'o'
-  qualifier: 0x71, // 'q'
 } as const;
 
 export interface AssetScriptInfo {
-  /** 'transfer' | 'issue' | 'owner' | 'qualifier' | 'unknown' */
-  type: 'transfer' | 'issue' | 'owner' | 'qualifier' | 'unknown';
+  type: 'transfer' | 'issue' | 'reissue' | 'owner' | 'unknown';
   /** Address the P2PKH part pays to (null if it isn't a standard address). */
   address: string | null;
   name: string;
-  /** Transfer/issue amount in integer units (scaled by the asset's divisions); null for owner. */
+  /** Amount in integer units (scaled by 10^8); null for an owner token, which carries no amount. */
   amount: bigint | null;
 }
 
@@ -116,16 +117,14 @@ export function parseAssetScript(script: Buffer): AssetScriptInfo | null {
 
   let type: AssetScriptInfo['type'] = 'unknown';
   let amount: bigint | null = null;
-  if (typeByte === ASSET_TYPE.transfer) {
-    type = 'transfer';
-    if (offset + 8 <= payload.length) amount = payload.readBigInt64LE(offset);
-  } else if (typeByte === ASSET_TYPE.issue) {
-    type = 'issue';
-    if (offset + 8 <= payload.length) amount = payload.readBigInt64LE(offset);
-  } else if (typeByte === ASSET_TYPE.owner) {
-    type = 'owner';
-  } else if (typeByte === ASSET_TYPE.qualifier) {
-    type = 'qualifier';
+  // transfer / new-asset issue / reissue all carry an int64 amount right after the name; an owner
+  // token carries none.
+  if (typeByte === ASSET_TYPE.transfer) type = 'transfer';
+  else if (typeByte === ASSET_TYPE.issue) type = 'issue';
+  else if (typeByte === ASSET_TYPE.reissue) type = 'reissue';
+  else if (typeByte === ASSET_TYPE.owner) type = 'owner';
+  if (type !== 'owner' && type !== 'unknown' && offset + 8 <= payload.length) {
+    amount = payload.readBigInt64LE(offset);
   }
 
   return { type, address, name, amount };


### PR DESCRIPTION
fix(assets): correct asset type labels; pin to a real Core golden vector; owner badge

Validated the asset script layer against a real Avian Core mainnet transaction
(a FLIGHTDECK issuance), which confirmed the marker "rvn" and the exact
P2PKH·OP_AVN_ASSET·push·OP_DROP framing, and that buildAssetTransferScript's
name+amount encoding is byte-identical to Core's — and caught a parser bug.

- parseAssetScript type labels were swapped: 'q' (0x71) is a NEW-ASSET issuance
  and 'r' (0x72) is a REISSUE, not the other way round. Fixed the ASSET_TYPE
  map and the parse (issue/reissue/transfer all read an int64 amount; owner has
  none). This is parse/label only — buildAssetTransferScript and the transfer
  builder use type 't' and were unaffected — but it mislabelled real holdings.
- Added permanent golden-vector tests from the real Core tx: parse the real
  owner token (type o) and new-asset issuance (type q), and assert the built
  transfer's name+amount bytes match Core's real encoding.
- AssetList: show an "Owner" badge for administrative tokens (NAME!), which
  grant reissue/management rights and read differently from ordinary holdings.

Typecheck clean; assetScript tests 11 green; build passes. Bumps to 2.4.28.
