### PR TITLE
feat(assets): send-asset UI — per-row Send with owner-token warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.30",
+  "version": "2.4.31",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Coins, RefreshCw, Search } from 'lucide-react';
+import { Coins, RefreshCw, Search, Send } from 'lucide-react';
 
 import { useWallet } from '@/contexts/WalletContext';
 import { getHeldAssets, type HeldAsset } from '@/services/wallet/AssetService';
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import SendAssetDialog from './SendAssetDialog';
 
 /** The kind of Avian asset name, for a small type badge. */
 function assetKind(name: string): 'owner' | 'unique' | 'sub' | 'restricted' | 'qualifier' | null {
@@ -30,6 +31,7 @@ export function AssetList({ className }: { className?: string }) {
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [query, setQuery] = useState('');
+  const [sending, setSending] = useState<HeldAsset | null>(null);
 
   const load = useCallback(async () => {
     if (!electrum || !address) return;
@@ -123,7 +125,20 @@ export function AssetList({ className }: { className?: string }) {
                       )}
                     </span>
                   </span>
-                  <span className="flex-shrink-0 font-mono text-sm">{asset.amount}</span>
+                  <span className="flex flex-shrink-0 items-center gap-2">
+                    <span className="font-mono text-sm">{asset.amount}</span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground hover:text-primary"
+                      onClick={() => setSending(asset)}
+                      disabled={asset.confirmedSats <= 0}
+                      aria-label={`Send ${asset.name}`}
+                      title={`Send ${asset.name}`}
+                    >
+                      <Send className="h-4 w-4" />
+                    </Button>
+                  </span>
                 </li>
               );
             })}
@@ -135,6 +150,13 @@ export function AssetList({ className }: { className?: string }) {
           </ul>
         )}
       </CardContent>
+
+      <SendAssetDialog
+        open={sending !== null}
+        onOpenChange={(next) => !next && setSending(null)}
+        asset={sending}
+        onSuccess={() => void load()}
+      />
     </Card>
   );
 }

