### PR TITLE
feat(assets): label asset transactions in history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.43",
+  "version": "2.4.44",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -15,6 +15,7 @@ import {
   ChevronRight,
   RefreshCw,
   Inbox,
+  Coins,
 } from 'lucide-react';
 
 import {
@@ -31,6 +32,8 @@ import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/EmptyState';
 import { toast } from 'sonner';
+import { useAssetTxOutputs } from '@/hooks/useAssetTxOutputs';
+import { describeAssetTx, formatAssetQty, type AssetTxLabel } from '@/services/wallet/assetHistory';
 
 // Loading placeholder that mirrors the transaction-row layout, so the list settles into place
 // rather than flashing a bare spinner.
@@ -48,6 +51,40 @@ function TxRowSkeleton() {
         </div>
         <Skeleton className="h-4 w-20 flex-shrink-0" />
       </div>
+    </div>
+  );
+}
+
+// A compact chip summarising the asset side of a transaction (e.g. "+5 SMAUG", "Issued
+// FLIGHTDECK#desktop"). Gains (receive/issue/reissue) read in the primary colour, sends in sodium.
+function AssetChips({ label }: { label: AssetTxLabel }) {
+  const positive = label.action !== 'send';
+  const color = positive ? 'bg-primary/10 text-primary' : 'bg-sodium/10 text-sodium';
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {label.entries.map((e) => {
+        let text: string;
+        if (label.action === 'issue') {
+          text = `Issued ${e.name}`;
+        } else if (label.action === 'reissue') {
+          text =
+            e.amount && e.amount > 0n
+              ? `Reissued ${e.name} (+${formatAssetQty(e.amount)})`
+              : `Reissued ${e.name}`;
+        } else {
+          text = `${label.action === 'receive' ? '+' : '−'}${formatAssetQty(e.amount ?? 0n)} ${e.name}`;
+        }
+        return (
+          <span
+            key={`${label.action}-${e.name}`}
+            className={`inline-flex max-w-full items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium ${color}`}
+            title={text}
+          >
+            <Coins className="h-3 w-3 flex-shrink-0" />
+            <span className="truncate font-mono">{text}</span>
+          </span>
+        );
+      })}
     </div>
   );
 }
@@ -295,6 +332,9 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
   const endIndex = startIndex + itemsPerPage;
   const paginatedTransactions = filteredTransactions.slice(startIndex, endIndex);
 
