### PR TITLE
feat(assets): sub + unique issuance engine (missed in #74 merge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.32",
+  "version": "2.4.33",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -1314,6 +1314,197 @@ export class WalletService {
         }
     }
 
+    /**
+     * Issue a sub-asset (`PARENT/SUB`, burns 100 AVN). Requires owning the `PARENT!` owner token.
+     */
+    async issueSubAsset(
+        subName: string,
+        params: { amount: bigint; units: number; reissuable: boolean },
+        password?: string,
+        options?: { feeRate?: number; changeAddress?: string },
+    ): Promise<string> {
+        const slash = subName.lastIndexOf('/');
+        if (slash <= 0) throw new Error('A sub-asset name must be PARENT/CHILD');
+        return this.issueChildAsset({
+            childName: subName,
+            parentName: subName.slice(0, slash),
+            amount: params.amount,
+            units: params.units,
+            reissuable: params.reissuable,
+            burnAmount: ISSUE_BURN.sub.amount,
+            burnAddress: ISSUE_BURN.sub.address,
+            password,
+            options,
+        });
+    }
+
+    /**
+     * Issue a unique asset (`PARENT#tag`, burns 5 AVN). Always quantity 1, 0 divisions,
+     * non-reissuable. Requires owning the `PARENT!` owner token.
+     */
+    async issueUniqueAsset(
+        uniqueName: string,
+        password?: string,
+        options?: { feeRate?: number; changeAddress?: string },
+    ): Promise<string> {
+        const hash = uniqueName.indexOf('#');
+        if (hash <= 0) throw new Error('A unique asset name must be PARENT#tag');
+        return this.issueChildAsset({
+            childName: uniqueName,
+            parentName: uniqueName.slice(0, hash),
+            amount: 100_000_000n, // exactly 1 unit
+            units: 0,
+            reissuable: false,
+            burnAmount: ISSUE_BURN.unique.amount,
+            burnAddress: ISSUE_BURN.unique.address,
+            password,
+            options,
+        });
+    }
+
+    /**
+     * Shared engine for sub/unique issuance. Spends the `PARENT!` owner token (returning it to
+     * ourselves), burns the type's fee, and creates the child asset + its `CHILD!` owner token.
+     * Output order matches Core: burn, AVN change, parent-owner transfer, new owner (2nd-last),
+     * new asset (last). Validated byte-for-byte against real Core sub and unique issuances.
+     */
+    private async issueChildAsset(opts: {
+        childName: string;
+        parentName: string;
+        amount: bigint;
+        units: number;
+        reissuable: boolean;
+        burnAmount: bigint;
+        burnAddress: string;
+        password?: string;
+        options?: { feeRate?: number; changeAddress?: string };
+    }): Promise<string> {
+        try {
+            const { childName, parentName, amount, units, reissuable, burnAmount, burnAddress } = opts;
+            if (amount <= 0n) throw new Error('Issuance amount must be positive');
+            if (units < 0 || units > 8) throw new Error('Units must be between 0 and 8');
+
+            const activeWallet = await StorageService.getActiveWallet();
+            if (!activeWallet) throw new Error('No active wallet found');
+            if ((activeWallet.addressType || 'p2pkh') !== 'p2pkh') {
+                throw new Error('Assets can only be issued from a legacy (R…) address');
+            }
+
+            let privateKeyWIF = activeWallet.privateKey;
+            if (activeWallet.isEncrypted) {
+                if (!opts.password) throw new Error('Password required for encrypted wallet');
+                try {
+                    const { decrypted } = await decryptData(privateKeyWIF, opts.password);
+                    if (!decrypted) throw new Error('Invalid password');
+                    privateKeyWIF = decrypted;
+                } catch {
+                    throw new Error('Invalid password');
+                }
+            }
+
+            const keyPair = ECPair.fromWIF(privateKeyWIF, avianNetwork);
+            const pubkey = Buffer.from(keyPair.publicKey);
+            const fromAddress = activeWallet.address;
+            const changeAddress = opts.options?.changeAddress?.trim() || fromAddress;
+
+            // The PARENT! owner token must be held; it is spent and returned.
+            const ownerName = `${parentName}!`;
+            const ownerUTXOs = await this.electrum.getAssetUTXOs(fromAddress, ownerName);
+            if (ownerUTXOs.length === 0) {
+                throw new Error(`You must own the ${ownerName} owner token to create ${childName}`);
+            }
+            const ownerUTXO = ownerUTXOs[0];
+            const ownerAmount = BigInt(Math.trunc(ownerUTXO.value)); // 1 unit
+
+            const burnScript = bitcoin.address.toOutputScript(burnAddress, avianNetwork);
+            const parentReturnScript = buildAssetTransferScript(changeAddress, ownerName, ownerAmount);
+            const newOwnerScript = buildOwnerScript(fromAddress, childName);
+            const newAssetScript = buildIssuanceScript(fromAddress, { name: childName, amount, units, reissuable });
+
+            const burn = Number(burnAmount);
+            const satPerVByte = await this.resolveFeeRate(opts.options?.feeRate);
+            const avnUTXOs = await this.electrum.getUTXOs(fromAddress);
+            const sortedAvn = [...avnUTXOs].sort((a, b) => b.value - a.value);
+            const totalAvn = sortedAvn.reduce((sum, utxo) => sum + utxo.value, 0);
+
+            // Outputs: burn(34) + change(34) + parentReturn + newOwner + newAsset. One owner input is
+            // always present, plus the AVN fee inputs.
+            const fixedOutputsVBytes =
+                34 + 34 +
+                (8 + 1 + parentReturnScript.length) +
+                (8 + 1 + newOwnerScript.length) +
+                (8 + 1 + newAssetScript.length);
+            const sizeFor = (avnInputCount: number) =>
+                10 + (1 + avnInputCount) * 148 + fixedOutputsVBytes;
+
+            let selectedAvn: typeof avnUTXOs = [];
+            let avnIn = 0;
+            let fee = 0;
+            for (let iteration = 0; iteration < 6; iteration++) {
+                fee = Math.ceil(sizeFor(Math.max(selectedAvn.length, 1)) * satPerVByte);
+                const target = burn + fee;
+                if (totalAvn < target) {
+                    throw new Error(
+                        `Insufficient AVN: creating ${childName} burns ${Number(burnAmount) / 1e8} AVN plus a network fee.`,
+                    );
+                }
+                selectedAvn = [];
+                avnIn = 0;
+                for (const utxo of sortedAvn) {
+                    if (avnIn >= target) break;
+                    selectedAvn.push(utxo);
+                    avnIn += utxo.value;
+                }
+                const recomputed = Math.ceil(sizeFor(selectedAvn.length) * satPerVByte);
+                if (avnIn >= burn + recomputed && recomputed <= fee) {
+                    fee = recomputed;
+                    break;
+                }
+                fee = recomputed;
+            }
+            if (avnIn < burn + fee) throw new Error('Insufficient AVN for the burn and fee');
+            const change = avnIn - burn - fee;
+            const finalChange = change >= DUST_THRESHOLD_SATS ? change : 0;
+
+            const tx = new bitcoin.Transaction();
+            tx.version = 2;
+            tx.locktime = 0;
+            // Inputs: the parent owner token first, then AVN fee inputs.
+            const allInputs = [ownerUTXO, ...selectedAvn];
+            for (const utxo of allInputs) {
+                tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
+            }
+            tx.addOutput(burnScript, burn);
+            if (finalChange > 0) {
+                tx.addOutput(bitcoin.address.toOutputScript(changeAddress, avianNetwork), finalChange);
+            }
+            tx.addOutput(parentReturnScript, 0);
+            tx.addOutput(newOwnerScript, 0);
+            tx.addOutput(newAssetScript, 0);
+
+            for (let i = 0; i < allInputs.length; i++) {
+                const utxo = allInputs[i];
+                const prevTxHex = await this.electrum.getTransaction(utxo.txid, false);
+                const prevOut = bitcoin.Transaction.fromHex(prevTxHex).outs[utxo.vout];
+                const digest = tx.hashForSignature(i, prevOut.script, SIGHASH_ALL_FORKID);
+                const derSignature = this.encodeDERWithCustomHashType(
+                    Buffer.from(keyPair.sign(digest)),
+                    SIGHASH_ALL_FORKID,
+                );
+                tx.ins[i].script = bitcoin.script.compile([derSignature, pubkey]);
+            }
+
+            const txHex = tx.toHex();
+            const txId = tx.getId();
+            await this.broadcastRawTransaction(txHex);
+            return txId;
+        } catch (error) {
+            walletLogger.error('Child asset issuance failed:', error);
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Asset issuance failed: ${message}`);
+        }
+    }
+
     async sendTransaction(
         toAddress: string,
         amount: number,

--- a/src/services/wallet/assetIssuance.test.ts
+++ b/src/services/wallet/assetIssuance.test.ts
@@ -4,7 +4,7 @@ import { ECPairFactory } from 'ecpair';
 import * as ecc from 'tiny-secp256k1';
 
 import { WalletService, avianNetwork, deriveAddress, secureEncrypt } from './WalletService';
-import { parseAssetScript, ISSUE_BURN } from './assetScript';
+import { buildOwnerScript, parseAssetScript, ISSUE_BURN } from './assetScript';
 import { StorageService } from '@/services/core/StorageService';
 import { TEST_PASSWORD, resetStorage } from '@/test/helpers';
 
@@ -166,5 +166,135 @@ describe('issueAsset (root)', () => {
       }),
     ).rejects.toThrow(/burns 500 AVN/);
     expect(broadcast).not.toHaveBeenCalled();
+  });
+});
+
+/** A prevtx whose output[0] is the `PARENT!` owner token (an asset script) paying the owner. */
+function ownerFundingTx(owner: string, parentName: string, seed: number) {
+  const tx = new bitcoin.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, seed), 0);
+  tx.addOutput(buildOwnerScript(owner, parentName), 0);
+  return { hex: tx.toHex(), txid: tx.getId() };
+}
+
+/** Electrum stub with a parent owner-token UTXO plus AVN UTXOs. */
+function createChildElectrum(owner: string, parentName: string, avnValues: number[], hasOwner = true) {
+  const txs = new Map<string, string>();
+  const ownerName = `${parentName}!`;
+  const ownerUtxos: { txid: string; vout: number; value: number; height: number; asset: string }[] = [];
+  if (hasOwner) {
+    const f = ownerFundingTx(owner, parentName, 200);
+    txs.set(f.txid, f.hex);
+    ownerUtxos.push({ txid: f.txid, vout: 0, value: COIN, height: 100, asset: ownerName });
+  }
+  const avnUtxos = avnValues.map((value, i) => {
+    const f = avnFundingTx(owner, value, i + 1);
+    txs.set(f.txid, f.hex);
+    return { txid: f.txid, vout: 0, value, height: 100 };
+  });
+  const broadcast = vi.fn(async (hex: string) => bitcoin.Transaction.fromHex(hex).getId());
+  return {
+    broadcast,
+    electrum: {
+      getAssetUTXOs: vi.fn(async (_a: string, name: string) => (name === ownerName ? ownerUtxos : [])),
+      getUTXOs: vi.fn(async () => avnUtxos),
+      getTransaction: vi.fn(async (txid: string) => txs.get(txid)),
+      broadcastTransaction: broadcast,
+      getFeeRateSatPerVByte: vi.fn(async () => 0),
+      isConnectedToServer: vi.fn(() => true),
+    },
+  };
+}
+
+describe('issueUniqueAsset', () => {
+  it('spends the parent owner token, burns 5 AVN, and lays out the unique correctly', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createChildElectrum(address, 'MYASSET', [10 * COIN]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.issueUniqueAsset('MYASSET#001', TEST_PASSWORD, { feeRate: 1 });
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    const outs = tx.outs;
+    // 5-AVN burn to the unique burn address.
+    expect(
+      outs.some(
+        (o) => o.value === 5 * COIN &&
+          (() => {
+            try {
+              return bitcoin.address.fromOutputScript(o.script, avianNetwork) === ISSUE_BURN.unique.address;
+            } catch {
+              return false;
+            }
+          })(),
+      ),
+    ).toBe(true);
+    // Parent owner returned, then new owner (2nd-last), new asset (last).
+    expect(parseAssetScript(outs[outs.length - 3].script as Buffer)).toMatchObject({
+      type: 'transfer',
+      name: 'MYASSET!',
+    });
+    expect(parseAssetScript(outs[outs.length - 2].script as Buffer)).toMatchObject({
+      type: 'owner',
+      name: 'MYASSET#001!',
+    });
+    expect(parseAssetScript(outs[outs.length - 1].script as Buffer)).toMatchObject({
+      type: 'issue',
+      name: 'MYASSET#001',
+      amount: 1n * BigInt(COIN),
+    });
+    // First input is the parent owner token.
+    expect(tx.ins.length).toBe(2); // owner + one AVN
+  });
+
+  it('refuses when the parent owner token is not held', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createChildElectrum(address, 'MYASSET', [10 * COIN], false);
+    const wallet = new WalletService(electrum as never);
+
+    await expect(wallet.issueUniqueAsset('MYASSET#001', TEST_PASSWORD, { feeRate: 1 })).rejects.toThrow(
+      /MYASSET! owner token/,
+    );
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+});
+
+describe('issueSubAsset', () => {
+  it('spends the parent owner token, burns 100 AVN, and creates the sub + its owner', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createChildElectrum(address, 'MYASSET', [200 * COIN]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.issueSubAsset(
+      'MYASSET/SUB',
+      { amount: 1000n * BigInt(COIN), units: 2, reissuable: true },
+      TEST_PASSWORD,
+      { feeRate: 1 },
+    );
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    const outs = tx.outs;
+    expect(
+      outs.some(
+        (o) => o.value === 100 * COIN &&
+          (() => {
+            try {
+              return bitcoin.address.fromOutputScript(o.script, avianNetwork) === ISSUE_BURN.sub.address;
+            } catch {
+              return false;
+            }
+          })(),
+      ),
+    ).toBe(true);
+    expect(parseAssetScript(outs[outs.length - 2].script as Buffer)).toMatchObject({
+      type: 'owner',
+      name: 'MYASSET/SUB!',
+    });
+    expect(parseAssetScript(outs[outs.length - 1].script as Buffer)).toMatchObject({
+      type: 'issue',
+      name: 'MYASSET/SUB',
+      amount: 1000n * BigInt(COIN),
+    });
   });
 });

--- a/src/services/wallet/assetScript.test.ts
+++ b/src/services/wallet/assetScript.test.ts
@@ -173,4 +173,48 @@ describe('real mainnet Core golden vectors', () => {
       realTransfer,
     );
   });
+
+  // Real Core sub/unique issuances share one structure: parent-owner transfer (rvn·t), new owner
+  // (rvn·o), new asset (rvn·q). These pin all three builders against Core for both types at once.
+  it('reproduces a real Core UNIQUE issuance (FLIGHTDECK#TEST) byte-for-byte', () => {
+    const PARENT_OWNER_DEST = 'RGAFrTpnpPWtT1UBxuxzuB8xMg9mxiq8Ah';
+    const UNIQUE_DEST = 'RV3Tjt8ZLnuahSL9QjTtVxLKBR7CQCfv49';
+    expect(buildAssetTransferScript(PARENT_OWNER_DEST, 'FLIGHTDECK!', 100_000_000n).toString('hex')).toBe(
+      '76a9144b791eb36f35affad78c1ef45461da116e91d77988acc01872766e740b464c494748544445434b2100e1f5050000000075',
+    );
+    expect(buildOwnerScript(UNIQUE_DEST, 'FLIGHTDECK#TEST').toString('hex')).toBe(
+      '76a914d8c9c40901617159d1ad92822da95f7ce4ca262988acc01572766e6f10464c494748544445434b23544553542175',
+    );
+    expect(
+      buildIssuanceScript(UNIQUE_DEST, {
+        name: 'FLIGHTDECK#TEST',
+        amount: 100_000_000n,
+        units: 0,
+        reissuable: false, // uniques are non-reissuable
+      }).toString('hex'),
+    ).toBe(
+      '76a914d8c9c40901617159d1ad92822da95f7ce4ca262988acc02072766e710f464c494748544445434b235445535400e1f505000000000000000075',
+    );
+  });
+
+  it('reproduces a real Core SUB issuance (FLIGHTDECK/TEST) byte-for-byte', () => {
+    const PARENT_OWNER_DEST = 'RQJ2bz6D998ex9fgwjEvCRH9dYHX3W84a7';
+    const SUB_DEST = 'RLujp8qVJ9upSyDNU9TL8nv3mNQW82MDAm';
+    expect(buildAssetTransferScript(PARENT_OWNER_DEST, 'FLIGHTDECK!', 100_000_000n).toString('hex')).toBe(
+      '76a914a4b264c6f967c76dfdef657a8f6cfbf677e9fb1f88acc01872766e740b464c494748544445434b2100e1f5050000000075',
+    );
+    expect(buildOwnerScript(SUB_DEST, 'FLIGHTDECK/TEST').toString('hex')).toBe(
+      '76a9147f92d9617eeb5fc717eb8d3c431b237f0caad14a88acc01572766e6f10464c494748544445434b2f544553542175',
+    );
+    expect(
+      buildIssuanceScript(SUB_DEST, {
+        name: 'FLIGHTDECK/TEST',
+        amount: 100_000_000n,
+        units: 0,
+        reissuable: true, // this sub was issued reissuable
+      }).toString('hex'),
+    ).toBe(
+      '76a9147f92d9617eeb5fc717eb8d3c431b237f0caad14a88acc02072766e710f464c494748544445434b2f5445535400e1f505000000000001000075',
+    );
+  });
 });


### PR DESCRIPTION
The sub/unique commit didn't make it onto `main` — #74 was merged at the root-only commit (2.4.32). This brings the missing sub + unique issuance engine (2.4.33), validated **byte-for-byte against your real Core sub (`FLIGHTDECK/TEST`) and unique (`FLIGHTDECK#TEST`) issuances**.

- `issueSubAsset` (100 AVN) / `issueUniqueAsset` (5 AVN): spend the `PARENT!` owner token (returned to you), burn the type fee, mint the new `CHILD!` owner + the new asset — output order matches Core exactly.
- Shared `issueChildAsset` engine; no new script code (the same transfer/owner/issuance builders compose all three types).
- Golden vectors for both real Core child issuances + stub builder invariants. 24 asset tests green.

Bumps to 2.4.33. Merge this so the Create-asset UI (next) can reach all three types.