--- a/src/components/SendAssetDialog.tsx
+++ b/src/components/SendAssetDialog.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { ArrowRight, Check, Coins, Lock, ShieldAlert } from 'lucide-react';
+
+import { useWallet } from '@/contexts/WalletContext';
+import { useSecurity } from '@/contexts/SecurityContext';
+import { useMediaQuery } from '@/hooks/use-media-query';
+import { WalletService } from '@/services/wallet/WalletService';
+import { formatAssetAmount, parseAssetAmount, type HeldAsset } from '@/services/wallet/AssetService';
+import { getExplorerUrl } from '@/lib/explorer';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface SendAssetDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  asset: HeldAsset | null;
+  onSuccess?: () => void;
+}
+
+/** Assets live on legacy P2PKH (R…) addresses only — never bech32. */
+const isLegacyAddress = (a: string) =>
+  /^R[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{25,34}$/.test(a.trim());
+
+export default function SendAssetDialog({
+  open,
+  onOpenChange,
+  asset,
+  onSuccess,
+}: SendAssetDialogProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const { electrum, isConnected, refreshAfterTransaction } = useWallet();
+  const { requireAuth } = useSecurity();
+
+  const [recipient, setRecipient] = useState('');
+  const [amountInput, setAmountInput] = useState('');
+  const [error, setError] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [txid, setTxid] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setRecipient('');
+      setAmountInput('');
+      setError('');
+      setTxid('');
+      setIsSending(false);
+    }
+  }, [open]);
+
+  if (!asset) return null;
+
+  const isOwner = asset.name.endsWith('!');
+  const heldFormatted = formatAssetAmount(asset.confirmedSats, asset.divisions);
+
+  const handleSend = async () => {
+    setError('');
+    if (!isLegacyAddress(recipient)) {
+      setError('Enter a valid legacy (R…) address. Assets can’t be sent to a bech32 (avn1…) address.');
+      return;
+    }
+    let amount: bigint;
+    try {
+      amount = parseAssetAmount(amountInput, asset.divisions);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Invalid amount');
+      return;
+    }
+    if (amount > BigInt(asset.confirmedSats)) {
+      setError(`Amount exceeds your balance of ${heldFormatted} ${asset.name}`);
+      return;
+    }
+    if (!electrum || !isConnected) {
+      setError('Not connected to the Avian network. Please check your connection.');
+      return;
+    }
+
+    setIsSending(true);
+    try {
+      const auth = await requireAuth(`Authenticate to send ${asset.name}`);
+      if (!auth.success) {
+        setError('Authentication is required to send an asset.');
+        return;
+      }
+      const service = new WalletService(electrum);
+      const id = await service.sendAssetTransfer(asset.name, amount, recipient.trim(), auth.password);
+      setTxid(id);
+      toast.success(`Sent ${asset.name}`);
+      void refreshAfterTransaction(1500);
+      onSuccess?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to send the asset.');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const body = txid ? (
+    <div className="space-y-4">
+      <Alert className="border-emerald-500/40 bg-emerald-500/10">
+        <Check className="h-4 w-4 text-emerald-600" />
+        <AlertDescription className="space-y-2">
+          <p>
+            Sent{' '}
+            <span className="font-mono">
+              {amountInput} {asset.name}
+            </span>
+            .
+          </p>
+          <a
+            href={getExplorerUrl(txid)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-sm font-medium text-primary underline underline-offset-2"
+          >
+            View on explorer
+          </a>
+        </AlertDescription>
+      </Alert>
+      <Button className="w-full" onClick={() => onOpenChange(false)}>
+        Done
+      </Button>
+    </div>
+  ) : (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-border bg-muted/40 p-4">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+          <Coins className="h-3.5 w-3.5 text-primary" /> Sending asset
+        </div>
+        <div className="mt-1 flex items-baseline justify-between gap-3">
+          <span className="truncate text-lg font-semibold">{asset.name}</span>
+          <span className="flex-shrink-0 font-mono text-sm text-muted-foreground">
+            Held: {heldFormatted}
+          </span>
+        </div>
+      </div>
+
+      {isOwner && (
+        <Alert className="border-caution/40 bg-caution/10 [&>svg]:text-caution">
+          <ShieldAlert className="h-4 w-4" />
+          <AlertDescription className="text-sm">
+            <strong>{asset.name}</strong> is an owner token. Sending it hands over administrative
+            control of <strong>{asset.name.slice(0, -1)}</strong> — reissue and management rights —
+            to the recipient. This cannot be undone.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="asset-recipient">Recipient (R… address)</Label>
+        <Input
+          id="asset-recipient"
+          value={recipient}
+          onChange={(e) => setRecipient(e.target.value)}
+          placeholder="R…"
+          spellCheck={false}
+          className="font-mono text-sm"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="asset-amount">Amount</Label>
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="h-auto p-0 text-xs"
+            onClick={() => setAmountInput(heldFormatted)}
+          >
+            Max
+          </Button>
+        </div>
+        <Input
+          id="asset-amount"
+          value={amountInput}
+          onChange={(e) => setAmountInput(e.target.value)}
+          placeholder={asset.divisions === 0 ? '0' : `0.${'0'.repeat(asset.divisions)}`}
+          inputMode="decimal"
+          className="font-mono"
+        />
+        <p className="text-xs text-muted-foreground">
+          {asset.divisions === 0
+            ? 'This asset is not divisible — whole numbers only.'
+            : `Up to ${asset.divisions} decimal place${asset.divisions === 1 ? '' : 's'}.`}{' '}
+          The network fee is paid in AVN.
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-start gap-2.5 rounded-lg border border-primary/25 bg-primary/5 p-3 text-sm">
+        <ArrowRight className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
+        <span>Sending authenticates first — nothing moves until you authorise.</span>
+      </div>
+
+      <div className="flex gap-2 pt-1">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1"
+          onClick={() => onOpenChange(false)}
+          disabled={isSending}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          className="flex-1 gap-2"
+          onClick={handleSend}
+          disabled={isSending || !recipient || !amountInput}
+        >
+          <Lock className="h-4 w-4" />
+          {isSending ? 'Sending…' : 'Send asset'}
+        </Button>
+      </div>
+    </div>
+  );
+
+  const title = `Send ${asset.name}`;
+  const description = 'Transfer this asset to another Avian address.';
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent className="max-h-[95vh]">
+          <DrawerHeader className="text-left">
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+          <div className="overflow-y-auto px-4 pb-6">{body}</div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        {body}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/services/wallet/AssetService.test.ts
+++ b/src/services/wallet/AssetService.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatAssetAmount } from './AssetService';
+import { formatAssetAmount, parseAssetAmount } from './AssetService';
 
 describe('formatAssetAmount', () => {
   // Asset amounts are always scaled by 10^8 (COIN); a quantity of 1 is on-chain 100000000.
@@ -26,5 +26,37 @@ describe('formatAssetAmount', () => {
   it('clamps out-of-range divisions to 0..8', () => {
     expect(formatAssetAmount(100_000_000, 8)).toBe('1.00000000');
     expect(formatAssetAmount(100_000_000, -1)).toBe('1');
+  });
+});
+
+describe('parseAssetAmount', () => {
+  it('scales a whole number by 10^8', () => {
+    expect(parseAssetAmount('1', 0)).toBe(100_000_000n);
+    expect(parseAssetAmount('15', 0)).toBe(1_500_000_000n);
+  });
+
+  it('scales a decimal within the asset’s divisions', () => {
+    expect(parseAssetAmount('1.5', 8)).toBe(150_000_000n);
+    expect(parseAssetAmount('1.5', 2)).toBe(150_000_000n);
+    expect(parseAssetAmount('0.00000001', 8)).toBe(1n);
+  });
+
+  it('round-trips with formatAssetAmount', () => {
+    for (const [input, div] of [['1', 0], ['1.50', 2], ['0.00000001', 8]] as [string, number][]) {
+      expect(formatAssetAmount(Number(parseAssetAmount(input, div)), div)).toBe(input);
+    }
+  });
+
+  it('rejects more decimals than the asset allows', () => {
+    expect(() => parseAssetAmount('1.5', 0)).toThrow(/not divisible/);
+    expect(() => parseAssetAmount('1.123', 2)).toThrow(/at most 2 decimal/);
+  });
+
+  it('rejects malformed input and zero', () => {
+    expect(() => parseAssetAmount('', 8)).toThrow(/valid amount/);
+    expect(() => parseAssetAmount('abc', 8)).toThrow(/valid amount/);
+    expect(() => parseAssetAmount('-1', 8)).toThrow(/valid amount/);
+    expect(() => parseAssetAmount('0', 8)).toThrow(/greater than zero/);
+    expect(() => parseAssetAmount('0.00', 2)).toThrow(/greater than zero/);
   });
 });

--- a/src/services/wallet/AssetService.ts
+++ b/src/services/wallet/AssetService.ts
@@ -32,6 +32,28 @@ export function formatAssetAmount(sats: number, divisions: number): string {
 }
 
 /**
+ * Parse a user-entered asset amount into the on-chain integer (scaled by 10^8). Rejects a malformed
+ * number, or more decimal places than the asset's `divisions` allow (a 0-division asset must be a
+ * whole number). The inverse of formatAssetAmount.
+ */
+export function parseAssetAmount(input: string, divisions: number): bigint {
+  const units = Math.min(Math.max(divisions | 0, 0), 8);
+  const trimmed = input.trim();
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) throw new Error('Enter a valid amount');
+  const [whole, frac = ''] = trimmed.split('.');
+  if (frac.length > units) {
+    throw new Error(
+      units === 0
+        ? 'This asset is not divisible — enter a whole number'
+        : `This asset allows at most ${units} decimal place${units === 1 ? '' : 's'}`,
+    );
+  }
+  const amount = BigInt(whole) * 100_000_000n + BigInt(frac.padEnd(8, '0'));
+  if (amount <= 0n) throw new Error('Amount must be greater than zero');
+  return amount;
+}
+
+/**
  * Every asset held at `address`, sorted by name, each with its metadata (divisions, reissuable,
  * IPFS) and a formatted quantity. The base coin (AVN) is excluded — it is the ordinary balance.
  */


### PR DESCRIPTION
Phase 2 UI, completing Avian asset support (display -> send). Wires the mainnet-validated `sendAssetTransfer` (#70) to the dashboard.

**Per-row Send button** on each asset opens a dialog that:
- takes a recipient **legacy R-address** (bech32 rejected — assets are legacy-only),
- a **divisions-aware amount** with a Max button (0-division assets are whole-number only, via the new `parseAssetAmount`),
- **warns before sending an owner token** (`NAME!`) that it hands over administrative control,
- authenticates (requireAuth), sends through the connected Electrum, and shows the txid + explorer link; refreshes the asset list on success.

Tests: `parseAssetAmount` incl. round-trip with `formatAssetAmount`; full asset suite (16) green, typecheck clean, build passes. Bumps to 2.4.31.

Suggested first live test: a small transfer of a throwaway asset to yourself — the script bytes are already byte-identical to Core (golden vectors in #71), so this confirms the full in-app round-trip.