### PR TITLE
hotfix(assets): pause asset issuance/reissue during network incident

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ ENABLE_PRICE_ALERTS=true
 # All security features are implemented client-side. Keys, mnemonics and passwords never leave
 # the browser and are never sent to a server.
 
+# Asset issuance kill-switch. Creating and reissuing assets is DISABLED by default while an Avian
+# network consensus issue is resolved. Set to "on" (only once it is safe again) to re-enable the
+# Create/Reissue flows. Sending existing assets is unaffected either way.
+# NEXT_PUBLIC_ASSET_ISSUANCE=on
+
 # Avian Connect: extra origins allowed to connect over plaintext http (for LAN development).
 # By default only https, plus http on loopback (localhost / 127.0.0.1 / [::1]), may connect.
 # Comma-separated; each entry is an exact hostname or an IPv4 CIDR. Leave unset in production.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.52",
+  "version": "2.4.53",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Coins, Plus, PlusCircle, RefreshCw, Search, Send } from 'lucide-react';
+import { AlertTriangle, Coins, Plus, PlusCircle, RefreshCw, Search, Send } from 'lucide-react';
 
 import { useWallet } from '@/contexts/WalletContext';
 import { getHeldAssets, ipfsImageUrl, type HeldAsset } from '@/services/wallet/AssetService';
+import { isAssetIssuanceEnabled, ASSET_ISSUANCE_PAUSED_MESSAGE } from '@/lib/featureFlags';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
@@ -94,8 +95,10 @@ export function AssetList({ className }: { className?: string }) {
     if (isConnected && address) void load();
   }, [isConnected, address, load]);
 
-  // Assets are legacy-address-only; a legacy wallet can create even with nothing held yet.
-  const canCreate = !!address && address.startsWith('R');
+  // Assets are legacy-address-only; a legacy wallet can create even with nothing held yet — but
+  // issuance is gated by a kill-switch while the network consensus issue is resolved.
+  const issuanceEnabled = isAssetIssuanceEnabled();
+  const canCreate = !!address && address.startsWith('R') && issuanceEnabled;
   // Owner tokens we hold (NAME!) → the roots we can create sub/unique assets under.
   const ownedRoots = assets
     .filter((a) => a.name.endsWith('!'))
