### PR TITLE
chore: point repo links at AvianNetwork/avian-flightdeck

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A Progressive Web App (PWA) implementation of the Avian cryptocurrency wallet, b
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/cdonnachie/avian-flightdeck.git
+git clone https://github.com/AvianNetwork/avian-flightdeck.git
 cd avian-flightdeck
 ```
 
@@ -302,7 +302,7 @@ MIT License - see LICENSE file for details
 
 For issues and questions:
 
-- GitHub Issues: [Repository Issues](https://github.com/cdonnachie/avian-flightdeck/issues)
+- GitHub Issues: [Repository Issues](https://github.com/AvianNetwork/avian-flightdeck/issues)
 - Community: Avian Network Discord/Telegram
 
 ## Roadmap

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.50",
+  "version": "2.4.51",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -614,7 +614,7 @@ export default function AboutPage() {
                                                 variant="outline"
                                                 className="w-full justify-start h-12"
                                                 onClick={() =>
-                                                    window.open('https://github.com/cdonnachie/avian-flightdeck', '_blank')
+                                                    window.open('https://github.com/AvianNetwork/avian-flightdeck', '_blank')
                                                 }
                                             >
                                                 <ExternalLink className="h-4 w-4 mr-3" />
@@ -632,7 +632,7 @@ export default function AboutPage() {
                                                 variant="outline"
                                                 className="w-full justify-start h-12"
                                                 onClick={() =>
-                                                    window.open('https://github.com/cdonnachie/avian-flightdeck/issues', '_blank')
+                                                    window.open('https://github.com/AvianNetwork/avian-flightdeck/issues', '_blank')
                                                 }
                                             >
                                                 <ExternalLink className="h-4 w-4 mr-3" />

--- a/src/app/settings/help/page.tsx
+++ b/src/app/settings/help/page.tsx
@@ -30,7 +30,7 @@ export default function HelpSettingsPage() {
             title: 'Documentation',
             description: 'User guides and documentation',
             icon: ExternalLink,
-            action: () => window.open('https://github.com/cdonnachie/avian-flightdeck', '_blank'),
+            action: () => window.open('https://github.com/AvianNetwork/avian-flightdeck', '_blank'),
         },
     ];
 

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -73,7 +73,7 @@ export default function AboutModal({ isOpen, onClose }: AboutModalProps) {
                 size="sm"
                 className="w-full justify-start"
                 onClick={() =>
-                  window.open('https://github.com/cdonnachie/avian-flightdeck', '_blank')
+                  window.open('https://github.com/AvianNetwork/avian-flightdeck', '_blank')
                 }
               >
                 <ExternalLink className="h-4 w-4 mr-2" />

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -201,7 +201,7 @@ export default function LandingPage() {
           <div className="fdl-foot__sign">FLIGHTDECK · <b>SYSTEMS NOMINAL</b> · you have control</div>
           <div className="fdl-foot__links">
             <button onClick={start}>Get started</button>
-            <a href="https://github.com/cdonnachie/avian-flightdeck" target="_blank" rel="noreferrer">Documentation</a>
+            <a href="https://github.com/AvianNetwork/avian-flightdeck" target="_blank" rel="noreferrer">Documentation</a>
             <a href="/terms">Terms</a>
           </div>
         </div>


### PR DESCRIPTION
The repository moved from `cdonnachie/` to the **AvianNetwork** org. Update every in-repo reference to the old slug so links name the real home (GitHub redirects the old URLs, but they should be correct):

- **In-app:** About page 'View Source Code' / 'Report Issues', settings → Help 'Documentation', AboutModal source link, landing footer 'Documentation'
- **README:** clone URL + issues link

Verified no `cdonnachie/avian-flightdeck` references remain. Typecheck green. Bump to 2.4.51.