### PR TITLE
chore(og): show only the screenshot in link previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.49",
+  "version": "2.4.50",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,6 @@ const robotoMono = localFont({
 // Twitter) key their preview cache on the full URL, so bump this whenever the screenshot changes to
 // force them to refetch instead of serving a stale thumbnail.
 const OG_IMAGE = '/screenshots/desktop-home.png?v=2';
-const OG_LOGO = '/icons/icon-512x512.png?v=2';
 
 export const metadata: Metadata = {
   // Resolves relative Open Graph / Twitter image URLs against the real host. Without it a static
@@ -67,13 +66,6 @@ export const metadata: Metadata = {
         width: 1920,
         height: 1080,
         alt: 'Avian FlightDeck Desktop Interface',
-        type: 'image/png',
-      },
-      {
-        url: OG_LOGO,
-        width: 512,
-        height: 512,
-        alt: 'Avian FlightDeck Logo',
         type: 'image/png',
       },
     ],


### PR DESCRIPTION
Drop the 512x512 logo from the OpenGraph `images` so link unfurlers (Discord, Slack, etc.) show a single, consistent preview — the landing screenshot — instead of choosing the logo. Twitter already referenced only the screenshot.

Bump to 2.4.50.

## After deploy

Discord caches on its side, so re-paste the link (or append a throwaway `#1` fragment) to force a fresh unfurl of the single screenshot preview.