### PR TITLE
fix(ui): stop large balance forcing horizontal overflow on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.40",
+  "version": "2.4.41",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -16,10 +16,10 @@ export function AppLayout({ children, headerProps, sidebarProps }: AppLayoutProp
     return (
         <SidebarProvider>
             <AppSidebar {...sidebarProps} />
-            <SidebarInset>
+            <SidebarInset className="min-w-0">
                 <AppHeader {...headerProps} />
                 <GradientBackground>
-                    <main className="flex flex-1 flex-col gap-4 p-6 pt-4">
+                    <main className="flex min-w-0 flex-1 flex-col gap-4 p-6 pt-4">
                         <div className="grid auto-rows-max items-start gap-6 md:gap-8 lg:col-span-2">
                             {children}
                         </div>


### PR DESCRIPTION
## Problem

On mobile, a large total balance (the `Sample` screenshot showed `5374639.66098297 AVN`) expanded outside the card and forced the whole page to scroll horizontally.

## Root cause

The dashboard content column — shadcn's `SidebarInset` and our own `<main>` — are flex items with `flex-1` but **no `min-w-0`**. A flex item without `min-w-0` won't shrink below its content's intrinsic width, so the wide monospace balance readout pushed the column past the viewport.

The `BalanceInstrument` readout was already set up to wrap (`min-w-0 break-words` + an `overflow-hidden` section backstop) — it just never got the chance because its container couldn't shrink.

## Fix

Add `min-w-0` to `SidebarInset` (via `className`, no edit to the shared shadcn component) and to `<main>`. The column now shrinks to the viewport and the existing `break-words` wrapping takes over.

Bump to 2.4.41.