### PR TITLE
feat(assets): Create-asset UI — root, sub & unique with burn confirmation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.33",
+  "version": "2.4.34",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Coins, RefreshCw, Search, Send } from 'lucide-react';
+import { Coins, Plus, RefreshCw, Search, Send } from 'lucide-react';
 
 import { useWallet } from '@/contexts/WalletContext';
 import { getHeldAssets, type HeldAsset } from '@/services/wallet/AssetService';
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import SendAssetDialog from './SendAssetDialog';
+import CreateAssetDialog from './CreateAssetDialog';
 
 /** The kind of Avian asset name, for a small type badge. */
 function assetKind(name: string): 'owner' | 'unique' | 'sub' | 'restricted' | 'qualifier' | null {
@@ -32,6 +33,7 @@ export function AssetList({ className }: { className?: string }) {
   const [loaded, setLoaded] = useState(false);
   const [query, setQuery] = useState('');
   const [sending, setSending] = useState<HeldAsset | null>(null);
+  const [creating, setCreating] = useState(false);
 
   const load = useCallback(async () => {
     if (!electrum || !address) return;
@@ -44,13 +46,27 @@ export function AssetList({ className }: { className?: string }) {
     }
   }, [electrum, address]);
 
+  // Reload now and again shortly after — a just-spent/created asset only drops off (or appears)
+  // once ElectrumX reflects the new tx, which lags the broadcast by a moment.
+  const reloadSoon = useCallback(() => {
+    void load();
+    setTimeout(() => void load(), 2500);
+  }, [load]);
+
   useEffect(() => {
     if (isConnected && address) void load();
   }, [isConnected, address, load]);
 
-  // Stay invisible until we know there is something to show — no empty card for AVN-only wallets.
+  // Assets are legacy-address-only; a legacy wallet can create even with nothing held yet.
+  const canCreate = !!address && address.startsWith('R');
+  // Owner tokens we hold (NAME!) → the roots we can create sub/unique assets under.
+  const ownedRoots = assets
+    .filter((a) => a.name.endsWith('!'))
+    .map((a) => a.name.slice(0, -1));
+
+  // Stay invisible until loaded; then only hide when there's nothing to show and nothing to create.
   if (!loaded && !loading) return null;
-  if (loaded && assets.length === 0) return null;
+  if (loaded && assets.length === 0 && !canCreate) return null;
 
   const filtered = query
     ? assets.filter((a) => a.name.toLowerCase().includes(query.toLowerCase()))
@@ -66,16 +82,28 @@ export function AssetList({ className }: { className?: string }) {
             <span className="text-sm font-normal text-muted-foreground">({assets.length})</span>
           )}
         </CardTitle>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={() => void load()}
-          disabled={loading}
-          aria-label="Refresh assets"
-        >
-          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-        </Button>
+        <span className="flex items-center gap-1">
+          {canCreate && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => setCreating(true)}
+            >
+              <Plus className="h-4 w-4" /> Create
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => void load()}
+            disabled={loading}
+            aria-label="Refresh assets"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+        </span>
       </CardHeader>
       <CardContent className="p-0">
         {assets.length > 6 && (
@@ -144,7 +172,7 @@ export function AssetList({ className }: { className?: string }) {
             })}
             {filtered.length === 0 && (
               <li className="px-4 py-6 text-center text-sm text-muted-foreground">
-                No assets match “{query}”.
+                {query ? `No assets match “${query}”.` : 'No assets yet — create one to get started.'}
               </li>
             )}
           </ul>
@@ -155,7 +183,14 @@ export function AssetList({ className }: { className?: string }) {
         open={sending !== null}
         onOpenChange={(next) => !next && setSending(null)}
         asset={sending}
-        onSuccess={() => void load()}
+        onSuccess={reloadSoon}
+      />
+
+      <CreateAssetDialog
+        open={creating}
+        onOpenChange={setCreating}
+        ownedRoots={ownedRoots}
+        onSuccess={reloadSoon}
       />
     </Card>
   );

