### PR TITLE
feat(assets): asset issuance engine — root + sub + unique (validated vs Core)

### DIFF
--- a/docs/proposals/avian-asset-issuance.md
+++ b/docs/proposals/avian-asset-issuance.md
@@ -1,0 +1,95 @@
+# Proposal: Avian asset issuance (create assets) in FlightDeck
+
+Status: draft · Builds on: docs/proposals/avian-assets.md (transfers, shipped)
+
+## 1. Goal
+
+Create new Avian assets from FlightDeck: **root** (`MYASSET`), **sub** (`MYASSET/SUB`), and **unique**
+(`MYASSET#tag`). Restricted (`$`), qualifier (`#…`), message-channel, and reissue are out of scope
+for now.
+
+Issuance is **irreversible and burns real AVN** (500 for a root asset), so this is the most
+safety-critical asset feature — every byte is validated against real Core transactions before it can
+be triggered from the UI.
+
+## 2. Facts confirmed from Avian Core (`c:\development\Avian`)
+
+**Burn cost + address** (`assets.cpp` GetIssue*BurnAmount / GetBurnAddress):
+
+| Type | Burns | Burn address (mainnet) |
+|---|---|---|
+| Root | 500 AVN | `RXissueAssetXXXXXXXXXXXXXXXXXhhZGt` |
+| Sub | 100 AVN | `RXissueSubAssetXXXXXXXXXXXXXWcwhwL` |
+| Unique | 5 AVN | `RXissueUniqueAssetXXXXXXXXXXWEAe58` |
+
+**New-asset script** = `P2PKH · OP_AVN_ASSET(0xc0) · push(payload) · OP_DROP`, value 0, where
+payload = `"rvn" · 'q'(0x71) · CNewAsset`. `CNewAsset` serialization (`assettypes.h`, exact — a
+mismatch builds an invalid asset):
+
+```
+compactSize(name) · name
+int64LE(amount)          // 10^8-scaled
+int8(units)              // 0..8 divisions
+int8(reissuable)         // 0 or 1
+int8(hasIPFS)            // 0 or 1
+  [ SerializeIPFSHash(ipfs) if hasIPFS==1 ]
+int8(hasANS)             // 0 or 1  ← easy to miss; always present
+  [ ansid if hasANS==1 ]
+```
+
+Verified byte-for-byte against the real FLIGHTDECK issuance: payload
+`rvnq · 0a "FLIGHTDECK" · 00e1f50500000000 · 00(units) · 01(reissuable) · 00(hasIPFS) · 00(hasANS)`.
+
+**Owner-token script** (`ConstructOwnerTransaction`) = `P2PKH · OP_AVN_ASSET · push("rvn" · 'o'(0x6f)
+· compactSize(name!) · name!) · OP_DROP`, value 0. The name carries the `!` and there is **no
+amount**. Verified against FLIGHTDECK's owner output (`rvno · 0b "FLIGHTDECK!"`).
+
+**Output ordering matters** (`asset_tx.cpp`): the **new-asset output must be LAST** and the **owner
+output second-to-last**. Burn and AVN change come before them.
+
+**Owner-token passthrough (sub/unique)** — to issue `PARENT/SUB` or `PARENT#tag` you must **own the
+`PARENT!` owner token**; the tx spends it as an input and returns it via a transfer output
+(`CAssetTransfer(PARENT!, 1·COIN)`), plus (for subs) mints a new `PARENT/SUB!` owner token.
+`OWNER_ASSET_AMOUNT = 1·COIN`, `OWNER_TAG = "!"`.
+
+**Name rules** (`assets.cpp`): max length 31 (30 for a root, less the type suffixes); uppercase
+`A–Z 0–9` and `_ . `; not starting/ending with punctuation; unique/sub/restricted have their own
+sub-rules. Full validation mirrors Core's `IsAssetNameValid`.
+
+## 3. Client architecture
+
+- **`assetScript.ts`** (extends the shipped, byte-validated module):
+  - `buildIssuanceScript(address, { name, amount, units, reissuable, ipfs? }) → Buffer` — the
+    `rvn·q` new-asset output. Golden-vector tested against FLIGHTDECK.
+  - `buildOwnerScript(address, rootName) → Buffer` — the `rvn·o` owner output. Golden-vector tested.
+  - `parseAssetScript` already reads `issue` (q) and `owner` (o).
+- **`WalletService.issueAsset(name, { amount, units, reissuable, ipfs? }, password, options)`** —
+  root issuance. Selects AVN UTXOs for `500·COIN + fee`, builds `[burn, AVN change, owner(2nd-last),
+  new-asset(last)]`, signs P2PKH inputs with FORKID, broadcasts. (Sub/unique add the parent-owner
+  input + passthrough — PR B.)
+- **Name availability**: before building, `electrum.getAssetMeta(name)` — if it returns data the name
+  is taken; issuance is refused. (Consensus still enforces this; the check is a friendly pre-flight.)
+
+## 4. Safety / UX
+
+- The Create-asset dialog states the **exact burn (500 AVN)** and that it is **permanent and
+  irreversible**, requires the name to pass validation + availability, and gates on authentication.
+- Reuses the existing auth flow; broadcasts through the connected Electrum (as the send flow does).
+- Owner token is explained: creating `MYASSET` also mints `MYASSET!`, which controls reissue.
+
+## 5. Proposed PR sequence
+
+1. **PR A — root issuance engine**: `buildIssuanceScript` + `buildOwnerScript` (golden-vector
+   validated against FLIGHTDECK), `issueAsset` builder, stub tests. No UI — mirrors how the transfer
+   builder (#70) landed before its UI (#73).
+2. **PR A2 — Create-asset UI**: a "Create asset" entry with name/amount/units/reissuable/IPFS,
+   availability check, and the burn confirmation.
+3. **PR B — sub + unique**: parent-owner passthrough + their builders/UI, validated against
+   real sub/unique golden vectors from Core.
+
+## 6. Open questions
+
+1. Golden vectors for **sub** and **unique** issuance (real Core tx hex) to pin their exact output
+   layout before PR B.
+2. IPFS support in v1, or defer (issue without IPFS first)?
+3. Where should "Create asset" live — a button on the Assets card header, or a menu entry?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.31",
+  "version": "2.4.32",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -32,7 +32,13 @@ import {
     type PsbtInputSummary,
     type PsbtOutputSummary,
 } from './psbt';
-import { buildAssetTransferScript } from './assetScript';
+import {
+    buildAssetTransferScript,
+    buildIssuanceScript,
+    buildOwnerScript,
+    isValidRootAssetName,
+    ISSUE_BURN,
+} from './assetScript';
 
 // How many transaction.get requests to keep in flight while syncing history. Electrum matches
 // responses by id, so a small pool cuts the latency of a large sync ~N-fold. Kept deliberately low:
@@ -1170,6 +1176,141 @@ export class WalletService {
             walletLogger.error('Asset transfer failed:', error);
             const message = error instanceof Error ? error.message : 'Unknown error';
             throw new Error(`Asset transfer failed: ${message}`);
+        }
+    }
+
+    /**
+     * Create (issue) a new root asset. This **burns 500 AVN** to an unspendable address and is
+     * irreversible. Builds `[burn, AVN change, owner token, new asset]` — the new-asset output must
+     * be last and the owner token second-to-last (Avian Core requires that ordering) — funds the
+     * burn + fee from AVN inputs, signs P2PKH inputs with the FORKID sighash, and broadcasts.
+     * Also mints the `NAME!` owner token (controls reissue) to the sender.
+     *
+     * The scripts are byte-validated against a real Core issuance (see assetScript.ts). Sub/unique
+     * issuance (which spends the parent owner token) is a separate method.
+     */
+    async issueAsset(
+        name: string,
+        params: { amount: bigint; units: number; reissuable: boolean },
+        password?: string,
+        options?: { feeRate?: number; changeAddress?: string },
+    ): Promise<string> {
+        try {
+            if (!isValidRootAssetName(name)) {
+                throw new Error(
+                    'Invalid asset name. Use 3–30 characters of A–Z, 0–9, _ and . (no leading, trailing or doubled punctuation).',
+                );
+            }
+            if (params.amount <= 0n) throw new Error('Issuance amount must be positive');
+            if (params.units < 0 || params.units > 8) throw new Error('Units must be between 0 and 8');
+
+            const activeWallet = await StorageService.getActiveWallet();
+            if (!activeWallet) throw new Error('No active wallet found');
+            if ((activeWallet.addressType || 'p2pkh') !== 'p2pkh') {
+                throw new Error('Assets can only be issued from a legacy (R…) address');
+            }
+
+            let privateKeyWIF = activeWallet.privateKey;
+            if (activeWallet.isEncrypted) {
+                if (!password) throw new Error('Password required for encrypted wallet');
+                try {
+                    const { decrypted } = await decryptData(privateKeyWIF, password);
+                    if (!decrypted) throw new Error('Invalid password');
+                    privateKeyWIF = decrypted;
+                } catch {
+                    throw new Error('Invalid password');
+                }
+            }
+
+            const keyPair = ECPair.fromWIF(privateKeyWIF, avianNetwork);
+            const pubkey = Buffer.from(keyPair.publicKey);
+            const fromAddress = activeWallet.address;
+            const changeAddress = options?.changeAddress?.trim() || fromAddress;
+
+            const burnAmount = Number(ISSUE_BURN.root.amount); // 500 AVN in sats
+            const burnScript = bitcoin.address.toOutputScript(ISSUE_BURN.root.address, avianNetwork);
+            const ownerScript = buildOwnerScript(fromAddress, name);
+            const assetScript = buildIssuanceScript(fromAddress, {
+                name,
+                amount: params.amount,
+                units: params.units,
+                reissuable: params.reissuable,
+            });
+
+            // Fund the burn + fee from AVN UTXOs (iterating on the selected input count).
+            const satPerVByte = await this.resolveFeeRate(options?.feeRate);
+            const avnUTXOs = await this.electrum.getUTXOs(fromAddress);
+            const sortedAvn = [...avnUTXOs].sort((a, b) => b.value - a.value);
+            const totalAvn = sortedAvn.reduce((sum, utxo) => sum + utxo.value, 0);
+
+            // Outputs: burn (34) + AVN change (34) + owner + new asset.
+            const fixedOutputsVBytes =
+                34 + 34 + (8 + 1 + ownerScript.length) + (8 + 1 + assetScript.length);
+            const sizeFor = (inputCount: number) => 10 + inputCount * 148 + fixedOutputsVBytes;
+
+            let selectedAvn: typeof avnUTXOs = [];
+            let avnIn = 0;
+            let fee = 0;
+            for (let iteration = 0; iteration < 6; iteration++) {
+                fee = Math.ceil(sizeFor(Math.max(selectedAvn.length, 1)) * satPerVByte);
+                const target = burnAmount + fee;
+                if (totalAvn < target) {
+                    throw new Error(
+                        `Insufficient AVN: issuing "${name}" burns 500 AVN plus a network fee.`,
+                    );
+                }
+                selectedAvn = [];
+                avnIn = 0;
+                for (const utxo of sortedAvn) {
+                    if (avnIn >= target) break;
+                    selectedAvn.push(utxo);
+                    avnIn += utxo.value;
+                }
+                const recomputed = Math.ceil(sizeFor(selectedAvn.length) * satPerVByte);
+                if (avnIn >= burnAmount + recomputed && recomputed <= fee) {
+                    fee = recomputed;
+                    break;
+                }
+                fee = recomputed;
+            }
+            if (avnIn < burnAmount + fee) throw new Error('Insufficient AVN for the burn and fee');
+            const change = avnIn - burnAmount - fee;
+            const finalChange = change >= DUST_THRESHOLD_SATS ? change : 0;
+
+            // Build: burn, [AVN change], owner (second-to-last), new asset (last).
+            const tx = new bitcoin.Transaction();
+            tx.version = 2;
+            tx.locktime = 0;
+            for (const utxo of selectedAvn) {
+                tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
+            }
+            tx.addOutput(burnScript, burnAmount);
+            if (finalChange > 0) {
+                tx.addOutput(bitcoin.address.toOutputScript(changeAddress, avianNetwork), finalChange);
+            }
+            tx.addOutput(ownerScript, 0);
+            tx.addOutput(assetScript, 0);
+
+            for (let i = 0; i < selectedAvn.length; i++) {
+                const utxo = selectedAvn[i];
+                const prevTxHex = await this.electrum.getTransaction(utxo.txid, false);
+                const prevOut = bitcoin.Transaction.fromHex(prevTxHex).outs[utxo.vout];
+                const digest = tx.hashForSignature(i, prevOut.script, SIGHASH_ALL_FORKID);
+                const derSignature = this.encodeDERWithCustomHashType(
+                    Buffer.from(keyPair.sign(digest)),
+                    SIGHASH_ALL_FORKID,
+                );
+                tx.ins[i].script = bitcoin.script.compile([derSignature, pubkey]);
+            }
+
+            const txHex = tx.toHex();
+            const txId = tx.getId();
+            await this.broadcastRawTransaction(txHex);
+            return txId;
+        } catch (error) {
+            walletLogger.error('Asset issuance failed:', error);
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Asset issuance failed: ${message}`);
         }
     }
 

--- a/src/services/wallet/assetIssuance.test.ts
+++ b/src/services/wallet/assetIssuance.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as bitcoin from 'bitcoinjs-lib';
+import { ECPairFactory } from 'ecpair';
+import * as ecc from 'tiny-secp256k1';
+
+import { WalletService, avianNetwork, deriveAddress, secureEncrypt } from './WalletService';
+import { parseAssetScript, ISSUE_BURN } from './assetScript';
+import { StorageService } from '@/services/core/StorageService';
+import { TEST_PASSWORD, resetStorage } from '@/test/helpers';
+
+/**
+ * Root asset issuance against a stubbed network. Invariants (regtest/mainnet golden-vector confirmed
+ * separately): 500 AVN is burned to the issuance burn address, the new-asset output is LAST and the
+ * owner token second-to-last (Core requires that order), AVN conservation holds, and every input is
+ * FORKID-signed. Nothing is broadcast for real.
+ */
+
+const ECPair = ECPairFactory(ecc);
+const SIGHASH_ALL_FORKID = 0x41;
+const COIN = 100_000_000;
+const BURN_ADDRESS = ISSUE_BURN.root.address;
+
+function avnFundingTx(owner: string, value: number, seed: number) {
+  const tx = new bitcoin.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, seed), 0);
+  tx.addOutput(bitcoin.address.toOutputScript(owner, avianNetwork), value);
+  return { hex: tx.toHex(), txid: tx.getId() };
+}
+
+function createElectrum(owner: string, avnValues: number[]) {
+  const txs = new Map<string, string>();
+  const avnUtxos = avnValues.map((value, i) => {
+    const f = avnFundingTx(owner, value, i + 1);
+    txs.set(f.txid, f.hex);
+    return { txid: f.txid, vout: 0, value, height: 100 };
+  });
+  const broadcast = vi.fn(async (hex: string) => bitcoin.Transaction.fromHex(hex).getId());
+  return {
+    broadcast,
+    electrum: {
+      getUTXOs: vi.fn(async () => avnUtxos),
+      getTransaction: vi.fn(async (txid: string) => txs.get(txid)),
+      broadcastTransaction: broadcast,
+      getFeeRateSatPerVByte: vi.fn(async () => 0),
+      isConnectedToServer: vi.fn(() => true),
+    },
+  };
+}
+
+async function createActiveWallet() {
+  const keyPair = ECPair.makeRandom({ network: avianNetwork });
+  const address = deriveAddress(Buffer.from(keyPair.publicKey), 'p2pkh');
+  await StorageService.createWallet({
+    name: 'Issuer',
+    address,
+    privateKey: await secureEncrypt(keyPair.toWIF(), TEST_PASSWORD),
+    isEncrypted: true,
+    addressType: 'p2pkh',
+  });
+  return { address, keyPair };
+}
+
+beforeEach(() => {
+  resetStorage();
+});
+
+describe('issueAsset (root)', () => {
+  it('burns 500 AVN and lays out owner (2nd-last) then new asset (last)', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createElectrum(address, [600 * COIN]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.issueAsset(
+      'MYASSET',
+      { amount: 1000n * BigInt(COIN), units: 0, reissuable: true },
+      TEST_PASSWORD,
+      { feeRate: 1 },
+    );
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    const outs = tx.outs;
+
+    // Last output is the new asset; second-to-last is the owner token.
+    const assetOut = parseAssetScript(outs[outs.length - 1].script as Buffer);
+    const ownerOut = parseAssetScript(outs[outs.length - 2].script as Buffer);
+    expect(assetOut).toMatchObject({ type: 'issue', name: 'MYASSET', amount: 1000n * BigInt(COIN) });
+    expect(outs[outs.length - 1].value).toBe(0);
+    expect(ownerOut).toMatchObject({ type: 'owner', name: 'MYASSET!', amount: null });
+    expect(outs[outs.length - 2].value).toBe(0);
+
+    // A 500-AVN burn to the issuance burn address exists.
+    const burn = outs.find(
+      (o) => o.value === 500 * COIN &&
+        (() => {
+          try {
+            return bitcoin.address.fromOutputScript(o.script, avianNetwork) === BURN_ADDRESS;
+          } catch {
+            return false;
+          }
+        })(),
+    );
+    expect(burn).toBeDefined();
+  });
+
+  it('conserves AVN: input = burn + change + fee, never underpaying', async () => {
+    const { address } = await createActiveWallet();
+    const avnValue = 600 * COIN;
+    const { electrum, broadcast } = createElectrum(address, [avnValue]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.issueAsset(
+      'MYASSET',
+      { amount: 1n * BigInt(COIN), units: 0, reissuable: false },
+      TEST_PASSWORD,
+      { feeRate: 1 },
+    );
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    // AVN out = burn + change (asset/owner outputs are 0).
+    const avnOut = tx.outs.reduce((s, o) => s + o.value, 0);
+    const fee = avnValue - avnOut;
+    expect(fee).toBeGreaterThan(0);
+    expect(fee).toBeGreaterThanOrEqual(tx.virtualSize());
+  });
+
+  it('signs every input with the FORKID sighash', async () => {
+    const { address, keyPair } = await createActiveWallet();
+    const { electrum, broadcast } = createElectrum(address, [600 * COIN]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.issueAsset(
+      'MYASSET',
+      { amount: 1n * BigInt(COIN), units: 0, reissuable: true },
+      TEST_PASSWORD,
+      { feeRate: 1 },
+    );
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    for (const input of tx.ins) {
+      const [signature, pubkey] = bitcoin.script.decompile(input.script) as Buffer[];
+      expect(signature[signature.length - 1]).toBe(SIGHASH_ALL_FORKID);
+      expect(Buffer.from(pubkey).toString('hex')).toBe(Buffer.from(keyPair.publicKey).toString('hex'));
+    }
+  });
+
+  it('refuses an invalid asset name', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createElectrum(address, [600 * COIN]);
+    const wallet = new WalletService(electrum as never);
+
+    await expect(
+      wallet.issueAsset('my asset!', { amount: 1n * BigInt(COIN), units: 0, reissuable: true }, TEST_PASSWORD),
+    ).rejects.toThrow(/Invalid asset name/);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it('refuses when AVN cannot cover the 500-AVN burn plus fee', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createElectrum(address, [100 * COIN]); // < 500 AVN
+    const wallet = new WalletService(electrum as never);
+
+    await expect(
+      wallet.issueAsset('MYASSET', { amount: 1n * BigInt(COIN), units: 0, reissuable: true }, TEST_PASSWORD, {
+        feeRate: 1,
+      }),
+    ).rejects.toThrow(/burns 500 AVN/);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/wallet/assetScript.test.ts
+++ b/src/services/wallet/assetScript.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest';
 import * as bitcoin from 'bitcoinjs-lib';
 
 import { avianNetwork } from './WalletService';
-import { buildAssetTransferScript, parseAssetScript, ASSET_MARKER } from './assetScript';
+import {
+  buildAssetTransferScript,
+  buildIssuanceScript,
+  buildOwnerScript,
+  parseAssetScript,
+  ASSET_MARKER,
+} from './assetScript';
 import { isAssetScript, OP_AVN_ASSET } from './psbt';
 
 /**
@@ -122,6 +128,21 @@ describe('real mainnet Core golden vectors', () => {
       name: 'FLIGHTDECK',
       amount: 100_000_000n, // qty 1, scaled by 10^8
     });
+  });
+
+  it('builds an owner-token output byte-identical to Core’s FLIGHTDECK owner output', () => {
+    expect(buildOwnerScript(OWNER, 'FLIGHTDECK').toString('hex')).toBe(ownerScript.toString('hex'));
+  });
+
+  it('builds a new-asset output byte-identical to Core’s FLIGHTDECK issuance', () => {
+    // FLIGHTDECK was issued with 1 unit, 0 divisions, reissuable, no IPFS/ANS.
+    const built = buildIssuanceScript(OWNER, {
+      name: 'FLIGHTDECK',
+      amount: 100_000_000n,
+      units: 0,
+      reissuable: true,
+    });
+    expect(built.toString('hex')).toBe(issueScript.toString('hex'));
   });
 
   it('builds a transfer whose name+amount bytes match Core’s real encoding', () => {

--- a/src/services/wallet/assetScript.ts
+++ b/src/services/wallet/assetScript.ts
@@ -61,6 +61,26 @@ function readCompactSize(buf: Buffer, offset: number): { value: number; size: nu
   return { value: Number(buf.readBigUInt64LE(offset + 1)), size: 9 };
 }
 
+/** The 25-byte P2PKH output script for a legacy R-address. Throws on bech32 — assets are legacy-only. */
+function legacyP2PKHScript(address: string): Buffer {
+  const p2pkh = bitcoin.address.toOutputScript(address, avianNetwork);
+  if (p2pkh.length !== 25 || p2pkh[0] !== bitcoin.opcodes.OP_DUP) {
+    throw new Error('Assets require a legacy P2PKH (R…) address — not a bech32 (avn1…) address');
+  }
+  return p2pkh;
+}
+
+/** Wrap an asset payload as `<P2PKH> OP_AVN_ASSET <push payload> OP_DROP`. */
+function wrapAssetScript(p2pkh: Buffer, payload: Buffer): Buffer {
+  return Buffer.concat([p2pkh, bitcoin.script.compile([OP_AVN_ASSET, payload, bitcoin.opcodes.OP_DROP])]);
+}
+
+function int64LE(value: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigInt64LE(value);
+  return b;
+}
+
 /**
  * Build a transfer output that pays `amount` (integer units) of `name` to `address`. The address
  * must be a legacy P2PKH (`R…`) — assets never live on bech32. Throws on a non-P2PKH address or a
@@ -68,24 +88,83 @@ function readCompactSize(buf: Buffer, offset: number): { value: number; size: nu
  */
 export function buildAssetTransferScript(address: string, name: string, amount: bigint): Buffer {
   if (amount <= 0n) throw new Error('Asset transfer amount must be positive');
-  const p2pkh = bitcoin.address.toOutputScript(address, avianNetwork);
-  if (p2pkh.length !== 25 || p2pkh[0] !== bitcoin.opcodes.OP_DUP) {
-    throw new Error('Asset transfers require a legacy P2PKH (R…) address');
-  }
   const nameBuf = Buffer.from(name, 'ascii');
-  const amountBuf = Buffer.alloc(8);
-  amountBuf.writeBigInt64LE(amount);
-
   const payload = Buffer.concat([
     ASSET_MARKER,
     Buffer.from([ASSET_TYPE.transfer]),
     encodeCompactSize(nameBuf.length),
     nameBuf,
-    amountBuf,
+    int64LE(amount),
   ]);
+  return wrapAssetScript(legacyP2PKHScript(address), payload);
+}
 
-  const tag = bitcoin.script.compile([OP_AVN_ASSET, payload, bitcoin.opcodes.OP_DROP]);
-  return Buffer.concat([p2pkh, tag]);
+// Issuance burn cost + mainnet burn address per type (Avian Core assets.cpp). Creating an asset
+// sends this AVN to an unspendable burn address — it is permanently destroyed.
+export const ISSUE_BURN = {
+  root: { amount: 500n * 100_000_000n, address: 'RXissueAssetXXXXXXXXXXXXXXXXXhhZGt' },
+  sub: { amount: 100n * 100_000_000n, address: 'RXissueSubAssetXXXXXXXXXXXXXWcwhwL' },
+  unique: { amount: 5n * 100_000_000n, address: 'RXissueUniqueAssetXXXXXXXXXXWEAe58' },
+} as const;
+
+/**
+ * Whether `name` is a valid root asset name (a friendly pre-flight; consensus is authoritative).
+ * Core: 3–30 of A–Z 0–9 `_` `.`, no leading/trailing or doubled punctuation.
+ */
+export function isValidRootAssetName(name: string): boolean {
+  if (name.length < 3 || name.length > 30) return false;
+  if (!/^[A-Z0-9._]+$/.test(name)) return false;
+  if (/^[._]|[._]$/.test(name)) return false;
+  if (/[._]{2}/.test(name)) return false;
+  return true;
+}
+
+export interface IssuanceParams {
+  name: string;
+  /** Total supply in integer units (10^8-scaled), e.g. 1 whole unit = 100000000. */
+  amount: bigint;
+  /** Divisibility 0–8. */
+  units: number;
+  reissuable: boolean;
+}
+
+/**
+ * Build a new-asset issuance output (`rvn·q · CNewAsset`) paying the created supply to `address`.
+ * IPFS/ANS are not carried (both flags 0) — deferred. Byte-exact to Avian Core `CNewAsset`.
+ */
+export function buildIssuanceScript(address: string, params: IssuanceParams): Buffer {
+  const { name, amount, units, reissuable } = params;
+  if (amount <= 0n) throw new Error('Issuance amount must be positive');
+  if (units < 0 || units > 8) throw new Error('Units must be between 0 and 8');
+  const nameBuf = Buffer.from(name, 'ascii');
+  const payload = Buffer.concat([
+    ASSET_MARKER,
+    Buffer.from([ASSET_TYPE.issue]),
+    encodeCompactSize(nameBuf.length),
+    nameBuf,
+    int64LE(amount),
+    Buffer.from([units & 0xff]),
+    Buffer.from([reissuable ? 1 : 0]),
+    Buffer.from([0]), // hasIPFS = 0 (IPFS deferred)
+    Buffer.from([0]), // hasANS = 0
+  ]);
+  return wrapAssetScript(legacyP2PKHScript(address), payload);
+}
+
+/**
+ * Build the owner-token output (`rvn·o`) for an issuance. `assetName` is the asset being created
+ * (root or sub); the token name carries the trailing `!` and no amount. Byte-exact to Core's
+ * ConstructOwnerTransaction.
+ */
+export function buildOwnerScript(address: string, assetName: string): Buffer {
+  const nameBuf = Buffer.from(`${assetName}!`, 'ascii');
+  const payload = Buffer.concat([
+    ASSET_MARKER,
+    Buffer.from([ASSET_TYPE.owner]),
+    encodeCompactSize(nameBuf.length),
+    nameBuf,
+  ]);
+  return wrapAssetScript(legacyP2PKHScript(address), payload);
 }
 
 /** Decode an asset output script into its type, address, name and amount (null if not an asset). */


### PR DESCRIPTION
PR A of asset issuance (design doc: `docs/proposals/avian-asset-issuance.md`). Creates a new **root asset** — **engine only, no UI**, so it's not user-reachable yet (mirrors how the transfer builder #70 preceded its UI #73).

Issuance **burns 500 AVN irreversibly**, so every script byte is validated **byte-for-byte against your real FLIGHTDECK issuance**:
- `buildIssuanceScript` — the `rvn·q` new-asset output (`CNewAsset`: name, amount, units, reissuable, hasIPFS, **hasANS** — the trailing byte that's easy to miss). Byte-identical to Core.
- `buildOwnerScript` — the `rvn·o` owner token (`NAME!`, no amount). Byte-identical to Core.
- `ISSUE_BURN` (root 500 / sub 100 / unique 5 AVN + mainnet burn addresses), `isValidRootAssetName`.
- `WalletService.issueAsset` — funds burn + fee from AVN, builds `[burn, AVN change, owner (2nd-last), new asset (last)]` in Core's required order, FORKID-signs, broadcasts; mints `NAME!` to the sender.

Deferred: IPFS/ANS, and sub/unique (they spend the parent owner token — separate PR needing their golden vectors).

Tests: 2 byte-identical Core golden vectors + 5 issuance invariants (burn amount/address, owner-2nd-last / asset-last ordering, AVN conservation without underpaying, FORKID signing, name/funds refusals). 19 asset tests green, build passes. Bumps to 2.4.32.

Next: **PR A2** — the Create-asset UI (with the 500 AVN burn confirmation + name-availability check), which will also fix the sent-asset-lingers-until-refresh todo.