### PR TITLE
fix(copy): say Argon2id, not scrypt, for at-rest KDF

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.46",
+  "version": "2.4.47",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -187,7 +187,7 @@ export default function LandingPage() {
         <div className="fdl-wrap">
           <div className="fdl-head"><span className="fdl-label">Under the panel</span><h2>The avionics, spelled out</h2></div>
           <div className="fdl-specs">
-            <div className="fdl-spec"><div className="k">Encryption at rest</div><div className="v">scrypt + AES-256-GCM</div></div>
+            <div className="fdl-spec"><div className="k">Encryption at rest</div><div className="v">Argon2id + AES-256-GCM</div></div>
             <div className="fdl-spec"><div className="k">Key derivation</div><div className="v">BIP39 · BIP32 HD</div></div>
             <div className="fdl-spec"><div className="k">Signatures</div><div className="v">SIGHASH · FORKID (0x41)</div></div>
             <div className="fdl-spec"><div className="k">Network</div><div className="v mint">ElectrumX · US / EU / CA</div></div>
@@ -222,7 +222,7 @@ const FEATURES = [
 ];
 
 const CHECKS = [
-  { title: 'Encrypted at rest', body: 'Your private keys and recovery phrase are sealed with scrypt and AES-256-GCM, and only ever decrypted in memory when you authorise an action.' },
+  { title: 'Encrypted at rest', body: 'Your private keys and recovery phrase are sealed with Argon2id and AES-256-GCM, and only ever decrypted in memory when you authorise an action.' },
   { title: 'Nothing phones home', body: 'There is no backend and no account. The app talks only to public ElectrumX servers to read balances and broadcast the transactions you sign.' },
   { title: 'Signatures need your say-so', body: 'Sending, exporting a key, and every dApp signature pass through an explicit approval screen and a fresh password or biometric check.' },
   { title: 'Only you can recover you', warn: true, body: 'No password reset, no support line that can move your coins. Keep your backup somewhere safe — losing it loses the wallet, and that is the price of holding your own keys.' },

--- a/src/components/OnboardingCreateWallet.tsx
+++ b/src/components/OnboardingCreateWallet.tsx
@@ -284,7 +284,7 @@ export default function OnboardingCreateWallet({
                             <ShieldCheck className="h-4 w-4" />
                             <span>
                                 Encrypted locally with AES-256-GCM using a key derived from your
-                                password with scrypt — your password never leaves this device.{' '}
+                                password with Argon2id — your password never leaves this device.{' '}
                                 <b>There&apos;s no reset</b>: if you lose it, restore from your
                                 recovery phrase.
                             </span>

--- a/src/components/WalletCreationWizard.tsx
+++ b/src/components/WalletCreationWizard.tsx
@@ -313,7 +313,7 @@ export default function WalletCreationWizard({
                         <ShieldCheck className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
                         <span>
                             Encrypted locally with AES-256-GCM using a key derived from your password
-                            with scrypt — your password never leaves this device.{' '}
+                            with Argon2id — your password never leaves this device.{' '}
                             <b className="text-primary">There&apos;s no reset</b>: if you lose it,
                             restore from your recovery phrase.
                         </span>


### PR DESCRIPTION
## Problem

The landing page still advertises `scrypt + AES-256-GCM` for at-rest encryption, but new wallets derive their key with **Argon2id** (64 MiB, t=3). scrypt is only a read-only fallback that gets re-encrypted to Argon2id on the next unlock.

## Changes (user-facing copy only)

- **LandingPage** — spec tile `scrypt + AES-256-GCM` → `Argon2id + AES-256-GCM`, and the 'Encrypted at rest' security check now reads 'sealed with Argon2id and AES-256-GCM'.
- **OnboardingCreateWallet** + **WalletCreationWizard** — the create-wallet encryption notice now says the key is derived 'with Argon2id'.

**Left unchanged:** `SecuritySettingsPanel`'s `scrypt · AES-256-GCM` label — that's the encryption-format *indicator* for a wallet that genuinely is still in scrypt format (it correctly flags 'upgrades on next unlock').

Typecheck green. Bump to 2.4.47.