### PR TITLE
fix(assets): describe received issuances as inbound, not 'Issued'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.44",
+  "version": "2.4.45",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/assetHistory.test.ts
+++ b/src/services/wallet/assetHistory.test.ts
@@ -65,6 +65,26 @@ describe('describeAssetTx', () => {
     });
   });
 
+  it('describes a received issuance as an inbound asset, not "Issued"', () => {
+    // Someone else issued FLIGHTDECK and sent it to us; from our side it is simply received.
+    const outputs = [
+      out('issue', 'FLIGHTDECK', 100_000_000n, US),
+      out('owner', 'FLIGHTDECK!', null, THEM), // issuer keeps the owner token
+    ];
+    expect(describeAssetTx(outputs, US, 'receive')).toEqual({
+      action: 'receive',
+      entries: [{ name: 'FLIGHTDECK', amount: 100_000_000n }],
+    });
+  });
+
+  it('counts a received owner token as one unit', () => {
+    const outputs = [out('owner', 'FLIGHTDECK!', null, US)];
+    expect(describeAssetTx(outputs, US, 'receive')).toEqual({
+      action: 'receive',
+      entries: [{ name: 'FLIGHTDECK!', amount: 100_000_000n }],
+    });
+  });
+
   it('recognises a reissue', () => {
     const outputs = [
       out('reissue', 'CRAIG_KINGDOM', 200_000_000n, US),

--- a/src/services/wallet/assetHistory.ts
+++ b/src/services/wallet/assetHistory.ts
@@ -41,19 +41,23 @@ function aggregate(outs: AssetScriptInfo[]): AssetTxEntry[] {
   const totals = new Map<string, bigint>();
   for (const o of outs) {
     if (!totals.has(o.name)) order.push(o.name);
-    totals.set(o.name, (totals.get(o.name) ?? 0n) + (o.amount ?? 0n));
+    // An owner token carries no amount but represents a single unit (scaled by 10^8 like any asset).
+    const amt = o.amount ?? (o.type === 'owner' ? 100_000_000n : 0n);
+    totals.set(o.name, (totals.get(o.name) ?? 0n) + amt);
   }
   return order.map((name) => ({ name, amount: totals.get(name) ?? 0n }));
 }
 
 /**
  * Classify a transaction's asset movement from the wallet's perspective. `rowType` is the history
- * row's existing AVN-side classification (send/receive), which we use to pick the transfer direction
- * without having to fetch input ownership.
+ * row's existing AVN-side classification (send/receive), which we trust to pick direction without
+ * fetching input ownership.
  *
- * Issuance and reissue are recognised by their output type. Transfers are attributed by address:
- * outputs paying the wallet are "received", outputs paying elsewhere are "sent" (change back to the
- * wallet is naturally excluded from the sent side). Owner-token-only movements produce no label.
+ * A wallet only ever issues or reissues on a send (it pays the burn), so the mint labels are gated
+ * to send rows. On a receive we describe purely what landed in the wallet — even when the whole
+ * transaction is an issuance done by someone else, from here it is simply an inbound asset. Sent
+ * transfers are attributed to outputs paying other addresses, so change back to the wallet is
+ * naturally excluded.
  */
 export function describeAssetTx(
   outputs: AssetScriptInfo[],
@@ -62,22 +66,27 @@ export function describeAssetTx(
 ): AssetTxLabel | null {
   if (outputs.length === 0) return null;
 
-  const issue = outputs.filter((o) => o.type === 'issue');
-  if (issue.length) return { action: 'issue', entries: aggregate(issue) };
+  if (rowType === 'send') {
+    const issue = outputs.filter((o) => o.type === 'issue');
+    if (issue.length) return { action: 'issue', entries: aggregate(issue) };
 
-  const reissue = outputs.filter((o) => o.type === 'reissue');
-  if (reissue.length) return { action: 'reissue', entries: aggregate(reissue) };
+    const reissue = outputs.filter((o) => o.type === 'reissue');
+    if (reissue.length) return { action: 'reissue', entries: aggregate(reissue) };
 
-  const transfers = outputs.filter((o) => o.type === 'transfer');
-  if (transfers.length === 0) return null; // e.g. an owner token moving alongside a sub-asset issue
+    const transfers = outputs.filter((o) => o.type === 'transfer');
+    if (transfers.length === 0) return null; // e.g. an owner token moving alongside a sub-asset issue
+    const toOthers = transfers.filter((o) => o.address !== walletAddress);
+    return { action: 'send', entries: aggregate(toOthers.length ? toOthers : transfers) };
+  }
 
-  const toUs = transfers.filter((o) => o.address === walletAddress);
-  const toOthers = transfers.filter((o) => o.address !== walletAddress);
-
-  // Trust the row's own send/receive classification first; fall back to whichever side has outputs.
-  if (rowType === 'receive' && toUs.length) return { action: 'receive', entries: aggregate(toUs) };
-  if (toOthers.length) return { action: 'send', entries: aggregate(toOthers) };
-  if (toUs.length) return { action: 'receive', entries: aggregate(toUs) };
+  // rowType === 'receive': whatever the wallet received, regardless of the transaction's overall
+  // purpose. Issue/reissue outputs paying the wallet are received amounts too.
+  const received = outputs.filter(
+    (o) =>
+      o.address === walletAddress &&
+      (o.type === 'transfer' || o.type === 'issue' || o.type === 'reissue' || o.type === 'owner'),
+  );
+  if (received.length) return { action: 'receive', entries: aggregate(received) };
   return null;
 }
 


### PR DESCRIPTION
## Problem

Testing #86 against real history surfaced one mislabeled row:

```
receive · From: RWdrtiny… · Issued FLIGHTDECK · +0 AVN
```

That transaction is an issuance, but **this wallet received the asset — RWdrtiny issued it**. Every other inbound row reads `+N ASSET`, so this one should too.

## Cause

`describeAssetTx` checked issue/reissue **before** direction, so any transaction containing an issue/reissue output was labeled "Issued"/"Reissued" even when the wallet was only the recipient.

## Fix

A wallet only ever issues or reissues on a **send** (it pays the burn), so the mint labels are now gated to send rows. On a **receive**, the label describes purely what landed in the wallet — issue/reissue/transfer/owner outputs paying us — so a received issuance reads `+1 FLIGHTDECK`. An owner token (which carries no on-chain amount) counts as one unit.

Existing labels are unchanged: your own `Issued CRAIG_KINGDOM`, `Reissued CRAIG_KINGDOM (+1)`, `−1 FLIGHTDECK`, `+1 FLIGHTDECK!` etc. still render as before — verified by the updated unit tests (11 passing).

Bump to 2.4.45.