### PR TITLE
fix(assets): keep the Create-asset success screen after issuing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.36",
+  "version": "2.4.37",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/CreateAssetDialog.tsx
+++ b/src/components/CreateAssetDialog.tsx
@@ -78,9 +78,12 @@ export default function CreateAssetDialog({
   const [isBusy, setIsBusy] = useState(false);
   const [txid, setTxid] = useState('');
 
+  // Reset only when the dialog opens — NOT when ownedRoots changes. After a successful issuance the
+  // asset list refreshes and ownedRoots gains the new owner token; if that re-ran this effect it
+  // would wipe txid and drop the success screen (with its explorer link) back to the empty form.
   useEffect(() => {
     if (open) {
-      setType(ownedRoots.length === 0 ? 'root' : 'root');
+      setType('root');
       setRootName('');
       setParent(ownedRoots[0] ?? '');
       setChildPart('');
@@ -94,7 +97,8 @@ export default function CreateAssetDialog({
       setTxid('');
       setIsBusy(false);
     }
-  }, [open, ownedRoots]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   const fullName = useMemo(() => {
     if (type === 'root') return rootName.trim();


### PR DESCRIPTION
After a successful issuance the dialog flashed its success state and reset straight back to the empty Root form — so the confirmation + "View on explorer" link were never seen (you noticed this after creating the unique).

Cause: `onSuccess` refreshes the asset list, the new owner token changes `ownedRoots`, and the dialog's reset effect depended on `ownedRoots` — so it re-ran while open and cleared `txid`. The reset now runs **only when the dialog opens**, so the success screen (explorer link, like the send flow) stays until you close it.

One-line-ish, typecheck + lint clean, build passes. Bumps to 2.4.37.