### PR TITLE
feat(assets): IPFS/TXid hash on issuance (root/sub/unique) + burn-confirm reset fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.34",
+  "version": "2.4.35",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/CreateAssetDialog.tsx
+++ b/src/components/CreateAssetDialog.tsx
@@ -71,6 +71,8 @@ export default function CreateAssetDialog({
   const [amountInput, setAmountInput] = useState('1');
   const [units, setUnits] = useState('0');
   const [reissuable, setReissuable] = useState(true);
+  const [addIpfs, setAddIpfs] = useState(false);
+  const [ipfs, setIpfs] = useState('');
   const [confirmBurn, setConfirmBurn] = useState(false);
   const [error, setError] = useState('');
   const [isBusy, setIsBusy] = useState(false);
@@ -85,6 +87,8 @@ export default function CreateAssetDialog({
       setAmountInput('1');
       setUnits('0');
       setReissuable(true);
+      setAddIpfs(false);
+      setIpfs('');
       setConfirmBurn(false);
       setError('');
       setTxid('');
@@ -153,14 +157,23 @@ export default function CreateAssetDialog({
         return;
       }
 
+      const ipfsValue = addIpfs && ipfs.trim() ? ipfs.trim() : undefined;
       const service = new WalletService(electrum);
       let id: string;
       if (type === 'root') {
-        id = await service.issueAsset(fullName, { amount, units: divisions, reissuable }, auth.password);
+        id = await service.issueAsset(
+          fullName,
+          { amount, units: divisions, reissuable, ipfs: ipfsValue },
+          auth.password,
+        );
       } else if (type === 'sub') {
-        id = await service.issueSubAsset(fullName, { amount, units: divisions, reissuable }, auth.password);
+        id = await service.issueSubAsset(
+          fullName,
+          { amount, units: divisions, reissuable, ipfs: ipfsValue },
+          auth.password,
+        );
       } else {
-        id = await service.issueUniqueAsset(fullName, auth.password);
+        id = await service.issueUniqueAsset(fullName, ipfsValue, auth.password);
       }
       setTxid(id);
       toast.success(`Created ${fullName}`);
@@ -318,6 +331,28 @@ export default function CreateAssetDialog({
           Unique assets are always quantity 1, indivisible, and cannot be reissued.
         </p>
       )}
+
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-sm">
+          <Checkbox checked={addIpfs} onCheckedChange={(c) => setAddIpfs(c === true)} />
+          Add IPFS / TXid hash
+        </label>
+        {addIpfs && (
+          <>
+            <Input
+              value={ipfs}
+              onChange={(e) => setIpfs(e.target.value)}
+              placeholder="IPFS v0 hash (Qm…) or a 64-character txid"
+              className="font-mono text-xs"
+              spellCheck={false}
+            />
+            <p className="text-xs text-muted-foreground">
+              Avian accepts IPFS <strong>v0</strong> CIDs only (SHA-256, base58 — starts with{' '}
+              <span className="font-mono">Qm</span>).
+            </p>
+          </>
+        )}
+      </div>
 
       <Alert className="border-caution/40 bg-caution/10 [&>svg]:text-caution">
         <Flame className="h-4 w-4" />

--- a/src/components/CreateAssetDialog.tsx
+++ b/src/components/CreateAssetDialog.tsx
@@ -198,7 +198,15 @@ export default function CreateAssetDialog({
     </div>
   ) : (
     <div className="space-y-4">
-      <Tabs value={type} onValueChange={(v) => setType(v as AssetType)}>
+      <Tabs
+        value={type}
+        onValueChange={(v) => {
+          setType(v as AssetType);
+          // The burn amount differs per type — never carry a confirmation across a change.
+          setConfirmBurn(false);
+          setError('');
+        }}
+      >
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="root">Root</TabsTrigger>
           <TabsTrigger value="sub" disabled={ownedRoots.length === 0}>

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -1191,7 +1191,7 @@ export class WalletService {
      */
     async issueAsset(
         name: string,
-        params: { amount: bigint; units: number; reissuable: boolean },
+        params: { amount: bigint; units: number; reissuable: boolean; ipfs?: string },
         password?: string,
         options?: { feeRate?: number; changeAddress?: string },
     ): Promise<string> {
@@ -1235,6 +1235,7 @@ export class WalletService {
                 amount: params.amount,
                 units: params.units,
                 reissuable: params.reissuable,
+                ipfs: params.ipfs,
             });
 
             // Fund the burn + fee from AVN UTXOs (iterating on the selected input count).
@@ -1319,7 +1320,7 @@ export class WalletService {
      */
     async issueSubAsset(
         subName: string,
-        params: { amount: bigint; units: number; reissuable: boolean },
+        params: { amount: bigint; units: number; reissuable: boolean; ipfs?: string },
         password?: string,
         options?: { feeRate?: number; changeAddress?: string },
     ): Promise<string> {
@@ -1331,6 +1332,7 @@ export class WalletService {
             amount: params.amount,
             units: params.units,
             reissuable: params.reissuable,
+            ipfs: params.ipfs,
             burnAmount: ISSUE_BURN.sub.amount,
             burnAddress: ISSUE_BURN.sub.address,
             password,
@@ -1340,10 +1342,11 @@ export class WalletService {
 
     /**
      * Issue a unique asset (`PARENT#tag`, burns 5 AVN). Always quantity 1, 0 divisions,
-     * non-reissuable. Requires owning the `PARENT!` owner token.
+     * non-reissuable. Requires owning the `PARENT!` owner token. An optional IPFS/txid may be set.
      */
     async issueUniqueAsset(
         uniqueName: string,
+        ipfs?: string,
         password?: string,
         options?: { feeRate?: number; changeAddress?: string },
     ): Promise<string> {
@@ -1355,6 +1358,7 @@ export class WalletService {
             amount: 100_000_000n, // exactly 1 unit
             units: 0,
             reissuable: false,
+            ipfs,
             burnAmount: ISSUE_BURN.unique.amount,
             burnAddress: ISSUE_BURN.unique.address,
             password,
@@ -1374,6 +1378,7 @@ export class WalletService {
         amount: bigint;
         units: number;
         reissuable: boolean;
+        ipfs?: string;
         burnAmount: bigint;
         burnAddress: string;
         password?: string;
@@ -1419,7 +1424,13 @@ export class WalletService {
             const burnScript = bitcoin.address.toOutputScript(burnAddress, avianNetwork);
             const parentReturnScript = buildAssetTransferScript(changeAddress, ownerName, ownerAmount);
             const newOwnerScript = buildOwnerScript(fromAddress, childName);
-            const newAssetScript = buildIssuanceScript(fromAddress, { name: childName, amount, units, reissuable });
+            const newAssetScript = buildIssuanceScript(fromAddress, {
+                name: childName,
+                amount,
+                units,
+                reissuable,
+                ipfs: opts.ipfs,
+            });
 
             const burn = Number(burnAmount);
             const satPerVByte = await this.resolveFeeRate(opts.options?.feeRate);

--- a/src/services/wallet/assetIssuance.test.ts
+++ b/src/services/wallet/assetIssuance.test.ts
@@ -213,7 +213,7 @@ describe('issueUniqueAsset', () => {
     const { electrum, broadcast } = createChildElectrum(address, 'MYASSET', [10 * COIN]);
     const wallet = new WalletService(electrum as never);
 
-    await wallet.issueUniqueAsset('MYASSET#001', TEST_PASSWORD, { feeRate: 1 });
+    await wallet.issueUniqueAsset('MYASSET#001', undefined, TEST_PASSWORD, { feeRate: 1 });
 
     const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
     const outs = tx.outs;
@@ -253,7 +253,7 @@ describe('issueUniqueAsset', () => {
     const { electrum, broadcast } = createChildElectrum(address, 'MYASSET', [10 * COIN], false);
     const wallet = new WalletService(electrum as never);
 
-    await expect(wallet.issueUniqueAsset('MYASSET#001', TEST_PASSWORD, { feeRate: 1 })).rejects.toThrow(
+    await expect(wallet.issueUniqueAsset('MYASSET#001', undefined, TEST_PASSWORD, { feeRate: 1 })).rejects.toThrow(
       /MYASSET! owner token/,
     );
     expect(broadcast).not.toHaveBeenCalled();

--- a/src/services/wallet/assetScript.test.ts
+++ b/src/services/wallet/assetScript.test.ts
@@ -217,4 +217,21 @@ describe('real mainnet Core golden vectors', () => {
       '76a9147f92d9617eeb5fc717eb8d3c431b237f0caad14a88acc02072766e710f464c494748544445434b2f5445535400e1f505000000000001000075',
     );
   });
+
+  it('reproduces a real Core issuance with an IPFS hash byte-for-byte', () => {
+    // FLIGHTDECK#001 (unique) issued with IPFS QmaQdhp16ksqeEQMfArTux8bjeBaJmAxi8JpnSCSgSEsQ3. The
+    // hash decodes (base58) to 0x12 0x20 ‖ 32-byte sha256, appended after hasIPFS=01.
+    const DEST = 'RAqL1E1MhbDbAWWdo9pugcvdP2GAt7SWSH';
+    expect(
+      buildIssuanceScript(DEST, {
+        name: 'FLIGHTDECK#001',
+        amount: 100_000_000n,
+        units: 0,
+        reissuable: false,
+        ipfs: 'QmaQdhp16ksqeEQMfArTux8bjeBaJmAxi8JpnSCSgSEsQ3',
+      }).toString('hex'),
+    ).toBe(
+      '76a914110c0d88b13de35be9708cf83bc76366c2545dd788acc04172766e710e464c494748544445434b2330303100e1f505000000000000011220b3516e0d37699ee67d4d79560b0abc3e99ec2485bb1f326a3eaa5f05e5f8aaf80075',
+    );
+  });
 });

--- a/src/services/wallet/assetScript.ts
+++ b/src/services/wallet/assetScript.ts
@@ -119,6 +119,50 @@ export function isValidRootAssetName(name: string): boolean {
   return true;
 }
 
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+/** Plain base58 (btc alphabet, no checksum) decode — for IPFS `Qm…` hashes. */
+function base58Decode(input: string): Buffer {
+  const bytes = [0];
+  for (const ch of input) {
+    const value = BASE58_ALPHABET.indexOf(ch);
+    if (value < 0) throw new Error('Invalid base58 character');
+    let carry = value;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  for (let k = 0; k < input.length && input[k] === '1'; k++) bytes.push(0);
+  return Buffer.from(bytes.reverse());
+}
+
+/**
+ * Encode an asset's IPFS/TXid reference into the 34-byte on-chain blob Core expects. Avian (like
+ * Ravencoin) only accepts **IPFS v0** CIDs — the 46-char base58 `Qm…` sha2-256 hash — which decodes
+ * directly to `0x12 0x20 <32-byte sha256>`; a v1 CID (`bafy…`) is rejected. A TXid is 64 hex chars,
+ * emitted as `0x54 0x20 <32-byte txid>`. Byte-exact to Avian Core DecodeAssetData + SerializeIPFSHash.
+ */
+export function encodeAssetData(hashOrTxid: string): Buffer {
+  const value = hashOrTxid.trim();
+  if (value.length === 46 && value.startsWith('Qm')) {
+    const decoded = base58Decode(value);
+    if (decoded.length !== 34) throw new Error('Invalid IPFS v0 hash');
+    return decoded; // already 0x12 0x20 ‖ 32-byte hash
+  }
+  if (value.length === 64 && /^[0-9a-fA-F]+$/.test(value)) {
+    return Buffer.concat([Buffer.from([TXID_NOTIFIER, 0x20]), Buffer.from(value, 'hex')]);
+  }
+  throw new Error('Provide an IPFS v0 hash (Qm…, 46 characters) or a 64-character txid');
+}
+
+const TXID_NOTIFIER = 0x54;
+
 export interface IssuanceParams {
   name: string;
   /** Total supply in integer units (10^8-scaled), e.g. 1 whole unit = 100000000. */
@@ -126,17 +170,21 @@ export interface IssuanceParams {
   /** Divisibility 0–8. */
   units: number;
   reissuable: boolean;
+  /** Optional IPFS hash (Qm…) or 64-hex txid to associate with the asset. */
+  ipfs?: string;
 }
 
 /**
  * Build a new-asset issuance output (`rvn·q · CNewAsset`) paying the created supply to `address`.
- * IPFS/ANS are not carried (both flags 0) — deferred. Byte-exact to Avian Core `CNewAsset`.
+ * Carries an optional IPFS/TXid hash; ANS is never carried (flag 0). Byte-exact to Avian Core
+ * `CNewAsset` (name, amount, units, reissuable, hasIPFS[, ipfs], hasANS).
  */
 export function buildIssuanceScript(address: string, params: IssuanceParams): Buffer {
-  const { name, amount, units, reissuable } = params;
+  const { name, amount, units, reissuable, ipfs } = params;
   if (amount <= 0n) throw new Error('Issuance amount must be positive');
   if (units < 0 || units > 8) throw new Error('Units must be between 0 and 8');
   const nameBuf = Buffer.from(name, 'ascii');
+  const ipfsBlob = ipfs ? encodeAssetData(ipfs) : null;
   const payload = Buffer.concat([
     ASSET_MARKER,
     Buffer.from([ASSET_TYPE.issue]),
@@ -145,7 +193,8 @@ export function buildIssuanceScript(address: string, params: IssuanceParams): Bu
     int64LE(amount),
     Buffer.from([units & 0xff]),
     Buffer.from([reissuable ? 1 : 0]),
-    Buffer.from([0]), // hasIPFS = 0 (IPFS deferred)
+    Buffer.from([ipfsBlob ? 1 : 0]), // hasIPFS
+    ...(ipfsBlob ? [ipfsBlob] : []),
     Buffer.from([0]), // hasANS = 0
   ]);
   return wrapAssetScript(legacyP2PKHScript(address), payload);


### PR DESCRIPTION
Adds **IPFS/TXid metadata** to asset creation, matching Core — validated **byte-for-byte against your real Core unique-with-IPFS issuance** (FLIGHTDECK#001, `QmaQdhp16…`).

- **IPFS v0 only** (as Avian/Ravencoin require): a 46-char base58 `Qm…` SHA-256 CID decodes straight to the on-chain `0x12 0x20 · <32-byte>` blob; a 64-hex txid becomes `0x54 0x20 · <32-byte>`. v1 (`bafy…`) is rejected.
- `buildIssuanceScript` sets `hasIPFS` + blob; `issueAsset`/`issueSubAsset` take optional `ipfs`, `issueUniqueAsset` gains an `ipfs` arg.
- **Create dialog**: an "Add IPFS / TXid hash" field on all three types, noting v0-only.
- Golden vector pinning the IPFS bytes to Core; tiny inline base58 decoder (no new dependency).

Also folds in the **burn-confirmation reset fix** (switching type clears the acknowledgement) that missed the #76 merge — so a 5 AVN confirm can't carry to a 500 AVN burn.

25 asset tests green, typecheck + lint clean, build passes. Bumps to 2.4.35.