### PR TITLE
feat(assets): reissue — mint more / update an asset (validated vs Core)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.39",
+  "version": "2.4.40",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Coins, Plus, RefreshCw, Search, Send } from 'lucide-react';
+import { Coins, Plus, PlusCircle, RefreshCw, Search, Send } from 'lucide-react';
 
 import { useWallet } from '@/contexts/WalletContext';
 import { getHeldAssets, ipfsImageUrl, type HeldAsset } from '@/services/wallet/AssetService';
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import SendAssetDialog from './SendAssetDialog';
 import CreateAssetDialog from './CreateAssetDialog';
+import ReissueAssetDialog from './ReissueAssetDialog';
 
 /** A small asset avatar: the IPFS image when the asset has one (click to enlarge), else a coin glyph. */
 function AssetThumbnail({ asset, onPreview }: { asset: HeldAsset; onPreview: (url: string) => void }) {
@@ -67,6 +68,7 @@ export function AssetList({ className }: { className?: string }) {
   const [loaded, setLoaded] = useState(false);
   const [query, setQuery] = useState('');
   const [sending, setSending] = useState<HeldAsset | null>(null);
+  const [reissuing, setReissuing] = useState<HeldAsset | null>(null);
   const [creating, setCreating] = useState(false);
   const [preview, setPreview] = useState<{ url: string; name: string } | null>(null);
 
@@ -192,8 +194,20 @@ export function AssetList({ className }: { className?: string }) {
                         )}
                       </span>
                     </span>
-                  <span className="flex flex-shrink-0 items-center gap-2">
-                    <span className="font-mono text-sm">{asset.amount}</span>
+                  <span className="flex flex-shrink-0 items-center gap-1">
+                    <span className="mr-1 font-mono text-sm">{asset.amount}</span>
+                    {asset.meta?.reissuable && ownedRoots.includes(asset.name) && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-primary"
+                        onClick={() => setReissuing(asset)}
+                        aria-label={`Reissue ${asset.name}`}
+                        title={`Reissue ${asset.name}`}
+                      >
+                        <PlusCircle className="h-4 w-4" />
+                      </Button>
+                    )}
                     <Button
                       variant="ghost"
                       size="icon"
