### PR TITLE
chore(og): version the 512x512 logo preview too

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.48",
+  "version": "2.4.49",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,7 @@ const robotoMono = localFont({
 // Twitter) key their preview cache on the full URL, so bump this whenever the screenshot changes to
 // force them to refetch instead of serving a stale thumbnail.
 const OG_IMAGE = '/screenshots/desktop-home.png?v=2';
+const OG_LOGO = '/icons/icon-512x512.png?v=2';
 
 export const metadata: Metadata = {
   // Resolves relative Open Graph / Twitter image URLs against the real host. Without it a static
@@ -69,7 +70,7 @@ export const metadata: Metadata = {
         type: 'image/png',
       },
       {
-        url: '/icons/icon-512x512.png',
+        url: OG_LOGO,
         width: 512,
         height: 512,
         alt: 'Avian FlightDeck Logo',


### PR DESCRIPTION
## Problem

After #90, Discord still shows the **old logo**: it unfurls the *second* OpenGraph image (`/icons/icon-512x512.png`), which #90 didn't version — so that URL was unchanged and kept serving Discord's cached copy.

## Fix

Apply the same `?v=` cache-buster to the logo via an `OG_LOGO` constant. Now both OG images (`OG_IMAGE` screenshot + `OG_LOGO` logo) carry `?v=2`, so crawlers refetch both.

Bump to 2.4.49.

## After deploy

Discord caches on its side too, so re-paste the link (or append a throwaway `#1` fragment) to force a fresh unfurl.