+  // Re-derive the asset side of each visible transaction (the history store keeps only the AVN side).
+  const assetOutputs = useAssetTxOutputs(paginatedTransactions.map((tx) => tx.txid));
+
   const nextPage = () => {
     if (currentPage < totalPages) {
       setCurrentPage(currentPage + 1);
@@ -478,7 +518,11 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
             />
           ) : (
             <div className="divide-y divide-border">
-              {paginatedTransactions.map((tx) => (
+              {paginatedTransactions.map((tx) => {
+                const outs = assetOutputs.get(tx.txid);
+                const assetLabel =
+                  outs && outs.length ? describeAssetTx(outs, address || '', tx.type) : null;
+                return (
                 <div
                   key={`${tx.id || tx.txid}-${tx.type}${tx.isVirtual ? '-virtual' : ''}`}
                   className="p-4 hover:bg-muted/50"
@@ -527,6 +571,8 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
                           </span>
                         </div>
 
+                        {assetLabel && <AssetChips label={assetLabel} />}
+
                         <div className="flex items-center gap-3">
                           <span className="text-sm text-muted-foreground">
                             {formatDate(tx.timestamp)}
@@ -553,7 +599,8 @@ export function TransactionHistory({ className }: TransactionHistoryProps) {
                     </div>
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/src/hooks/useAssetTxOutputs.ts
+++ b/src/hooks/useAssetTxOutputs.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useWallet } from '@/contexts/WalletContext';
+import { decodeAssetOutputs } from '@/services/wallet/assetHistory';
+import type { AssetScriptInfo } from '@/services/wallet/assetScript';
+
+/**
+ * Lazily decode the asset outputs of the given transactions (typically the visible history page).
+ *
+ * The transaction history stores only the AVN side, so the asset side is re-derived on demand from
+ * each transaction's raw hex. Results are cached by txid across pages and fetched with modest
+ * concurrency; labels appear progressively as batches resolve. A transaction with no asset outputs
+ * caches as an empty array so it is never re-fetched.
+ *
+ * Returns a Map of txid → decoded asset outputs (undefined for a txid that hasn't loaded yet).
+ */
+export function useAssetTxOutputs(txids: string[]): Map<string, AssetScriptInfo[]> {
+  const { electrum, address } = useWallet();
+  const cache = useRef<Map<string, AssetScriptInfo[]>>(new Map());
+  const inflight = useRef<Set<string>>(new Set());
+  // Bump to re-render the consumer as cached results fill in; the Map reference stays stable.
+  const [, bump] = useState(0);
+
+  const key = txids.join(',');
+
+  useEffect(() => {
+    if (!electrum || !address) return;
+    // Refs are stable for the component's lifetime; capture them so the cleanup closure is clearly
+    // operating on the same instances the effect used.
+    const cacheMap = cache.current;
+    const inflightSet = inflight.current;
+
+    const toFetch = txids.filter((id) => id && !cacheMap.has(id) && !inflightSet.has(id));
+    if (toFetch.length === 0) return;
+
+    let cancelled = false;
+    toFetch.forEach((id) => inflightSet.add(id));
+
+    (async () => {
+      const CONCURRENCY = 6;
+      for (let i = 0; i < toFetch.length; i += CONCURRENCY) {
+        if (cancelled) break;
+        const batch = toFetch.slice(i, i + CONCURRENCY);
+        const results = await Promise.all(
+          batch.map(async (id) => {
+            try {
+              const hex: string = await electrum.getTransaction(id, false);
+              return [id, decodeAssetOutputs(hex)] as const;
+            } catch {
+              // A fetch/parse failure caches as "no assets" so the row degrades to a plain AVN entry
+              // rather than retrying forever.
+              return [id, [] as AssetScriptInfo[]] as const;
+            }
+          }),
+        );
+        for (const [id, outs] of results) {
+          cacheMap.set(id, outs);
+          inflightSet.delete(id);
+        }
+        if (!cancelled) bump((v) => v + 1);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      // Release any not-yet-fetched ids so a later render can pick them up again.
+      toFetch.forEach((id) => {
+        if (!cacheMap.has(id)) inflightSet.delete(id);
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, electrum, address]);
+
+  return cache.current;
+}

--- a/src/services/wallet/assetHistory.test.ts
+++ b/src/services/wallet/assetHistory.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeAssetTx, formatAssetQty } from './assetHistory';
+import type { AssetScriptInfo } from './assetScript';
+
+const US = 'RXt29uWwW6RJRSjZ4nrpLLpwVs2Xt7YyXm';
+const THEM = 'RXReissueAssetXXXXXXXXXXXXXXVEFAWu';
+
+// Terse builder for a decoded asset output.
+const out = (
+  type: AssetScriptInfo['type'],
+  name: string,
+  amount: bigint | null,
+  address: string | null,
+): AssetScriptInfo => ({ type, name, amount, address });
+
+describe('formatAssetQty', () => {
+  it('drops trailing zeros so a whole quantity reads as an integer', () => {
+    expect(formatAssetQty(100_000_000n)).toBe('1');
+    expect(formatAssetQty(1_500_000_000n)).toBe('15');
+  });
+
+  it('keeps only the significant decimals', () => {
+    expect(formatAssetQty(550_000_000n)).toBe('5.5');
+    expect(formatAssetQty(1n)).toBe('0.00000001');
+    expect(formatAssetQty(0n)).toBe('0');
+  });
+});
+
+describe('describeAssetTx', () => {
+  it('returns null when the transaction carries no asset outputs', () => {
+    expect(describeAssetTx([], US, 'receive')).toBeNull();
+  });
+
+  it('labels a received transfer with the amount paid to us', () => {
+    const outputs = [
+      out('transfer', 'SMAUG', 500_000_000n, US), // 5 to us
+      out('transfer', 'SMAUG', 200_000_000n, THEM), // change/other — ignored on receive
+    ];
+    expect(describeAssetTx(outputs, US, 'receive')).toEqual({
+      action: 'receive',
+      entries: [{ name: 'SMAUG', amount: 500_000_000n }],
+    });
+  });
+
+  it('labels a sent transfer with the amount that left to others (change excluded)', () => {
+    const outputs = [
+      out('transfer', 'SMAUG', 500_000_000n, THEM), // 5 sent away
+      out('transfer', 'SMAUG', 900_000_000n, US), // change back to us — excluded
+    ];
+    expect(describeAssetTx(outputs, US, 'send')).toEqual({
+      action: 'send',
+      entries: [{ name: 'SMAUG', amount: 500_000_000n }],
+    });
+  });
+
+  it('recognises an issuance regardless of the AVN-side classification', () => {
+    const outputs = [
+      out('issue', 'FLIGHTDECK#desktop', 100_000_000n, US),
+      out('owner', 'FLIGHTDECK!', null, US),
+    ];
+    expect(describeAssetTx(outputs, US, 'send')).toEqual({
+      action: 'issue',
+      entries: [{ name: 'FLIGHTDECK#desktop', amount: 100_000_000n }],
+    });
+  });
+
+  it('recognises a reissue', () => {
+    const outputs = [
+      out('reissue', 'CRAIG_KINGDOM', 200_000_000n, US),
+      out('owner', 'CRAIG_KINGDOM!', null, US),
+    ];
+    expect(describeAssetTx(outputs, US, 'send')).toEqual({
+      action: 'reissue',
+      entries: [{ name: 'CRAIG_KINGDOM', amount: 200_000_000n }],
+    });
+  });
+
+  it('sums multiple outputs of the same asset', () => {
+    const outputs = [
+      out('transfer', 'SMAUG', 300_000_000n, US),
+      out('transfer', 'SMAUG', 200_000_000n, US),
+    ];
+    expect(describeAssetTx(outputs, US, 'receive')).toEqual({
+      action: 'receive',
+      entries: [{ name: 'SMAUG', amount: 500_000_000n }],
+    });
+  });
+
+  it('ignores an owner-token-only movement', () => {
+    const outputs = [out('owner', 'CRAIG_KINGDOM!', null, THEM)];
+    expect(describeAssetTx(outputs, US, 'send')).toBeNull();
+  });
+});

--- a/src/services/wallet/assetHistory.ts
+++ b/src/services/wallet/assetHistory.ts
@@ -1,0 +1,97 @@
+// Asset transaction history: turn a raw transaction into a human label like "Received 5 SMAUG",
+// "Issued FLIGHTDECK#desktop" or "Reissued CRAIG_KINGDOM". This is read-only display logic — it
+// decodes a transaction's outputs and classifies the asset movement from the wallet's point of
+// view. It never touches the sync pipeline or storage; the transaction history stores only the AVN
+// side, so we re-derive the asset side on demand from the raw hex.
+
+import * as bitcoin from 'bitcoinjs-lib';
+import { parseAssetScript, type AssetScriptInfo } from './assetScript';
+
+/** One asset touched by a transaction, with the amount involved (null for an owner token). */
+export interface AssetTxEntry {
+  name: string;
+  /** Integer units, scaled by 10^8 (like AVN); null for an owner token, which carries no amount. */
+  amount: bigint | null;
+}
+
+export interface AssetTxLabel {
+  /** issue = minted new, reissue = minted more / updated, send/receive = a transfer. */
+  action: 'issue' | 'reissue' | 'send' | 'receive';
+  entries: AssetTxEntry[];
+}
+
+/**
+ * Decode every asset-carrying output of a raw transaction. bitcoinjs parses the outputs generically
+ * (the asset bytes are just part of each scriptPubKey), so this works regardless of how a given
+ * ElectrumX server renders assets in its verbose decode. Non-asset outputs are skipped.
+ */
+export function decodeAssetOutputs(txHex: string): AssetScriptInfo[] {
+  const tx = bitcoin.Transaction.fromHex(txHex);
+  const infos: AssetScriptInfo[] = [];
+  for (const out of tx.outs) {
+    const info = parseAssetScript(out.script);
+    if (info) infos.push(info);
+  }
+  return infos;
+}
+
+/** Sum output amounts by asset name, preserving first-seen order. */
+function aggregate(outs: AssetScriptInfo[]): AssetTxEntry[] {
+  const order: string[] = [];
+  const totals = new Map<string, bigint>();
+  for (const o of outs) {
+    if (!totals.has(o.name)) order.push(o.name);
+    totals.set(o.name, (totals.get(o.name) ?? 0n) + (o.amount ?? 0n));
+  }
+  return order.map((name) => ({ name, amount: totals.get(name) ?? 0n }));
+}
+
+/**
+ * Classify a transaction's asset movement from the wallet's perspective. `rowType` is the history
+ * row's existing AVN-side classification (send/receive), which we use to pick the transfer direction
+ * without having to fetch input ownership.
+ *
+ * Issuance and reissue are recognised by their output type. Transfers are attributed by address:
+ * outputs paying the wallet are "received", outputs paying elsewhere are "sent" (change back to the
+ * wallet is naturally excluded from the sent side). Owner-token-only movements produce no label.
+ */
+export function describeAssetTx(
+  outputs: AssetScriptInfo[],
+  walletAddress: string,
+  rowType: 'send' | 'receive',
+): AssetTxLabel | null {
+  if (outputs.length === 0) return null;
+
+  const issue = outputs.filter((o) => o.type === 'issue');
+  if (issue.length) return { action: 'issue', entries: aggregate(issue) };
+
+  const reissue = outputs.filter((o) => o.type === 'reissue');
+  if (reissue.length) return { action: 'reissue', entries: aggregate(reissue) };
+
+  const transfers = outputs.filter((o) => o.type === 'transfer');
+  if (transfers.length === 0) return null; // e.g. an owner token moving alongside a sub-asset issue
+
+  const toUs = transfers.filter((o) => o.address === walletAddress);
+  const toOthers = transfers.filter((o) => o.address !== walletAddress);
+
+  // Trust the row's own send/receive classification first; fall back to whichever side has outputs.
+  if (rowType === 'receive' && toUs.length) return { action: 'receive', entries: aggregate(toUs) };
+  if (toOthers.length) return { action: 'send', entries: aggregate(toOthers) };
+  if (toUs.length) return { action: 'receive', entries: aggregate(toUs) };
+  return null;
+}
+
+/**
+ * Format an asset amount (integer units scaled by 10^8) as a trimmed decimal string, e.g.
+ * 100000000 → "1", 550000000 → "5.5". Divisions don't need to be known here: trailing zeros are
+ * dropped, which yields the same result the asset's divisions would.
+ */
+export function formatAssetQty(sats: bigint): string {
+  const COIN = 100_000_000n;
+  const neg = sats < 0n;
+  const v = neg ? -sats : sats;
+  const whole = v / COIN;
+  const frac = (v % COIN).toString().padStart(8, '0').replace(/0+$/, '');
+  const s = frac ? `${whole.toString()}.${frac}` : whole.toString();
+  return neg ? `-${s}` : s;
+}


### PR DESCRIPTION
## What

Transaction history stored only the **AVN side** of each transaction, so an asset transfer/issue/reissue showed as a bare `Send`/`Receive` with a fee-sized AVN amount and no indication an asset moved.

Each history row now shows a compact chip describing the asset movement:

- `+5 SMAUG` / `−5 SMAUG` for transfers (received / sent)
- `Issued FLIGHTDECK#desktop`
- `Reissued CRAIG_KINGDOM (+2)`

## How

The asset side is re-derived **on demand** — no changes to the sync pipeline or storage:

- For the visible page, fetch each transaction's raw hex (`getTransaction(txid, false)`) and decode its outputs with **bitcoinjs + `parseAssetScript`**. Decoding the raw outputs ourselves is server-agnostic — it doesn't depend on how a given ElectrumX fork renders assets in its verbose output.
- `describeAssetTx` classifies the movement from the wallet's perspective: issuance/reissue by output type; transfers attributed by address (outputs paying us = received, outputs paying others = sent, so change back to us is naturally excluded), using the row's existing send/receive classification to pick direction.
- Results are cached by txid across pages and fetched with modest concurrency (6), so labels fill in progressively. A plain AVN transaction shows no chip; a fetch/parse failure degrades gracefully to no chip.

## Files

- `src/services/wallet/assetHistory.ts` — `decodeAssetOutputs` / `describeAssetTx` / `formatAssetQty` (pure logic)
- `src/hooks/useAssetTxOutputs.ts` — lazy, cached per-page decode hook
- `src/components/TransactionHistory.tsx` — renders the `AssetChips`
- `src/services/wallet/assetHistory.test.ts` — 9 unit tests (labeling + formatting)

Typecheck, lint, `next build`, and tests all green. Bump to 2.4.44.