### PR TITLE
fix(assets): non-existent asset name no longer reported as already taken

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.35",
+  "version": "2.4.36",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/core/ElectrumService.ts
+++ b/src/services/core/ElectrumService.ts
@@ -529,11 +529,14 @@ export class ElectrumService {
     }
   }
 
-  /** Metadata for an asset: divisions (0–8 units), reissuable, IPFS, and total supply. */
+  /** Metadata for an asset, or null if it doesn't exist. */
   async getAssetMeta(name: string): Promise<AssetMeta | null> {
     try {
       const response = await this.makeRequest('blockchain.asset.get_meta', [name]);
-      if (!response) return null;
+      // ElectrumX returns an empty object ({}) for an asset that doesn't exist — a real asset always
+      // carries a numeric `divisions`. Treat anything without it as "not found" so callers (e.g. the
+      // create-asset availability check) don't read a non-existent name as taken.
+      if (!response || typeof response.divisions !== 'number') return null;
       return {
         name,
         divisions: typeof response.divisions === 'number' ? response.divisions : 0,


### PR DESCRIPTION
The Create-asset **availability check** falsely reported "NAME already exists" for names that were actually **free** (you hit this on FLIGHTDECK#desktop).

Root cause: ElectrumX's `blockchain.asset.get_meta` returns an **empty object `{}`** for a non-existent asset — not null, not an error. `getAssetMeta` treated that truthy `{}` as real metadata, so any free name looked taken.

Fix: `getAssetMeta` now requires a numeric `divisions` (which every real asset carries) and returns null otherwise. Free names create; only genuinely existing ones are blocked. Bumps to 2.4.36.