### PR TITLE
chore(og): version the social preview image to bust stale caches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.47",
+  "version": "2.4.48",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,11 @@ const robotoMono = localFont({
   display: 'swap',
 });
 
+// Social preview image. The `?v=` suffix is a cache-buster: link-unfurl crawlers (Discord, Slack,
+// Twitter) key their preview cache on the full URL, so bump this whenever the screenshot changes to
+// force them to refetch instead of serving a stale thumbnail.
+const OG_IMAGE = '/screenshots/desktop-home.png?v=2';
+
 export const metadata: Metadata = {
   // Resolves relative Open Graph / Twitter image URLs against the real host. Without it a static
   // export bakes in http://localhost:3000, so link-unfurl crawlers can't fetch the preview images.
@@ -57,7 +62,7 @@ export const metadata: Metadata = {
     description: 'Secure and user-friendly Avian cryptocurrency wallet for managing your digital assets',
     images: [
       {
-        url: '/screenshots/desktop-home.png',
+        url: OG_IMAGE,
         width: 1920,
         height: 1080,
         alt: 'Avian FlightDeck Desktop Interface',
@@ -80,7 +85,7 @@ export const metadata: Metadata = {
     description: 'Secure and user-friendly Avian cryptocurrency wallet for managing your digital assets',
     creator: '@aavianfoundation',
     site: '@aavianfoundation',
-    images: ['/screenshots/desktop-home.png'],
+    images: [OG_IMAGE],
   },
 
   // Additional metadata for better SEO


### PR DESCRIPTION
## Problem

Discord is unfurling an **old** `flightdeck.avn.network` preview thumbnail. Link-unfurl crawlers cache the OG image by its full URL, so when the screenshot at `/screenshots/desktop-home.png` is updated the same path keeps serving the stale cached image.

## Fix

Add a `?v=` cache-buster to the OG image URL via a single `OG_IMAGE` constant, used by both the OpenGraph and Twitter `images`. Bumping the suffix changes the URL, so crawlers refetch instead of serving the cached thumbnail.

Currently `?v=2`; bump it whenever the screenshot changes.

Bump to 2.4.48.

## After merge

Discord may still show the old image from its own cache for a while. To force a refresh immediately, re-paste the link in a channel (or use Discord's link — the new `?v=2` URL is treated as fresh), or wait for its cache to expire.