### PR TITLE
fix(ui): stop asset list forcing horizontal overflow on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.41",
+  "version": "2.4.42",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -237,7 +237,7 @@ export default function Home() {
             }}
         >
             {/* Multi-panel dashboard for desktop, single column for mobile */}
-            <div className="block lg:hidden max-w-xl md:max-w-2xl space-y-6">
+            <div className="block lg:hidden min-w-0 max-w-xl md:max-w-2xl space-y-6">
                 {/* Mobile layout */}
 
                 {/* Balance instrument */}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -20,7 +20,7 @@ export function AppLayout({ children, headerProps, sidebarProps }: AppLayoutProp
                 <AppHeader {...headerProps} />
                 <GradientBackground>
                     <main className="flex min-w-0 flex-1 flex-col gap-4 p-6 pt-4">
-                        <div className="grid auto-rows-max items-start gap-6 md:gap-8 lg:col-span-2">
+                        <div className="grid grid-cols-1 auto-rows-max items-start gap-6 md:gap-8 lg:col-span-2">
                             {children}
                         </div>
                     </main>


### PR DESCRIPTION
## Problem

On mobile the **Assets** card expanded past the viewport, pushing the per-row Send controls off-screen and creating a horizontal scroll. Deleting the asset rows in devtools resized the page correctly — confirming the rows are the width driver.

## Root cause

The dashboard content is rendered inside AppLayout's grid, which had **no explicit columns** — a single `auto` track. Grid items in an `auto` track get `min-width: auto`, so they won't shrink below their content's min-content width.

Each asset name is rendered with `truncate` (`white-space: nowrap`), and a nowrap element's **min-content contribution is the full untruncated text**. So a long name like `AVIANMEMECONTEST#7_OF_100` forced the grid item — and the whole page — wider than the viewport.

#83's `min-w-0` on `<main>` couldn't fix this on its own because the grid re-establishes `min-width: auto` on its own items.

## Fix

- Set the grid track to `minmax(0, 1fr)` via `grid-cols-1` on the AppLayout grid, so items can shrink below their content.
- Add a defensive `min-w-0` on the mobile dashboard column.

The asset row's existing `truncate` then constrains long names to the card width; the Send/Reissue controls stay on-screen.

Bump to 2.4.42.