### PR TITLE
feat(connect): allow extra http origins via NEXT_PUBLIC_CONNECT_HTTP_HOSTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ ENABLE_PRICE_ALERTS=true
 # Security Settings
 # All security features are implemented client-side. Keys, mnemonics and passwords never leave
 # the browser and are never sent to a server.
+
+# Avian Connect: extra origins allowed to connect over plaintext http (for LAN development).
+# By default only https, plus http on loopback (localhost / 127.0.0.1 / [::1]), may connect.
+# Comma-separated; each entry is an exact hostname or an IPv4 CIDR. Leave unset in production.
+# Example (allow a whole /24 subnet): NEXT_PUBLIC_CONNECT_HTTP_HOSTS=10.10.30.0/24
+# NEXT_PUBLIC_CONNECT_HTTP_HOSTS=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.51",
+  "version": "2.4.52",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/provider/protocol.test.ts
+++ b/src/services/provider/protocol.test.ts
@@ -6,6 +6,7 @@ import {
   buildRedirectUrl,
   decodeRequestParam,
   encodeEnvelope,
+  ipv4InCidr,
   isConnectResponse,
   makeError,
   makeEvent,
@@ -211,6 +212,8 @@ describe('normalizeOrigin', () => {
     expect(normalizeOrigin('http://localhost:3000')).toBe('http://localhost:3000');
     expect(normalizeOrigin('http://127.0.0.1:3000')).toBe('http://127.0.0.1:3000');
     expect(normalizeOrigin('http://realm.example')).toBeNull();
+    // A LAN address is rejected unless NEXT_PUBLIC_CONNECT_HTTP_HOSTS opts it in (unset in tests).
+    expect(normalizeOrigin('http://10.10.30.5:3000')).toBeNull();
   });
 
   it('rejects non-http(s) and opaque origins', () => {
@@ -219,6 +222,33 @@ describe('normalizeOrigin', () => {
     expect(normalizeOrigin('data:text/html,hi')).toBeNull();
     expect(normalizeOrigin('not a url')).toBeNull();
     expect(normalizeOrigin('')).toBeNull();
+  });
+});
+
+describe('ipv4InCidr', () => {
+  it('matches addresses inside a /24', () => {
+    expect(ipv4InCidr('10.10.30.1', '10.10.30.0/24')).toBe(true);
+    expect(ipv4InCidr('10.10.30.254', '10.10.30.0/24')).toBe(true);
+    // A base written with a host part still masks correctly (10.10.30.1/24 → 10.10.30.0/24).
+    expect(ipv4InCidr('10.10.30.50', '10.10.30.1/24')).toBe(true);
+  });
+
+  it('rejects addresses outside the range', () => {
+    expect(ipv4InCidr('10.10.31.1', '10.10.30.0/24')).toBe(false);
+    expect(ipv4InCidr('192.168.1.1', '10.10.30.0/24')).toBe(false);
+  });
+
+  it('handles /32 and /0 edges', () => {
+    expect(ipv4InCidr('10.10.30.7', '10.10.30.7/32')).toBe(true);
+    expect(ipv4InCidr('10.10.30.8', '10.10.30.7/32')).toBe(false);
+    expect(ipv4InCidr('8.8.8.8', '0.0.0.0/0')).toBe(true);
+  });
+
+  it('rejects malformed input', () => {
+    expect(ipv4InCidr('not-an-ip', '10.10.30.0/24')).toBe(false);
+    expect(ipv4InCidr('10.10.30.1', '10.10.30.0/33')).toBe(false);
+    expect(ipv4InCidr('10.10.30.999', '10.10.30.0/24')).toBe(false);
+    expect(ipv4InCidr('10.10.30.1', 'garbage')).toBe(false);
   });
 });
 

--- a/src/services/provider/protocol.ts
+++ b/src/services/provider/protocol.ts
@@ -209,10 +209,54 @@ export function decodeRequestParam(param: string): ParseResult {
 
 const LOCAL_HOSTS = ['localhost', '127.0.0.1', '[::1]'];
 
+// Extra hosts/subnets allowed to use plaintext http, for LAN development against a self-hosted
+// deploy. Comma-separated NEXT_PUBLIC_CONNECT_HTTP_HOSTS, each entry an exact hostname or an IPv4
+// CIDR (e.g. "10.10.30.0/24"). Empty by default, so the public build keeps the https-or-loopback
+// rule; NEXT_PUBLIC_* is inlined at build time, so set it in the environment that builds the app.
+const EXTRA_HTTP_HOSTS = (process.env.NEXT_PUBLIC_CONNECT_HTTP_HOSTS ?? '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+/** Parse an IPv4 dotted-quad to a 32-bit unsigned int, or null if it isn't a valid IPv4 address. */
+function ipv4ToInt(host: string): number | null {
+  const parts = host.split('.');
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    n = (n << 8) | octet;
+  }
+  return n >>> 0;
+}
+
+/** True if `hostname` is an IPv4 address inside the `a.b.c.d/bits` CIDR range. */
+export function ipv4InCidr(hostname: string, cidr: string): boolean {
+  const [range, bitsRaw] = cidr.split('/');
+  const bits = Number(bitsRaw);
+  if (!Number.isInteger(bits) || bits < 0 || bits > 32) return false;
+  const ip = ipv4ToInt(hostname);
+  const base = ipv4ToInt(range);
+  if (ip === null || base === null) return false;
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (ip & mask) === (base & mask);
+}
+
+/** Whether a plaintext-http origin with this hostname is permitted (loopback + configured LAN). */
+function isHttpHostAllowed(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (LOCAL_HOSTS.includes(host)) return true;
+  return EXTRA_HTTP_HOSTS.some((entry) =>
+    entry.includes('/') ? ipv4InCidr(host, entry) : entry === host,
+  );
+}
+
 /**
  * Normalises an origin or URL to `scheme://host[:port]`, lowercased and without a trailing slash.
  * Returns null for anything that is not an origin we are willing to talk to: opaque origins,
- * and plaintext http outside of local development.
+ * and plaintext http outside of local development (loopback, plus any NEXT_PUBLIC_CONNECT_HTTP_HOSTS).
  */
 export function normalizeOrigin(value: string): string | null {
   if (typeof value !== 'string' || value.length === 0 || value.length > 2048) {
@@ -229,7 +273,7 @@ export function normalizeOrigin(value: string): string | null {
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     return null;
   }
-  if (url.protocol === 'http:' && !LOCAL_HOSTS.includes(url.hostname.toLowerCase())) {
+  if (url.protocol === 'http:' && !isHttpHostAllowed(url.hostname)) {
     return null;
   }
 


### PR DESCRIPTION
## Why

Avian Connect's origin gate (`normalizeOrigin`) accepts **https from any host**, but **plaintext http only on loopback** (`localhost` / `127.0.0.1` / `[::1]`). That blocks LAN development where a dApp and/or the wallet are reached over `http` on a private IP like `10.10.30.x`.

## What

Add an **opt-in** allowlist env var, `NEXT_PUBLIC_CONNECT_HTTP_HOSTS`:
- Comma-separated; each entry is an exact hostname or an **IPv4 CIDR** (e.g. `10.10.30.0/24`).
- Consulted **only for http origins**, in addition to loopback.
- **Empty by default**, so the public production build keeps the exact https-or-loopback behavior it has today.

`normalizeOrigin` now calls a new `ipv4InCidr` helper (exported, unit-tested for /24, /32, /0, and malformed input). `.env.example` documents the var.

## How to enable your subnet

Set this in the environment that **builds** the app (`NEXT_PUBLIC_*` is inlined at build time):

```
NEXT_PUBLIC_CONNECT_HTTP_HOSTS=10.10.30.0/24
```

Note `10.10.30.1/24` also works — the base is masked to the network address.

## Security note

This permits **unencrypted** Connect sessions from the listed hosts, so scope it to private/trusted ranges only (which is why it's off by default and not baked into the public build). Every Connect request still requires explicit in-wallet approval and shows the origin.

Tests: 43 in protocol.test.ts pass; typecheck green. Bump to 2.4.52.