### PR TITLE
fix(assets): unique issuance must not create an owner token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avian-flightdeck",
-  "version": "2.4.53",
+  "version": "2.4.54",
   "description": "Advanced Avian cryptocurrency wallet with HD wallet support, UTXO coin control, biometric authentication, and comprehensive backup features as a Progressive Web App",
   "engines": {
     "node": ">=22"

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -1335,6 +1335,7 @@ export class WalletService {
             amount: params.amount,
             units: params.units,
             reissuable: params.reissuable,
+            createOwnerToken: true, // sub-assets have their own CHILD! owner token
             ipfs: params.ipfs,
             burnAmount: ISSUE_BURN.sub.amount,
             burnAddress: ISSUE_BURN.sub.address,
@@ -1361,6 +1362,7 @@ export class WalletService {
             amount: 100_000_000n, // exactly 1 unit
             units: 0,
             reissuable: false,
+            createOwnerToken: false, // uniques have NO owner token — consensus rejects one
             ipfs,
             burnAmount: ISSUE_BURN.unique.amount,
             burnAddress: ISSUE_BURN.unique.address,
@@ -1371,9 +1373,12 @@ export class WalletService {
 
     /**
      * Shared engine for sub/unique issuance. Spends the `PARENT!` owner token (returning it to
-     * ourselves), burns the type's fee, and creates the child asset + its `CHILD!` owner token.
-     * Output order matches Core: burn, AVN change, parent-owner transfer, new owner (2nd-last),
-     * new asset (last). Validated byte-for-byte against real Core sub and unique issuances.
+     * ourselves) and burns the type's fee. Sub-assets also create their own `CHILD!` owner token;
+     * unique assets must NOT — a unique has no owner token of its own, it inherits authority from
+     * the parent root owner. Emitting a `NAME#unique!` owner-creation output is rejected by Avian
+     * consensus (Core 4.2.0, and 5.0.3 onward) and previously split the chain, so `createOwnerToken`
+     * is false for uniques. Output order matches Core: burn, AVN change, parent-owner transfer,
+     * [new owner (2nd-last) for sub only], new asset (last). Validated against real Core issuances.
      */
     private async issueChildAsset(opts: {
         childName: string;
@@ -1381,6 +1386,8 @@ export class WalletService {
         amount: bigint;
         units: number;
         reissuable: boolean;
+        /** Sub-assets get a `CHILD!` owner token; unique assets must not (consensus rejects it). */
+        createOwnerToken: boolean;
         ipfs?: string;
         burnAmount: bigint;
         burnAddress: string;
@@ -1427,7 +1434,9 @@ export class WalletService {
 
             const burnScript = bitcoin.address.toOutputScript(burnAddress, avianNetwork);
             const parentReturnScript = buildAssetTransferScript(changeAddress, ownerName, ownerAmount);
-            const newOwnerScript = buildOwnerScript(fromAddress, childName);
+            // Sub-assets carry their own owner token; unique assets must not — a NAME#unique! owner
+            // output is rejected by consensus and caused the 5.0.x/4.2.0 chain split.
+            const newOwnerScript = opts.createOwnerToken ? buildOwnerScript(fromAddress, childName) : null;
             const newAssetScript = buildIssuanceScript(fromAddress, {
                 name: childName,
                 amount,
@@ -1447,7 +1456,7 @@ export class WalletService {
             const fixedOutputsVBytes =
                 34 + 34 +
                 (8 + 1 + parentReturnScript.length) +
-                (8 + 1 + newOwnerScript.length) +
+                (newOwnerScript ? 8 + 1 + newOwnerScript.length : 0) +
                 (8 + 1 + newAssetScript.length);
             const sizeFor = (avnInputCount: number) =>
                 10 + (1 + avnInputCount) * 148 + fixedOutputsVBytes;
@@ -1494,7 +1503,7 @@ export class WalletService {
                 tx.addOutput(bitcoin.address.toOutputScript(changeAddress, avianNetwork), finalChange);
             }
             tx.addOutput(parentReturnScript, 0);
-            tx.addOutput(newOwnerScript, 0);
+            if (newOwnerScript) tx.addOutput(newOwnerScript, 0);
             tx.addOutput(newAssetScript, 0);
 
             for (let i = 0; i < allInputs.length; i++) {

--- a/src/services/wallet/assetIssuance.test.ts
+++ b/src/services/wallet/assetIssuance.test.ts
@@ -257,20 +257,19 @@ describe('issueUniqueAsset', () => {
           })(),
       ),
     ).toBe(true);
-    // Parent owner returned, then new owner (2nd-last), new asset (last).
-    expect(parseAssetScript(outs[outs.length - 3].script as Buffer)).toMatchObject({
+    // A unique has NO owner token of its own: parent owner returned (2nd-last), unique asset (last).
+    expect(parseAssetScript(outs[outs.length - 2].script as Buffer)).toMatchObject({
       type: 'transfer',
       name: 'MYASSET!',
-    });
-    expect(parseAssetScript(outs[outs.length - 2].script as Buffer)).toMatchObject({
-      type: 'owner',
-      name: 'MYASSET#001!',
     });
     expect(parseAssetScript(outs[outs.length - 1].script as Buffer)).toMatchObject({
       type: 'issue',
       name: 'MYASSET#001',
       amount: 1n * BigInt(COIN),
     });
+    // A NAME#unique! owner-creation output is rejected by Avian consensus (it split the chain versus
+    // 4.2.0), so unique issuance must never emit one.
+    expect(outs.some((o) => parseAssetScript(o.script as Buffer)?.type === 'owner')).toBe(false);
     // First input is the parent owner token.
     expect(tx.ins.length).toBe(2); // owner + one AVN
   });

--- a/src/services/wallet/assetScript.test.ts
+++ b/src/services/wallet/assetScript.test.ts
@@ -241,16 +241,15 @@ describe('real mainnet Core golden vectors', () => {
     );
   });
 
-  // Real Core sub/unique issuances share one structure: parent-owner transfer (rvn·t), new owner
-  // (rvn·o), new asset (rvn·q). These pin all three builders against Core for both types at once.
-  it('reproduces a real Core UNIQUE issuance (FLIGHTDECK#TEST) byte-for-byte', () => {
+  // Sub and unique issuances differ on the owner token: a SUB gets its own CHILD! owner (rvn·o),
+  // a UNIQUE does NOT — a unique inherits authority from its parent root owner and creates only the
+  // parent-owner transfer (rvn·t) + the new asset (rvn·q). Emitting a NAME#unique! owner output is
+  // rejected by consensus and split the chain (see issueChildAsset / the 5.0.3 fix).
+  it('reproduces a real Core UNIQUE issuance (FLIGHTDECK#TEST) byte-for-byte — no owner token', () => {
     const PARENT_OWNER_DEST = 'RGAFrTpnpPWtT1UBxuxzuB8xMg9mxiq8Ah';
     const UNIQUE_DEST = 'RV3Tjt8ZLnuahSL9QjTtVxLKBR7CQCfv49';
     expect(buildAssetTransferScript(PARENT_OWNER_DEST, 'FLIGHTDECK!', 100_000_000n).toString('hex')).toBe(
       '76a9144b791eb36f35affad78c1ef45461da116e91d77988acc01872766e740b464c494748544445434b2100e1f5050000000075',
-    );
-    expect(buildOwnerScript(UNIQUE_DEST, 'FLIGHTDECK#TEST').toString('hex')).toBe(
-      '76a914d8c9c40901617159d1ad92822da95f7ce4ca262988acc01572766e6f10464c494748544445434b23544553542175',
     );
     expect(
       buildIssuanceScript(UNIQUE_DEST, {


### PR DESCRIPTION
The FlightDeck-side fix for the chain-split bug (#2 of the incident follow-ups).

## What

A unique asset has no owner token of its own — it inherits authority from its parent root ROOT! owner, which is *transferred* (not created) in the issuance. Emitting a NAME#unique! owner output is rejected by Avian consensus (4.2.0, and 5.0.3 onward) and split the chain.

issueChildAsset built that owner token for BOTH sub and unique. Now gated behind a new createOwnerToken flag:
- issueSubAsset -> createOwnerToken: true  (sub-assets legitimately have a CHILD! owner)
- issueUniqueAsset -> createOwnerToken: false (uniques must not)

Unique issuance now emits [burn, AVN change, parent ROOT! transfer-back, unique asset(last)] with NO owner output; fee sizing adjusted accordingly.

## Tests

- issueUniqueAsset test now asserts there is NO owner-type output and the unique asset is last.
- Corrected the assetScript UNIQUE golden vector: dropped the (incorrect) buildOwnerScript assertion that enshrined the bug; the SUB golden vector still covers buildOwnerScript.
- Full suite: 672 pass. Typecheck + next build green.

## Note

Issuance is still disabled by the kill-switch (from the hotfix). Flip NEXT_PUBLIC_ASSET_ISSUANCE=on only once the network is reunified on 5.0.3.

Bump to 2.4.54.