@@ -222,6 +236,13 @@ export function AssetList({ className }: { className?: string }) {
         open={sending !== null}
         onOpenChange={(next) => !next && setSending(null)}
         asset={sending}
+        onSuccess={reloadSoon}
+      />
+
+      <ReissueAssetDialog
+        open={reissuing !== null}
+        onOpenChange={(next) => !next && setReissuing(null)}
+        asset={reissuing}
         onSuccess={reloadSoon}
       />
 

--- a/src/components/ReissueAssetDialog.tsx
+++ b/src/components/ReissueAssetDialog.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { AlertTriangle, Check, Flame, Lock } from 'lucide-react';
+
+import { useWallet } from '@/contexts/WalletContext';
+import { useSecurity } from '@/contexts/SecurityContext';
+import { useMediaQuery } from '@/hooks/use-media-query';
+import { WalletService } from '@/services/wallet/WalletService';
+import { formatAssetAmount, parseAssetAmount, type HeldAsset } from '@/services/wallet/AssetService';
+import { ISSUE_BURN } from '@/services/wallet/assetScript';
+import { getExplorerUrl } from '@/lib/explorer';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface ReissueAssetDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  asset: HeldAsset | null;
+  onSuccess?: () => void;
+}
+
+const REISSUE_BURN = Number(ISSUE_BURN.reissue.amount) / 1e8; // 100 AVN
+
+export default function ReissueAssetDialog({
+  open,
+  onOpenChange,
+  asset,
+  onSuccess,
+}: ReissueAssetDialogProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const { electrum, isConnected, refreshAfterTransaction } = useWallet();
+  const { requireAuth } = useSecurity();
+
+  const [amountInput, setAmountInput] = useState('0');
+  const [unitsChoice, setUnitsChoice] = useState('keep'); // 'keep' | '<n>'
+  const [reissuable, setReissuable] = useState(true);
+  const [addIpfs, setAddIpfs] = useState(false);
+  const [ipfs, setIpfs] = useState('');
+  const [confirmBurn, setConfirmBurn] = useState(false);
+  const [error, setError] = useState('');
+  const [isBusy, setIsBusy] = useState(false);
+  const [txid, setTxid] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setAmountInput('0');
+      setUnitsChoice('keep');
+      setReissuable(true);
+      setAddIpfs(false);
+      setIpfs('');
+      setConfirmBurn(false);
+      setError('');
+      setTxid('');
+      setIsBusy(false);
+    }
+  }, [open]);
+
+  if (!asset) return null;
+
+  const currentDivisions = asset.divisions;
+  // Reissue can only raise divisions.
+  const higherDivisions = [1, 2, 3, 4, 5, 6, 7, 8].filter((u) => u > currentDivisions);
+
+  const handleReissue = async () => {
+    setError('');
+    if (!confirmBurn) {
+      setError(`Please confirm the ${REISSUE_BURN} AVN burn.`);
+      return;
+    }
+    if (!electrum || !isConnected) {
+      setError('Not connected to the Avian network.');
+      return;
+    }
+
+    // Additional supply; 0 (or blank) means a settings-only reissue.
+    let amount = 0n;
+    const trimmed = amountInput.trim();
+    if (trimmed && !/^0(\.0*)?$/.test(trimmed)) {
+      try {
+        amount = parseAssetAmount(trimmed, currentDivisions);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Invalid amount');
+        return;
+      }
+    }
+
+    const units = unitsChoice === 'keep' ? -1 : Number(unitsChoice);
+    const ipfsValue = addIpfs && ipfs.trim() ? ipfs.trim() : undefined;
+
+    if (amount === 0n && units === -1 && reissuable && !ipfsValue) {
+      setError('Nothing to change — add supply, change divisions/reissuable, or set an IPFS hash.');
+      return;
+    }
+
+    setIsBusy(true);
+    try {
+      const auth = await requireAuth(`Authenticate to reissue ${asset.name}`);
+      if (!auth.success) {
+        setError('Authentication is required to reissue.');
+        return;
+      }
+      const service = new WalletService(electrum);
+      const id = await service.reissueAsset(
+        asset.name,
+        { amount, units, reissuable, ipfs: ipfsValue },
+        auth.password,
+      );
+      setTxid(id);
+      toast.success(`Reissued ${asset.name}`);
+      void refreshAfterTransaction(1500);
+      onSuccess?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to reissue the asset.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const body = txid ? (
+    <div className="space-y-4">
+      <Alert className="border-emerald-500/40 bg-emerald-500/10">
+        <Check className="h-4 w-4 text-emerald-600" />
+        <AlertDescription className="space-y-2">
+          <p>
+            Reissued <span className="font-mono">{asset.name}</span>.
+          </p>
+          <a
+            href={getExplorerUrl(txid)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-sm font-medium text-primary underline underline-offset-2"
+          >
+            View on explorer
+          </a>
+        </AlertDescription>
+      </Alert>
+      <Button className="w-full" onClick={() => onOpenChange(false)}>
+        Done
+      </Button>
+    </div>
+  ) : (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm">
+        <span className="font-mono font-medium">{asset.name}</span>
+        <span className="ml-2 text-muted-foreground">
+          held {formatAssetAmount(asset.confirmedSats, currentDivisions)} · {currentDivisions} divisions
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="reissue-amount">Mint additional supply</Label>
+        <Input
+          id="reissue-amount"
+          value={amountInput}
+          onChange={(e) => setAmountInput(e.target.value)}
+          inputMode="decimal"
+          className="font-mono"
+        />
+        <p className="text-xs text-muted-foreground">Leave 0 to only change the settings below.</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-2">
+          <Label>Divisions</Label>
+          <Select value={unitsChoice} onValueChange={setUnitsChoice} disabled={higherDivisions.length === 0}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="keep">Keep ({currentDivisions})</SelectItem>
+              {higherDivisions.map((u) => (
+                <SelectItem key={u} value={String(u)}>
+                  {u}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">Can only increase.</p>
+        </div>
+        <div className="flex items-end pb-2">
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox checked={reissuable} onCheckedChange={(c) => setReissuable(c === true)} />
+            Stays reissuable
+          </label>
+        </div>
+      </div>
+
+      {!reissuable && (
+        <Alert className="border-caution/40 bg-caution/10 [&>svg]:text-caution">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription className="text-sm">
+            Unchecking this <strong>permanently locks</strong> {asset.name} — it can never be reissued
+            again.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-sm">
+          <Checkbox checked={addIpfs} onCheckedChange={(c) => setAddIpfs(c === true)} />
+          Set / replace IPFS hash
+        </label>
+        {addIpfs && (
+          <Input
+            value={ipfs}
+            onChange={(e) => setIpfs(e.target.value)}
+            placeholder="IPFS v0 hash (Qm…) or a 64-character txid"
+            className="font-mono text-xs"
+            spellCheck={false}
+          />
+        )}
+      </div>
+
+      <Alert className="border-caution/40 bg-caution/10 [&>svg]:text-caution">
+        <Flame className="h-4 w-4" />
+        <AlertDescription className="space-y-2 text-sm">
+          <p>
+            Reissuing <strong>permanently burns {REISSUE_BURN} AVN</strong> and cannot be undone.
+          </p>
+          <label className="flex items-center gap-2 font-medium">
+            <Checkbox checked={confirmBurn} onCheckedChange={(c) => setConfirmBurn(c === true)} />I
+            understand {REISSUE_BURN} AVN will be burned.
+          </label>
+        </AlertDescription>
+      </Alert>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex gap-2 pt-1">
+        <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)} disabled={isBusy}>
+          Cancel
+        </Button>
+        <Button className="flex-1 gap-2" onClick={handleReissue} disabled={isBusy || !confirmBurn}>
+          <Lock className="h-4 w-4" />
+          {isBusy ? 'Reissuing…' : `Reissue (burn ${REISSUE_BURN} AVN)`}
+        </Button>
+      </div>
+    </div>
+  );
+
+  const title = `Reissue ${asset.name}`;
+  const description = 'Mint more supply or update this asset. Burns AVN and is permanent.';
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent className="max-h-[95vh]">
+          <DrawerHeader className="text-left">
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+          <div className="overflow-y-auto px-4 pb-6">{body}</div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        {body}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -36,6 +36,7 @@ import {
     buildAssetTransferScript,
     buildIssuanceScript,
     buildOwnerScript,
+    buildReissueScript,
     isValidRootAssetName,
     ISSUE_BURN,
 } from './assetScript';
@@ -1513,6 +1514,142 @@ export class WalletService {
             walletLogger.error('Child asset issuance failed:', error);
             const message = error instanceof Error ? error.message : 'Unknown error';
             throw new Error(`Asset issuance failed: ${message}`);
+        }
+    }
+
+    /**
+     * Reissue an existing reissuable asset you own: mint more supply (`amount`, 0 for metadata-only)
+     * and/or change its units/reissuable/IPFS. **Burns 100 AVN.** Requires the `NAME!` owner token,
+     * which is spent and returned. Outputs: burn, AVN change, owner transfer (2nd-last), reissue
+     * output (last) — Core's order. Validated byte-for-byte against a real Core reissue.
+     *
+     * `units` is the new divisions (0–8, can only increase) or -1 to leave unchanged; a supplied
+     * `ipfs` replaces the asset's hash, omitting it keeps the current one.
+     */
+    async reissueAsset(
+        name: string,
+        params: { amount: bigint; units: number; reissuable: boolean; ipfs?: string },
+        password?: string,
+        options?: { feeRate?: number; changeAddress?: string },
+    ): Promise<string> {
+        try {
+            if (params.amount < 0n) throw new Error('Reissue amount cannot be negative');
+
+            const activeWallet = await StorageService.getActiveWallet();
+            if (!activeWallet) throw new Error('No active wallet found');
+            if ((activeWallet.addressType || 'p2pkh') !== 'p2pkh') {
+                throw new Error('Assets can only be reissued from a legacy (R…) address');
+            }
+
+            let privateKeyWIF = activeWallet.privateKey;
+            if (activeWallet.isEncrypted) {
+                if (!password) throw new Error('Password required for encrypted wallet');
+                try {
+                    const { decrypted } = await decryptData(privateKeyWIF, password);
+                    if (!decrypted) throw new Error('Invalid password');
+                    privateKeyWIF = decrypted;
+                } catch {
+                    throw new Error('Invalid password');
+                }
+            }
+
+            const keyPair = ECPair.fromWIF(privateKeyWIF, avianNetwork);
+            const pubkey = Buffer.from(keyPair.publicKey);
+            const fromAddress = activeWallet.address;
+            const changeAddress = options?.changeAddress?.trim() || fromAddress;
+
+            // The NAME! owner token proves authority; it is spent and returned.
+            const ownerName = `${name}!`;
+            const ownerUTXOs = await this.electrum.getAssetUTXOs(fromAddress, ownerName);
+            if (ownerUTXOs.length === 0) {
+                throw new Error(`You must own the ${ownerName} owner token to reissue ${name}`);
+            }
+            const ownerUTXO = ownerUTXOs[0];
+            const ownerAmount = BigInt(Math.trunc(ownerUTXO.value));
+
+            const burnScript = bitcoin.address.toOutputScript(ISSUE_BURN.reissue.address, avianNetwork);
+            const parentReturnScript = buildAssetTransferScript(changeAddress, ownerName, ownerAmount);
+            const reissueScript = buildReissueScript(fromAddress, {
+                name,
+                amount: params.amount,
+                units: params.units,
+                reissuable: params.reissuable,
+                ipfs: params.ipfs,
+            });
+
+            const burn = Number(ISSUE_BURN.reissue.amount);
+            const satPerVByte = await this.resolveFeeRate(options?.feeRate);
+            const avnUTXOs = await this.electrum.getUTXOs(fromAddress);
+            const sortedAvn = [...avnUTXOs].sort((a, b) => b.value - a.value);
+            const totalAvn = sortedAvn.reduce((sum, utxo) => sum + utxo.value, 0);
+
+            // Outputs: burn(34) + change(34) + owner transfer + reissue. One owner input + AVN inputs.
+            const fixedOutputsVBytes =
+                34 + 34 + (8 + 1 + parentReturnScript.length) + (8 + 1 + reissueScript.length);
+            const sizeFor = (avnInputCount: number) =>
+                10 + (1 + avnInputCount) * 148 + fixedOutputsVBytes;
+
+            let selectedAvn: typeof avnUTXOs = [];
+            let avnIn = 0;
+            let fee = 0;
+            for (let iteration = 0; iteration < 6; iteration++) {
+                fee = Math.ceil(sizeFor(Math.max(selectedAvn.length, 1)) * satPerVByte);
+                const target = burn + fee;
+                if (totalAvn < target) {
+                    throw new Error(`Insufficient AVN: reissuing ${name} burns 100 AVN plus a network fee.`);
+                }
+                selectedAvn = [];
+                avnIn = 0;
+                for (const utxo of sortedAvn) {
+                    if (avnIn >= target) break;
+                    selectedAvn.push(utxo);
+                    avnIn += utxo.value;
+                }
+                const recomputed = Math.ceil(sizeFor(selectedAvn.length) * satPerVByte);
+                if (avnIn >= burn + recomputed && recomputed <= fee) {
+                    fee = recomputed;
+                    break;
+                }
+                fee = recomputed;
+            }
+            if (avnIn < burn + fee) throw new Error('Insufficient AVN for the burn and fee');
+            const change = avnIn - burn - fee;
+            const finalChange = change >= DUST_THRESHOLD_SATS ? change : 0;
+
+            const tx = new bitcoin.Transaction();
+            tx.version = 2;
+            tx.locktime = 0;
+            const allInputs = [ownerUTXO, ...selectedAvn];
+            for (const utxo of allInputs) {
+                tx.addInput(Buffer.from(utxo.txid, 'hex').reverse(), utxo.vout);
+            }
+            tx.addOutput(burnScript, burn);
+            if (finalChange > 0) {
+                tx.addOutput(bitcoin.address.toOutputScript(changeAddress, avianNetwork), finalChange);
+            }
+            tx.addOutput(parentReturnScript, 0);
+            tx.addOutput(reissueScript, 0);
+
+            for (let i = 0; i < allInputs.length; i++) {
+                const utxo = allInputs[i];
+                const prevTxHex = await this.electrum.getTransaction(utxo.txid, false);
+                const prevOut = bitcoin.Transaction.fromHex(prevTxHex).outs[utxo.vout];
+                const digest = tx.hashForSignature(i, prevOut.script, SIGHASH_ALL_FORKID);
+                const derSignature = this.encodeDERWithCustomHashType(
+                    Buffer.from(keyPair.sign(digest)),
+                    SIGHASH_ALL_FORKID,
+                );
+                tx.ins[i].script = bitcoin.script.compile([derSignature, pubkey]);
+            }
+
+            const txHex = tx.toHex();
+            const txId = tx.getId();
+            await this.broadcastRawTransaction(txHex);
+            return txId;
+        } catch (error) {
+            walletLogger.error('Asset reissue failed:', error);
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Asset reissue failed: ${message}`);
         }
     }
 

--- a/src/services/wallet/assetIssuance.test.ts
+++ b/src/services/wallet/assetIssuance.test.ts
@@ -298,3 +298,59 @@ describe('issueSubAsset', () => {
     });
   });
 });
+
+describe('reissueAsset', () => {
+  it('spends the owner token, burns 100 AVN, and lays out owner (2nd-last) then reissue (last)', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createChildElectrum(address, 'MYASSET', [200 * COIN]);
+    const wallet = new WalletService(electrum as never);
+
+    await wallet.reissueAsset(
+      'MYASSET',
+      { amount: 500n * BigInt(COIN), units: -1, reissuable: true },
+      TEST_PASSWORD,
+      { feeRate: 1 },
+    );
+
+    const tx = bitcoin.Transaction.fromHex(broadcast.mock.calls[0][0] as string);
+    const outs = tx.outs;
+    // 100-AVN burn to the reissue burn address.
+    expect(
+      outs.some(
+        (o) => o.value === 100 * COIN &&
+          (() => {
+            try {
+              return bitcoin.address.fromOutputScript(o.script, avianNetwork) === ISSUE_BURN.reissue.address;
+            } catch {
+              return false;
+            }
+          })(),
+      ),
+    ).toBe(true);
+    // Owner returned (2nd-last), reissue output (last) — no new owner token.
+    expect(parseAssetScript(outs[outs.length - 2].script as Buffer)).toMatchObject({
+      type: 'transfer',
+      name: 'MYASSET!',
+    });
+    expect(parseAssetScript(outs[outs.length - 1].script as Buffer)).toMatchObject({
+      type: 'reissue',
+      name: 'MYASSET',
+      amount: 500n * BigInt(COIN),
+    });
+    // Two inputs: the owner token + one AVN.
+    expect(tx.ins.length).toBe(2);
+  });
+
+  it('refuses when the owner token is not held', async () => {
+    const { address } = await createActiveWallet();
+    const { electrum, broadcast } = createChildElectrum(address, 'MYASSET', [200 * COIN], false);
+    const wallet = new WalletService(electrum as never);
+
+    await expect(
+      wallet.reissueAsset('MYASSET', { amount: 1n * BigInt(COIN), units: -1, reissuable: true }, TEST_PASSWORD, {
+        feeRate: 1,
+      }),
+    ).rejects.toThrow(/MYASSET! owner token/);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/wallet/assetScript.test.ts
+++ b/src/services/wallet/assetScript.test.ts
@@ -6,6 +6,7 @@ import {
   buildAssetTransferScript,
   buildIssuanceScript,
   buildOwnerScript,
+  buildReissueScript,
   parseAssetScript,
   ASSET_MARKER,
 } from './assetScript';
@@ -95,6 +96,72 @@ describe('parseAssetScript', () => {
   it('returns null for a plain (non-asset) P2PKH', () => {
     const plain = bitcoin.address.toOutputScript(ADDR, avianNetwork);
     expect(parseAssetScript(plain)).toBeNull();
+  });
+});
+
+describe('buildReissueScript', () => {
+  // Independently construct the expected reissue payload from Core's CReissueAsset format:
+  // "rvn" · 'r' · compactSize(name) · name · int64LE(amount) · int8(units) · int8(reissuable) ·
+  // [ipfs] · 0x00 (empty ANSID). No hasIPFS/hasANS flags (unlike CNewAsset).
+  function expectedReissue(name: string, amount: bigint, units: number, reissuable: boolean): Buffer {
+    const p2pkh = bitcoin.address.toOutputScript(ADDR, avianNetwork);
+    const nameBuf = Buffer.from(name, 'ascii');
+    const amountBuf = Buffer.alloc(8);
+    amountBuf.writeBigInt64LE(amount);
+    const payload = Buffer.concat([
+      Buffer.from([0x72, 0x76, 0x6e, 0x72]), // rvn + 'r'
+      Buffer.from([nameBuf.length]),
+      nameBuf,
+      amountBuf,
+      Buffer.from([units & 0xff]),
+      Buffer.from([reissuable ? 1 : 0]),
+      Buffer.from([0x00]), // empty ANSID
+    ]);
+    const push = Buffer.concat([Buffer.from([payload.length]), payload]);
+    return Buffer.concat([p2pkh, Buffer.from([OP_AVN_ASSET]), push, Buffer.from([0x75])]);
+  }
+
+  it('matches an independent construction (mint more supply, units unchanged)', () => {
+    const built = buildReissueScript(ADDR, {
+      name: 'FLIGHTDECK',
+      amount: 1000n * 100_000_000n,
+      units: -1, // unchanged → 0xff
+      reissuable: true,
+    });
+    expect(built.toString('hex')).toBe(
+      expectedReissue('FLIGHTDECK', 1000n * 100_000_000n, -1, true).toString('hex'),
+    );
+    // -1 units serialize as 0xff.
+    expect(built.includes(Buffer.from([0xff, 0x01, 0x00]))).toBe(true);
+  });
+
+  it('parses back as a reissue with its name and amount', () => {
+    const built = buildReissueScript(ADDR, { name: 'SMAUG', amount: 5n * 100_000_000n, units: 0, reissuable: false });
+    expect(parseAssetScript(built)).toMatchObject({
+      type: 'reissue',
+      name: 'SMAUG',
+      amount: 5n * 100_000_000n,
+    });
+  });
+
+  it('allows a metadata-only reissue (amount 0)', () => {
+    expect(() => buildReissueScript(ADDR, { name: 'SMAUG', amount: 0n, units: -1, reissuable: false })).not.toThrow();
+  });
+
+  it('reproduces a real Core reissue (CRAIG_KINGDOM +1, units unchanged) byte-for-byte', () => {
+    // The reissue output of a real Avian Core CRAIG_KINGDOM reissue: +1 supply, units unchanged
+    // (0xff), stays reissuable. Definitive validation of the 100-AVN-burn reissue path.
+    const DEST = 'RBzWECT1sEKDVfQBH8aJDrv7pnDrXKA9E9';
+    expect(
+      buildReissueScript(DEST, {
+        name: 'CRAIG_KINGDOM',
+        amount: 100_000_000n,
+        units: -1, // unchanged → 0xff
+        reissuable: true,
+      }).toString('hex'),
+    ).toBe(
+      '76a9141dc074e3cc3747909b016fb0adb604ee19ef87f188acc01d72766e720d43524149475f4b494e47444f4d00e1f50500000000ff010075',
+    );
   });
 });
 

--- a/src/services/wallet/assetScript.ts
+++ b/src/services/wallet/assetScript.ts
@@ -105,7 +105,11 @@ export const ISSUE_BURN = {
   root: { amount: 500n * 100_000_000n, address: 'RXissueAssetXXXXXXXXXXXXXXXXXhhZGt' },
   sub: { amount: 100n * 100_000_000n, address: 'RXissueSubAssetXXXXXXXXXXXXXWcwhwL' },
   unique: { amount: 5n * 100_000_000n, address: 'RXissueUniqueAssetXXXXXXXXXXWEAe58' },
+  reissue: { amount: 100n * 100_000_000n, address: 'RXReissueAssetXXXXXXXXXXXXXXVEFAWu' },
 } as const;
+
+/** Sentinel for a reissue that leaves the asset's divisions unchanged (Core: nUnits == -1). */
+export const REISSUE_UNITS_UNCHANGED = -1;
 
 /**
  * Whether `name` is a valid root asset name (a friendly pre-flight; consensus is authoritative).
@@ -196,6 +200,46 @@ export function buildIssuanceScript(address: string, params: IssuanceParams): Bu
     Buffer.from([ipfsBlob ? 1 : 0]), // hasIPFS
     ...(ipfsBlob ? [ipfsBlob] : []),
     Buffer.from([0]), // hasANS = 0
+  ]);
+  return wrapAssetScript(legacyP2PKHScript(address), payload);
+}
+
+export interface ReissueParams {
+  name: string;
+  /** Additional supply to mint (10^8-scaled); 0 for a metadata-only reissue. */
+  amount: bigint;
+  /** New divisions 0–8, or REISSUE_UNITS_UNCHANGED (-1) to leave them as they are. */
+  units: number;
+  /** Whether the asset stays reissuable afterwards (false locks it permanently). */
+  reissuable: boolean;
+  /** Optional new IPFS/txid; omit to keep the existing one. */
+  ipfs?: string;
+}
+
+/**
+ * Build a reissue output (`rvn·r · CReissueAsset`) minting `amount` more of an existing asset to
+ * `address` and/or updating its units/reissuable/IPFS. `CReissueAsset` has no hasIPFS/hasANS flags:
+ * the IPFS blob is present only when given, and an empty ANS id is a trailing 0x00. Byte-exact to
+ * Avian Core.
+ */
+export function buildReissueScript(address: string, params: ReissueParams): Buffer {
+  const { name, amount, units, reissuable, ipfs } = params;
+  if (amount < 0n) throw new Error('Reissue amount cannot be negative');
+  if (units !== REISSUE_UNITS_UNCHANGED && (units < 0 || units > 8)) {
+    throw new Error('Units must be 0–8, or -1 to keep them unchanged');
+  }
+  const nameBuf = Buffer.from(name, 'ascii');
+  const ipfsBlob = ipfs ? encodeAssetData(ipfs) : null;
+  const payload = Buffer.concat([
+    ASSET_MARKER,
+    Buffer.from([ASSET_TYPE.reissue]),
+    encodeCompactSize(nameBuf.length),
+    nameBuf,
+    int64LE(amount),
+    Buffer.from([units & 0xff]), // -1 → 0xff (no change)
+    Buffer.from([reissuable ? 1 : 0]),
+    ...(ipfsBlob ? [ipfsBlob] : []), // SerializeIPFSHash writes nothing when absent
+    Buffer.from([0]), // empty strANSID
   ]);
   return wrapAssetScript(legacyP2PKHScript(address), payload);
 }


### PR DESCRIPTION
Reissue a reissuable asset you own: mint more supply and/or change divisions (increase-only), the reissuable flag, or the IPFS hash. **Burns 100 AVN.** **Validated byte-for-byte against your real Core CRAIG_KINGDOM reissue** — including the `0xff` units-unchanged sentinel.

- `buildReissueScript`: `rvn·r · CReissueAsset` (name, amount, units, reissuable, [ipfs], empty ANSID — no hasIPFS/hasANS flags). `ISSUE_BURN.reissue` (100 AVN + `RXReissueAsset…`).
- `reissueAsset`: spends the `NAME!` owner token (returned), burns 100 AVN, outputs `burn / change / owner transfer (2nd-last) / reissue (last)`.
- **ReissueAssetDialog** + a Reissue (⊕) action on the asset row, shown only for reissuable assets whose `NAME!` owner token you hold: additional-supply, divisions (increase-only), reissuable (with a lock warning), IPFS, a 100 AVN burn confirmation, auth, and a success screen with explorer link.

Golden vector + stub-network structure tests; typecheck + lint clean, build passes. Rebased on the latest main (includes the #81 mobile fix). Bumps to 2.4.40.

A burn only occurs on a consensus-valid reissue, so a bad one fails harmlessly (no burn).