--- a/src/components/CreateAssetDialog.tsx
+++ b/src/components/CreateAssetDialog.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { AlertTriangle, Check, Flame, Lock } from 'lucide-react';
+
+import { useWallet } from '@/contexts/WalletContext';
+import { useSecurity } from '@/contexts/SecurityContext';
+import { useMediaQuery } from '@/hooks/use-media-query';
+import { WalletService } from '@/services/wallet/WalletService';
+import { parseAssetAmount } from '@/services/wallet/AssetService';
+import { ISSUE_BURN, isValidRootAssetName } from '@/services/wallet/assetScript';
+import { getExplorerUrl } from '@/lib/explorer';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+type AssetType = 'root' | 'sub' | 'unique';
+
+interface CreateAssetDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Root names the wallet can create children under (from held `NAME!` owner tokens). */
+  ownedRoots: string[];
+  onSuccess?: () => void;
+}
+
+const burnFor = (type: AssetType) =>
+  Number(type === 'root' ? ISSUE_BURN.root.amount : type === 'sub' ? ISSUE_BURN.sub.amount : ISSUE_BURN.unique.amount) /
+  1e8;
+
+export default function CreateAssetDialog({
+  open,
+  onOpenChange,
+  ownedRoots,
+  onSuccess,
+}: CreateAssetDialogProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const { electrum, isConnected, refreshAfterTransaction } = useWallet();
+  const { requireAuth } = useSecurity();
+
+  const [type, setType] = useState<AssetType>('root');
+  const [rootName, setRootName] = useState('');
+  const [parent, setParent] = useState('');
+  const [childPart, setChildPart] = useState('');
+  const [amountInput, setAmountInput] = useState('1');
+  const [units, setUnits] = useState('0');
+  const [reissuable, setReissuable] = useState(true);
+  const [confirmBurn, setConfirmBurn] = useState(false);
+  const [error, setError] = useState('');
+  const [isBusy, setIsBusy] = useState(false);
+  const [txid, setTxid] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setType(ownedRoots.length === 0 ? 'root' : 'root');
+      setRootName('');
+      setParent(ownedRoots[0] ?? '');
+      setChildPart('');
+      setAmountInput('1');
+      setUnits('0');
+      setReissuable(true);
+      setConfirmBurn(false);
+      setError('');
+      setTxid('');
+      setIsBusy(false);
+    }
+  }, [open, ownedRoots]);
+
+  const fullName = useMemo(() => {
+    if (type === 'root') return rootName.trim();
+    if (type === 'sub') return parent && childPart ? `${parent}/${childPart.trim()}` : '';
+    return parent && childPart ? `${parent}#${childPart.trim()}` : '';
+  }, [type, rootName, parent, childPart]);
+
+  const burn = burnFor(type);
+  const needsParent = type === 'sub' || type === 'unique';
+  const divisions = Number(units) || 0;
+
+  const handleCreate = async () => {
+    setError('');
+    if (needsParent && !parent) {
+      setError('Choose a parent asset — you need its owner token to create this.');
+      return;
+    }
+    if (type === 'root' && !isValidRootAssetName(fullName)) {
+      setError('Invalid name. 3–30 characters of A–Z, 0–9, _ and . (no leading/trailing/doubled punctuation).');
+      return;
+    }
+    if (needsParent && !childPart.trim()) {
+      setError(type === 'sub' ? 'Enter a sub-asset name.' : 'Enter a unique tag.');
+      return;
+    }
+    if (!confirmBurn) {
+      setError(`Please confirm the ${burn} AVN burn.`);
+      return;
+    }
+    if (!electrum || !isConnected) {
+      setError('Not connected to the Avian network.');
+      return;
+    }
+
+    let amount: bigint;
+    try {
+      amount = type === 'unique' ? 100_000_000n : parseAssetAmount(amountInput, divisions);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Invalid amount');
+      return;
+    }
+
+    setIsBusy(true);
+    try {
+      // Friendly pre-flight: refuse a name that already exists (consensus enforces this too).
+      try {
+        const meta = await electrum.getAssetMeta(fullName);
+        if (meta) {
+          setError(`"${fullName}" already exists.`);
+          setIsBusy(false);
+          return;
+        }
+      } catch {
+        /* get_meta throws for a non-existent asset — that's the good case. */
+      }
+
+      const auth = await requireAuth(`Authenticate to create ${fullName}`);
+      if (!auth.success) {
+        setError('Authentication is required to create an asset.');
+        return;
+      }
+
+      const service = new WalletService(electrum);
+      let id: string;
+      if (type === 'root') {
+        id = await service.issueAsset(fullName, { amount, units: divisions, reissuable }, auth.password);
+      } else if (type === 'sub') {
+        id = await service.issueSubAsset(fullName, { amount, units: divisions, reissuable }, auth.password);
+      } else {
+        id = await service.issueUniqueAsset(fullName, auth.password);
+      }
+      setTxid(id);
+      toast.success(`Created ${fullName}`);
+      void refreshAfterTransaction(1500);
+      onSuccess?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create the asset.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const body = txid ? (
+    <div className="space-y-4">
+      <Alert className="border-emerald-500/40 bg-emerald-500/10">
+        <Check className="h-4 w-4 text-emerald-600" />
+        <AlertDescription className="space-y-2">
+          <p>
+            Created <span className="font-mono">{fullName}</span> — and its{' '}
+            <span className="font-mono">{fullName}!</span> owner token.
+          </p>
+          <a
+            href={getExplorerUrl(txid)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-sm font-medium text-primary underline underline-offset-2"
+          >
+            View on explorer
+          </a>
+        </AlertDescription>
+      </Alert>
+      <Button className="w-full" onClick={() => onOpenChange(false)}>
+        Done
+      </Button>
+    </div>
+  ) : (
+    <div className="space-y-4">
+      <Tabs value={type} onValueChange={(v) => setType(v as AssetType)}>
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="root">Root</TabsTrigger>
+          <TabsTrigger value="sub" disabled={ownedRoots.length === 0}>
+            Sub
+          </TabsTrigger>
+          <TabsTrigger value="unique" disabled={ownedRoots.length === 0}>
+            Unique
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {needsParent && ownedRoots.length === 0 && (
+        <Alert>
+          <AlertDescription className="text-sm">
+            You need to own an asset (its <span className="font-mono">NAME!</span> owner token) before
+            creating a sub-asset or unique under it.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {type === 'root' ? (
+        <div className="space-y-2">
+          <Label htmlFor="root-name">Asset name</Label>
+          <Input
+            id="root-name"
+            value={rootName}
+            onChange={(e) => setRootName(e.target.value.toUpperCase())}
+            placeholder="MYASSET"
+            className="font-mono"
+            autoCapitalize="characters"
+          />
+        </div>
+      ) : (
+        <div className="grid grid-cols-[1fr_auto_1fr] items-end gap-2">
+          <div className="space-y-2">
+            <Label>Parent</Label>
+            <Select value={parent} onValueChange={setParent}>
+              <SelectTrigger className="font-mono">
+                <SelectValue placeholder="Owned asset" />
+              </SelectTrigger>
+              <SelectContent>
+                {ownedRoots.map((r) => (
+                  <SelectItem key={r} value={r} className="font-mono">
+                    {r}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <span className="pb-2.5 font-mono text-lg text-muted-foreground">
+            {type === 'sub' ? '/' : '#'}
+          </span>
+          <div className="space-y-2">
+            <Label htmlFor="child-part">{type === 'sub' ? 'Sub-asset' : 'Tag'}</Label>
+            <Input
+              id="child-part"
+              value={childPart}
+              onChange={(e) => setChildPart(type === 'sub' ? e.target.value.toUpperCase() : e.target.value)}
+              placeholder={type === 'sub' ? 'SUB' : '001'}
+              className="font-mono"
+            />
+          </div>
+        </div>
+      )}
+
+      {fullName && (
+        <p className="text-xs text-muted-foreground">
+          Creating <span className="font-mono text-foreground">{fullName}</span>
+        </p>
+      )}
+
+      {type !== 'unique' && (
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <Label htmlFor="supply">Supply</Label>
+            <Input
+              id="supply"
+              value={amountInput}
+              onChange={(e) => setAmountInput(e.target.value)}
+              inputMode="decimal"
+              className="font-mono"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="divisions">Divisions</Label>
+            <Select value={units} onValueChange={setUnits}>
+              <SelectTrigger id="divisions">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((u) => (
+                  <SelectItem key={u} value={String(u)}>
+                    {u}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      )}
+
+      {type !== 'unique' ? (
+        <label className="flex items-center gap-2 text-sm">
+          <Checkbox checked={reissuable} onCheckedChange={(c) => setReissuable(c === true)} />
+          Reissuable (you can mint more or change it later)
+        </label>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Unique assets are always quantity 1, indivisible, and cannot be reissued.
+        </p>
+      )}
+
+      <Alert className="border-caution/40 bg-caution/10 [&>svg]:text-caution">
+        <Flame className="h-4 w-4" />
+        <AlertDescription className="space-y-2 text-sm">
+          <p>
+            Creating this <strong>permanently burns {burn} AVN</strong> and cannot be undone.
+          </p>
+          <label className="flex items-center gap-2 font-medium">
+            <Checkbox checked={confirmBurn} onCheckedChange={(c) => setConfirmBurn(c === true)} />I
+            understand {burn} AVN will be burned.
+          </label>
+        </AlertDescription>
+      </Alert>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex gap-2 pt-1">
+        <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)} disabled={isBusy}>
+          Cancel
+        </Button>
+        <Button className="flex-1 gap-2" onClick={handleCreate} disabled={isBusy || !fullName || !confirmBurn}>
+          <Lock className="h-4 w-4" />
+          {isBusy ? 'Creating…' : `Create (burn ${burn} AVN)`}
+        </Button>
+      </div>
+    </div>
+  );
+
+  const title = 'Create asset';
+  const description = 'Issue a new Avian asset. This burns AVN and is permanent.';
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent className="max-h-[95vh]">
+          <DrawerHeader className="text-left">
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+          <div className="overflow-y-auto px-4 pb-6">{body}</div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        {body}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
The UI that makes the (validated) issuance engine reachable. A **Create asset** button on the Assets card opens a dialog for **root, sub, and unique** assets.

- **Type picker**; sub/unique require a parent, chosen from the `NAME!` owner tokens you hold (disabled when none).
- Name/tag, **divisions-aware** supply, divisions, reissuable; uniques fixed to qty 1 / indivisible / non-reissuable.
- A **checkbox-gated confirmation of the exact burn (500 / 100 / 5 AVN)** and its permanence, a **name-availability pre-check** (`getAssetMeta`), and the existing auth flow; shows the txid + explorer link and notes the `NAME!` owner token was minted.
- The Assets card now also renders (with Create + empty state) for a **legacy wallet holding no assets yet**, so issuance is discoverable.
- **Fixes the sent/created-asset-lingers-until-refresh todo**: asset actions reload immediately and again shortly after, once ElectrumX catches up.

Typecheck + lint clean, build passes. Bumps to 2.4.34.

**Safety recap:** every issuance byte is validated against your real Core root/sub/unique txs (#74/#75); this PR only adds the form + the burn confirmation gate. Suggested first live test: create a **unique** (5 AVN, cheapest) under FLIGHTDECK.