### PR TITLE
feat(ui): enlarge asset image preview on desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.42",
+  "version": "2.4.43",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -254,7 +254,7 @@ export function AssetList({ className }: { className?: string }) {
       />
 
       <Dialog open={preview !== null} onOpenChange={(next) => !next && setPreview(null)}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-2xl md:max-w-3xl lg:max-w-4xl">
           <DialogHeader>
             <DialogTitle className="break-all font-mono text-sm">{preview?.name}</DialogTitle>
           </DialogHeader>
@@ -263,7 +263,7 @@ export function AssetList({ className }: { className?: string }) {
             <img
               src={preview.url}
               alt={preview.name}
-              className="mx-auto max-h-[70vh] w-full rounded-md object-contain"
+              className="mx-auto max-h-[80vh] w-auto max-w-full rounded-md object-contain"
             />
           )}
         </DialogContent>


### PR DESCRIPTION
## Change

The asset IPFS image preview modal was capped at `sm:max-w-md` (448px), so a large image (e.g. SMAUG) rendered small on desktop.

- Widen the preview dialog responsively: `sm:max-w-2xl` → `md:max-w-3xl` → `lg:max-w-4xl`.
- Let the image size to its intrinsic width up to the container (`w-auto max-w-full`) and raise the height cap to `max-h-[80vh]`, so it fills the available space on large screens while staying contained on mobile.

Bump to 2.4.43.