@@ -143,6 +146,12 @@ export function AssetList({ className }: { className?: string }) {
         </span>
       </CardHeader>
       <CardContent className="p-0">
+        {!issuanceEnabled && (
+          <div className="flex items-start gap-2 border-b border-caution/30 bg-caution/10 px-4 py-3 text-sm text-caution">
+            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <span>{ASSET_ISSUANCE_PAUSED_MESSAGE}</span>
+          </div>
+        )}
         {assets.length > 6 && (
           <div className="relative border-b border-border/60 p-3">
             <Search className="absolute left-5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -196,7 +205,7 @@ export function AssetList({ className }: { className?: string }) {
                     </span>
                   <span className="flex flex-shrink-0 items-center gap-1">
                     <span className="mr-1 font-mono text-sm">{asset.amount}</span>
-                    {asset.meta?.reissuable && ownedRoots.includes(asset.name) && (
+                    {issuanceEnabled && asset.meta?.reissuable && ownedRoots.includes(asset.name) && (
                       <Button
                         variant="ghost"
                         size="icon"
@@ -225,7 +234,11 @@ export function AssetList({ className }: { className?: string }) {
             })}
             {filtered.length === 0 && (
               <li className="px-4 py-6 text-center text-sm text-muted-foreground">
-                {query ? `No assets match “${query}”.` : 'No assets yet — create one to get started.'}
+                {query
+                  ? `No assets match “${query}”.`
+                  : issuanceEnabled
+                    ? 'No assets yet — create one to get started.'
+                    : 'No assets yet.'}
               </li>
             )}
           </ul>
@@ -240,14 +253,14 @@ export function AssetList({ className }: { className?: string }) {
       />
 
       <ReissueAssetDialog
-        open={reissuing !== null}
+        open={issuanceEnabled && reissuing !== null}
         onOpenChange={(next) => !next && setReissuing(null)}
         asset={reissuing}
         onSuccess={reloadSoon}
       />
 
       <CreateAssetDialog
-        open={creating}
+        open={issuanceEnabled && creating}
         onOpenChange={setCreating}
         ownedRoots={ownedRoots}
         onSuccess={reloadSoon}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,20 @@
+// Runtime feature gates.
+
+/**
+ * Asset ISSUANCE (create + reissue) kill-switch. OFF by default while an Avian network consensus
+ * issue is resolved: a unique-asset issuance that also creates a `NAME#unique!` owner token is
+ * accepted by Core 5.0.x but rejected by 4.2.0, which split the chain. Until Core is patched, the
+ * network reunified, and the issuance builders corrected, the wallet must not build any new
+ * issuance/reissue transactions. Sending existing assets is unaffected.
+ *
+ * Read via a function so it is evaluated per call: `process.env.NEXT_PUBLIC_*` is inlined into the
+ * browser bundle at build time (so production is off unless the flag is set), while tests can toggle
+ * it at runtime. Re-enable by building with `NEXT_PUBLIC_ASSET_ISSUANCE=on` once it is safe.
+ */
+export function isAssetIssuanceEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ASSET_ISSUANCE === 'on';
+}
+
+/** User-facing explanation shown where issuance controls used to be. */
+export const ASSET_ISSUANCE_PAUSED_MESSAGE =
+  'Asset creation and reissue are temporarily paused while an Avian network issue is resolved. Sending existing assets is unaffected.';

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -40,6 +40,7 @@ import {
     isValidRootAssetName,
     ISSUE_BURN,
 } from './assetScript';
+import { isAssetIssuanceEnabled, ASSET_ISSUANCE_PAUSED_MESSAGE } from '@/lib/featureFlags';
 
 // How many transaction.get requests to keep in flight while syncing history. Electrum matches
 // responses by id, so a small pool cuts the latency of a large sync ~N-fold. Kept deliberately low:
@@ -1197,6 +1198,7 @@ export class WalletService {
         options?: { feeRate?: number; changeAddress?: string },
     ): Promise<string> {
         try {
+            if (!isAssetIssuanceEnabled()) throw new Error(ASSET_ISSUANCE_PAUSED_MESSAGE);
             if (!isValidRootAssetName(name)) {
                 throw new Error(
                     'Invalid asset name. Use 3–30 characters of A–Z, 0–9, _ and . (no leading, trailing or doubled punctuation).',
@@ -1386,6 +1388,7 @@ export class WalletService {
         options?: { feeRate?: number; changeAddress?: string };
     }): Promise<string> {
         try {
+            if (!isAssetIssuanceEnabled()) throw new Error(ASSET_ISSUANCE_PAUSED_MESSAGE);
             const { childName, parentName, amount, units, reissuable, burnAmount, burnAddress } = opts;
             if (amount <= 0n) throw new Error('Issuance amount must be positive');
             if (units < 0 || units > 8) throw new Error('Units must be between 0 and 8');
@@ -1533,6 +1536,7 @@ export class WalletService {
         options?: { feeRate?: number; changeAddress?: string },
     ): Promise<string> {
         try {
+            if (!isAssetIssuanceEnabled()) throw new Error(ASSET_ISSUANCE_PAUSED_MESSAGE);
             if (params.amount < 0n) throw new Error('Reissue amount cannot be negative');
 
             const activeWallet = await StorageService.getActiveWallet();

--- a/src/services/wallet/assetIssuance.test.ts
+++ b/src/services/wallet/assetIssuance.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as bitcoin from 'bitcoinjs-lib';
 import { ECPairFactory } from 'ecpair';
 import * as ecc from 'tiny-secp256k1';
@@ -61,8 +61,35 @@ async function createActiveWallet() {
   return { address, keyPair };
 }
 
+// These tests exercise the issuance builders, which are gated behind the asset-issuance kill-switch
+// (off by default during the network incident). Enable it for this suite; a dedicated test below
+// covers the disabled path.
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_ASSET_ISSUANCE = 'on';
+});
+afterAll(() => {
+  delete process.env.NEXT_PUBLIC_ASSET_ISSUANCE;
+});
+
 beforeEach(() => {
   resetStorage();
+});
+
+describe('asset issuance kill-switch', () => {
+  it('refuses to build an issuance while issuance is disabled', async () => {
+    const prev = process.env.NEXT_PUBLIC_ASSET_ISSUANCE;
+    delete process.env.NEXT_PUBLIC_ASSET_ISSUANCE;
+    try {
+      const { address } = await createActiveWallet();
+      const { electrum } = createElectrum(address, [600 * COIN]);
+      const wallet = new WalletService(electrum as never);
+      await expect(
+        wallet.issueAsset('PAUSEDASSET', { amount: 1n * BigInt(COIN), units: 0, reissuable: true }, TEST_PASSWORD),
+      ).rejects.toThrow(/temporarily paused/);
+    } finally {
+      process.env.NEXT_PUBLIC_ASSET_ISSUANCE = prev;
+    }
+  });
 });
 
 describe('issueAsset (root)', () => {


### PR DESCRIPTION
This does not fix the builder itself or the Core consensus hole — those are follow-ups. This is purely the stop-the-bleeding gate.

## Why (urgent)

A unique-asset issuance that ALSO creates a NAME#unique! owner token is accepted by Avian Core 5.0.x but rejected by 4.2.0 (whose consensus runs VerifyNewUniqueAsset s nOwners > 0 guard, error bad-txns-failed-unique-asset-formatting-check). That divergence split the chain. FlightDeck issueUniqueAsset builds exactly that owner token, so the wallet must stop producing any issuance/reissue transactions until Core is patched and the network reunified.

## What this does

Adds an asset-issuance kill-switch — isAssetIssuanceEnabled(), driven by NEXT_PUBLIC_ASSET_ISSUANCE, default OFF (merge+deploy disables it with no env wiring; production stays off unless explicitly re-enabled):

- UI (AssetList): hides the Create button and every per-row Reissue button, shows a caution notice, and guards the Create/Reissue dialogs so they cannot open.
- Service (WalletService): issueAsset, issueChildAsset (covers sub AND unique), and reissueAsset throw before building anything — the real choke point, independent of the UI.
- Sending existing assets is unaffected.

## Follow-ups (not in this PR)

- #2 wallet builder fix: stop creating the unique owner token.
- #3 Core 5.0.3 consensus guard on the unique path, mirroring the existing restricted-asset fix (commit 895b9f7b9).

## Verification

- 672 unit tests pass (issuance-builder suite runs with the flag enabled; added a test asserting issuance throws while disabled).
- Typecheck + next build (static export) green.
- .env.example documents NEXT_PUBLIC_ASSET_ISSUANCE.

Bump to 2.4.53. Merge = deploy, which is the intent here.

## Re-enabling later

Build with NEXT_PUBLIC_ASSET_ISSUANCE=on once Core is patched, the network reunified, and the issuance builder corrected.