### PR TITLE
fix(psbt): broadcast signed PSBT through the connected Electrum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/PsbtSigner.tsx
+++ b/src/components/PsbtSigner.tsx
@@ -38,7 +38,7 @@ const shorten = (a: string) => (a.length > 24 ? `${a.slice(0, 12)}…${a.slice(-
  * the signed PSBT back. Asset inputs are surfaced and never signed. See src/services/wallet/psbt.ts.
  */
 export default function PsbtSigner() {
-  const { address, isEncrypted, refreshAfterTransaction } = useWallet();
+  const { address, isEncrypted, refreshAfterTransaction, electrum, isConnected } = useWallet();
   const [walletService] = useState(() => new WalletService());
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -146,12 +146,22 @@ export default function PsbtSigner() {
   };
 
   const handleBroadcast = async () => {
+    // The component's WalletService is offline (summarize/sign/finalize need no network); broadcast
+    // must go through the wallet's live, connected ElectrumService from context.
+    if (!electrum || !isConnected) {
+      toast.error('Not connected', {
+        description: 'Connect to the Avian network before broadcasting.',
+      });
+      return;
+    }
     setIsBusy(true);
     try {
       const { hex, txid: id } = walletService.finalizePsbt(signedPsbt);
-      const broadcastId = await walletService.broadcastRawTransaction(hex);
-      const finalId = typeof broadcastId === 'string' ? broadcastId : id;
-      setTxid(finalId);
+      const broadcastId = await electrum.broadcastTransaction(hex);
+      if (!broadcastId || typeof broadcastId !== 'string') {
+        throw new Error('Transaction broadcast failed. Please try again later.');
+      }
+      setTxid(broadcastId || id);
       toast.success('Transaction broadcast');
       void refreshAfterTransaction(1500);
     } catch (error) {


### PR DESCRIPTION
The PSBT signer's WalletService had no ElectrumService, so it used a fresh unconnected one. summarize/sign/finalize are offline and worked, but the Broadcast button failed with "Electrum not connected". Broadcast now goes through the wallet's live connected ElectrumService from context (finalize stays offline), with a clear "Not connected" message when offline. Bumps to 2.4.29.