### PR TITLE
feat(descriptor): derive and spend beyond the first address

### DIFF
--- a/src/components/DerivedAddressesPanel.tsx
+++ b/src/components/DerivedAddressesPanel.tsx
@@ -691,11 +691,9 @@ export default function DerivedAddressesPanel() {
             }
 
             try {
-                // Check if there's a stored mnemonic for this wallet
-                const storedMnemonic = await StorageService.getMnemonic();
-
-                // A wallet is HD-compatible if it has a stored mnemonic
-                const hasHdCapabilities = !!storedMnemonic;
+                // A wallet is HD-compatible if it has a stored mnemonic, or an
+                // account-level xprv from a descriptor import
+                const hasHdCapabilities = await StorageService.hasHdCapability();
 
                 setIsHdWallet(hasHdCapabilities);
 
@@ -736,7 +734,8 @@ export default function DerivedAddressesPanel() {
                         This wallet was not created with HD (hierarchical deterministic) capabilities.
                     </p>
                     <p className="text-xs text-caution mt-1">
-                        Only wallets created with a seed phrase support derived addresses.
+                        Only wallets created from a seed phrase or imported from a descriptor
+                        support derived addresses.
                     </p>
                 </div>
             </div>

--- a/src/components/SendForm.tsx
+++ b/src/components/SendForm.tsx
@@ -568,8 +568,7 @@ export default function SendForm() {
   // Check if current wallet is HD-compatible (without loading change addresses immediately)
   const checkHdWalletCapabilities = useCallback(async () => {
     try {
-      const storedMnemonic = await StorageService.getMnemonic();
-      const hasHdCapabilities = !!storedMnemonic;
+      const hasHdCapabilities = await StorageService.hasHdCapability();
       setIsHdWallet(hasHdCapabilities);
 
       if (!hasHdCapabilities) {
@@ -606,7 +605,7 @@ export default function SendForm() {
               authResult.password,
               0, // account index
               preferredCount, // number of addresses from preference
-              'p2pkh', // address type
+              undefined, // address type — falls back to the wallet's own script type
               1, // change path (1 for change addresses)
             );
 

--- a/src/components/UTXOOverview.tsx
+++ b/src/components/UTXOOverview.tsx
@@ -330,8 +330,7 @@ export function UTXOOverview({ isOpen, onClose, onConsolidateUTXOs, maxInputs = 
         }
 
         // Check if this is an HD wallet
-        const storedMnemonic = await StorageService.getMnemonic();
-        const hasHdCapabilities = !!storedMnemonic;
+        const hasHdCapabilities = await StorageService.hasHdCapability();
         setIsHdWallet(hasHdCapabilities);
 
         const currentBlockHeight = await electrum.getCurrentBlockHeight();

--- a/src/components/UTXOSelector.tsx
+++ b/src/components/UTXOSelector.tsx
@@ -101,8 +101,7 @@ export function UTXOSelector({
         }
 
         // Check if this is an HD wallet
-        const storedMnemonic = await StorageService.getMnemonic();
-        const hasHdCapabilities = !!storedMnemonic;
+        const hasHdCapabilities = await StorageService.hasHdCapability();
         setIsHdWallet(hasHdCapabilities);
 
         const currentBlockHeight = await electrum.getCurrentBlockHeight();
@@ -160,8 +159,9 @@ export function UTXOSelector({
 
         // Get both receiving and change addresses
         const [receivingAddresses, changeAddresses] = await Promise.all([
-          deriveCurrentWalletAddresses!(password, 0, changeAddressCount, 'p2pkh', 0, 921),
-          deriveCurrentWalletAddresses!(password, 0, changeAddressCount, 'p2pkh', 1, 921),
+          // undefined address type = use the wallet's own script type
+          deriveCurrentWalletAddresses!(password, 0, changeAddressCount, undefined, 0),
+          deriveCurrentWalletAddresses!(password, 0, changeAddressCount, undefined, 1),
         ]);
 
         const allAddresses = [...receivingAddresses, ...changeAddresses];

--- a/src/services/core/StorageService.test.ts
+++ b/src/services/core/StorageService.test.ts
@@ -131,6 +131,22 @@ describe('lookups', () => {
     expect(await StorageService.getActiveWallet()).toBeNull();
   });
 
+  it('treats both mnemonic and descriptor wallets as HD-capable', async () => {
+    // The UI gates the derived-address panel and HD UTXO scan on this, so a descriptor
+    // import — which stores an account xprv instead of a mnemonic — must qualify too.
+    await createWallet({ mnemonic: 'encrypted-mnemonic-blob' });
+    expect(await StorageService.hasHdCapability()).toBe(true);
+
+    resetStorage();
+    await createWallet({ xprv: 'encrypted-xprv-blob' });
+    expect(await StorageService.hasHdCapability()).toBe(true);
+    expect(await StorageService.hasMnemonic()).toBe(false);
+
+    resetStorage();
+    await createWallet();
+    expect(await StorageService.hasHdCapability()).toBe(false);
+  });
+
   it('reports emptiness consistently', async () => {
     expect(await StorageService.hasWallet()).toBe(false);
     expect(await StorageService.getWalletCount()).toBe(0);

--- a/src/services/core/StorageService.ts
+++ b/src/services/core/StorageService.ts
@@ -1668,6 +1668,16 @@ export class StorageService {
     return !!activeWallet?.mnemonic;
   }
 
+  /**
+   * Whether the active wallet can derive further addresses in its account tree.
+   * True for mnemonic wallets and for descriptor-imported wallets, which store an
+   * account-level xprv instead of a mnemonic.
+   */
+  static async hasHdCapability(): Promise<boolean> {
+    const activeWallet = await this.getActiveWallet();
+    return !!(activeWallet?.mnemonic || activeWallet?.xprv);
+  }
+
   static async getIsEncrypted(): Promise<boolean> {
     const activeWallet = await this.getActiveWallet();
     return activeWallet?.isEncrypted || false;

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -1915,30 +1915,47 @@ export class WalletService {
             );
             let hdRoot = null;
             let mnemonic = null;
+            // Account-level node for descriptor-imported wallets (xprv, no mnemonic)
+            let hdAccountNode: ReturnType<typeof bip32.fromBase58> | null = null;
 
             if (hasHdUtxos) {
                 // Get mnemonic for HD wallet operations
                 mnemonic = await StorageService.getMnemonic();
-                if (!mnemonic) {
+
+                if (mnemonic) {
+                    // Decrypt mnemonic if needed
+                    let decryptedMnemonic = mnemonic;
+                    if (activeWallet.isEncrypted && password) {
+                        try {
+                            decryptedMnemonic = await secureDecrypt(mnemonic, password);
+                        } catch (error) {
+                            // If mnemonic decryption fails, try using it as-is (might not be encrypted)
+                            decryptedMnemonic = mnemonic;
+                        }
+                    }
+
+                    // Create HD root from mnemonic
+                    const seed = await bip39.mnemonicToSeed(decryptedMnemonic);
+                    hdRoot = bip32.fromSeed(seed, avianNetwork);
+                } else if (activeWallet.xprv) {
+                    // Descriptor-imported wallet — the stored xprv is already at account level
+                    let decryptedXprv = activeWallet.xprv;
+                    if (activeWallet.isEncrypted) {
+                        if (!password) {
+                            throw new Error('Password required to sign from derived addresses');
+                        }
+                        try {
+                            decryptedXprv = await secureDecrypt(activeWallet.xprv, password);
+                        } catch (error) {
+                            throw new Error('Invalid password or corrupted xprv');
+                        }
+                    }
+                    hdAccountNode = bip32.fromBase58(decryptedXprv, avianNetwork);
+                } else {
                     throw new Error(
-                        'HD wallet UTXOs detected but no mnemonic found. Cannot sign from derived addresses.',
+                        'HD wallet UTXOs detected but no mnemonic or account key found. Cannot sign from derived addresses.',
                     );
                 }
-
-                // Decrypt mnemonic if needed
-                let decryptedMnemonic = mnemonic;
-                if (activeWallet.isEncrypted && password) {
-                    try {
-                        decryptedMnemonic = await secureDecrypt(mnemonic, password);
-                    } catch (error) {
-                        // If mnemonic decryption fails, try using it as-is (might not be encrypted)
-                        decryptedMnemonic = mnemonic;
-                    }
-                }
-
-                // Create HD root from mnemonic
-                const seed = await bip39.mnemonicToSeed(decryptedMnemonic);
-                hdRoot = bip32.fromSeed(seed, avianNetwork);
             }
 
             // Helper function to get the correct key pair for an address
@@ -1946,13 +1963,15 @@ export class WalletService {
                 if (address === activeWallet.address) {
                     // Main wallet address - use main private key
                     return ECPair.fromWIF(privateKeyWIF, avianNetwork);
-                } else if (hdRoot) {
-                    // HD address - derive the correct key
-                    // We need to find which derivation path this address corresponds to
-                    // Use the wallet's stored coin type and address type for derivation
-                    const coinType = activeWallet.coinType || 921;
-                    const walletType: AddressType = activeWallet.addressType || 'p2pkh';
-                    const walletPurpose = purposeForAddressType(walletType);
+                }
+
+                // HD address - find which derivation path this address corresponds to.
+                // Use the wallet's stored coin type and address type for derivation.
+                const coinType = activeWallet.coinType || 921;
+                const walletType: AddressType = activeWallet.addressType || 'p2pkh';
+                const walletPurpose = purposeForAddressType(walletType);
+
+                if (hdRoot) {
                     // Check both receiving (0) and change (1) paths
                     for (const changePath of [0, 1]) {
                         for (let addressIndex = 0; addressIndex < 50; addressIndex++) {
@@ -1973,9 +1992,28 @@ export class WalletService {
                         }
                     }
                     throw new Error(`Could not find derivation path for HD address: ${address}`);
-                } else {
-                    throw new Error(`Cannot sign UTXO from address ${address} - HD wallet not available`);
+                } else if (hdAccountNode) {
+                    // xprv is at account level, so only change/index remain to be derived
+                    for (const changePath of [0, 1]) {
+                        const changeNode = hdAccountNode.derive(changePath);
+                        for (let addressIndex = 0; addressIndex < 50; addressIndex++) {
+                            const child = changeNode.derive(addressIndex);
+                            const derivedAddress = deriveAddress(
+                                Buffer.from(child.publicKey),
+                                walletType,
+                            );
+
+                            if (derivedAddress === address) {
+                                return ECPair.fromPrivateKey(Buffer.from(child.privateKey!), {
+                                    network: avianNetwork,
+                                });
+                            }
+                        }
+                    }
+                    throw new Error(`Could not find derivation path for HD address: ${address}`);
                 }
+
+                throw new Error(`Cannot sign UTXO from address ${address} - HD wallet not available`);
             };
 
             // Manual transaction building (skip PSBT since it has sighash issues)
@@ -4635,7 +4673,7 @@ export class WalletService {
         password: string,
         accountIndex: number = 0,
         addressCount: number = 10,
-        addressType: string = 'p2pkh',
+        addressType?: string,
         changePath: number = 0, // 0 for receiving addresses, 1 for change addresses
     ): Promise<Array<{ path: string; address: string; balance: number; hasTransactions: boolean }>> {
         try {
@@ -4644,6 +4682,10 @@ export class WalletService {
             if (!activeWallet) {
                 throw new Error('No active wallet found');
             }
+
+            // Callers that don't specify a type get the wallet's own script type —
+            // deriving p2pkh for a wpkh wallet would scan addresses it doesn't own
+            const resolvedAddressType = addressType || activeWallet.addressType || 'p2pkh';
 
             // Use the wallet's stored coin type, defaulting to 921 for legacy wallets
             const coinType = activeWallet.coinType || 921;
@@ -4665,14 +4707,15 @@ export class WalletService {
                 }
 
                 const accountNode = bip32.fromBase58(decryptedXprv, avianNetwork);
-                const resolvedType = (addressType as AddressType) || activeWallet.addressType || 'p2pkh';
-                const purpose = purposeForAddressType(resolvedType as AddressType);
+                const resolvedType = resolvedAddressType as AddressType;
+                const purpose = purposeForAddressType(resolvedType);
 
                 const result: Array<{ path: string; address: string; balance: number; hasTransactions: boolean }> = [];
                 const electrum = this.electrum;
+                const changeNode = accountNode.derive(changePath);
 
                 for (let i = 0; i < addressCount; i++) {
-                    const childNode = accountNode.derive(changePath).derive(i);
+                    const childNode = changeNode.derive(i);
                     if (!childNode.privateKey) throw new Error(`Failed to derive key at ${changePath}/${i}`);
                     const kp = ECPair.fromPrivateKey(Buffer.from(childNode.privateKey), { network: avianNetwork });
                     const addr = deriveAddress(Buffer.from(kp.publicKey), resolvedType as AddressType);
@@ -4734,7 +4777,7 @@ export class WalletService {
                 decryptedPassphrase, // Use the decrypted passphrase from wallet
                 accountIndex,
                 addressCount,
-                addressType,
+                resolvedAddressType,
                 changePath,
                 coinType,
             );

--- a/src/services/wallet/derivation.test.ts
+++ b/src/services/wallet/derivation.test.ts
@@ -26,9 +26,21 @@ vi.mock('../core/ElectrumService', () => {
   return { ElectrumService };
 });
 
-import { WalletService, decryptData } from './WalletService';
+import * as bip39 from 'bip39';
+import { BIP32Factory } from 'bip32';
+import * as ecc from 'tiny-secp256k1';
+
+import {
+  WalletService,
+  avianNetwork,
+  buildDescriptorBody,
+  decryptData,
+  descriptorChecksum,
+} from './WalletService';
 import { StorageService } from '@/services/core/StorageService';
 import { TEST_MNEMONIC, TEST_PASSWORD, resetStorage } from '@/test/helpers';
+
+const bip32 = BIP32Factory(ecc);
 
 const GOLDEN = {
   /** m/44'/921'/0'/0/0 — the wallet's default path */
@@ -335,6 +347,80 @@ describe('deriveAddressesWithBalances', () => {
   it('produces unique addresses across an index range', async () => {
     const derived = await WalletService.deriveAddressesWithBalances(TEST_MNEMONIC, '', 0, 10);
     expect(new Set(derived.map((entry) => entry.address)).size).toBe(10);
+  });
+});
+
+describe('deriveCurrentWalletAddresses for a descriptor-imported wallet', () => {
+  /**
+   * A descriptor import stores an account-level xprv and no mnemonic. The whole account tree
+   * is still reachable, so these must land on the same golden addresses the mnemonic produces —
+   * a descriptor wallet is not a single-address wallet.
+   */
+  const seed = bip39.mnemonicToSeedSync(TEST_MNEMONIC);
+  const accountNodeFor = (purpose: number) =>
+    bip32.fromSeed(seed, avianNetwork).derivePath(`m/${purpose}'/921'/0'`);
+
+  const importDescriptor = async (
+    addrType: 'p2pkh' | 'p2wpkh' = 'p2pkh',
+    purpose = 44,
+  ) => {
+    const body = buildDescriptorBody(
+      addrType,
+      'deadbeef',
+      purpose,
+      921,
+      accountNodeFor(purpose).toBase58(),
+    );
+    return wallet.importWalletFromDescriptor({
+      name: `Descriptor ${addrType}`,
+      descriptor: `${body}#${descriptorChecksum(body)}`,
+      password: TEST_PASSWORD,
+      makeActive: true,
+    });
+  };
+
+  it('derives past the first address, without a mnemonic', async () => {
+    const imported = await importDescriptor();
+    expect(imported.mnemonic).toBeFalsy();
+
+    const derived = await wallet.deriveCurrentWalletAddresses(TEST_PASSWORD, 0, 2, 'p2pkh', 0);
+
+    expect(derived).toHaveLength(2);
+    expect(derived[0]).toMatchObject({
+      path: "m/44'/921'/0'/0/0",
+      address: GOLDEN.avianAccount0,
+    });
+    expect(derived[1]).toMatchObject({
+      path: "m/44'/921'/0'/0/1",
+      address: GOLDEN.index1,
+    });
+  });
+
+  it('derives the change chain separately', async () => {
+    await importDescriptor();
+
+    const [change] = await wallet.deriveCurrentWalletAddresses(TEST_PASSWORD, 0, 1, 'p2pkh', 1);
+
+    expect(change.path).toBe("m/44'/921'/0'/1/0");
+    expect(change.address).toBe(GOLDEN.change0);
+  });
+
+  it("falls back to the wallet's own script type when the caller names none", async () => {
+    // Callers that hardcoded 'p2pkh' would otherwise scan addresses a wpkh wallet never owns.
+    await importDescriptor('p2wpkh', 84);
+
+    const [derived] = await wallet.deriveCurrentWalletAddresses(TEST_PASSWORD, 0, 1);
+
+    expect(derived.path).toBe("m/84'/921'/0'/0/0");
+    expect(derived.address).toBe(GOLDEN.nativeSegwit);
+  });
+
+  it('refuses the wrong password rather than deriving from a corrupt key', async () => {
+    await importDescriptor();
+
+    await expect(
+      wallet.deriveCurrentWalletAddresses('not-the-password', 0, 1, 'p2pkh', 0),
+    ).rejects.toThrow(/Invalid password/);
   });
 });
 

--- a/src/services/wallet/sendTransaction.test.ts
+++ b/src/services/wallet/sendTransaction.test.ts
@@ -3,17 +3,22 @@ import * as bitcoin from 'bitcoinjs-lib';
 import { ECPairFactory } from 'ecpair';
 import * as ecc from 'tiny-secp256k1';
 
+import * as bip39 from 'bip39';
+import { BIP32Factory } from 'bip32';
+
 import {
   WalletService,
   avianNetwork,
+  buildDescriptorBody,
   deriveAddress,
+  descriptorChecksum,
   resolveSendAmounts,
   secureEncrypt,
 } from './WalletService';
 import { estimateTxFee } from './fees';
 import { CoinSelectionStrategy } from './UTXOSelectionService';
 import { StorageService } from '@/services/core/StorageService';
-import { TEST_PASSWORD, resetStorage } from '@/test/helpers';
+import { TEST_MNEMONIC, TEST_PASSWORD, resetStorage } from '@/test/helpers';
 
 /**
  * Transaction building against a stubbed network layer. Nothing is broadcast: the fake Electrum
@@ -23,6 +28,7 @@ import { TEST_PASSWORD, resetStorage } from '@/test/helpers';
  */
 
 const ECPair = ECPairFactory(ecc);
+const bip32 = BIP32Factory(ecc);
 
 const SIGHASH_ALL_FORKID = 0x41;
 const RECIPIENT = 'RJNi221gkDstBPUxeeJgtmDY4EXMEj6uvF';
@@ -555,6 +561,44 @@ describe('sendTransactionWithManualUTXOs', () => {
       ),
     ).rejects.toThrow();
     expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it('signs a UTXO on a derived address of a descriptor-imported wallet', async () => {
+    // A descriptor import has no mnemonic, so the HD signing path has to fall back to the
+    // stored account xprv — otherwise funds on any address but the first are unspendable.
+    const accountNode = bip32
+      .fromSeed(bip39.mnemonicToSeedSync(TEST_MNEMONIC), avianNetwork)
+      .derivePath("m/44'/921'/0'");
+    const derivedChild = accountNode.derive(0).derive(3);
+    const derivedAddress = deriveAddress(Buffer.from(derivedChild.publicKey), 'p2pkh');
+
+    const { electrum, broadcast, utxos } = createFakeElectrum(derivedAddress, [500_000]);
+    const wallet = new WalletService(electrum as never);
+
+    const body = buildDescriptorBody('p2pkh', 'deadbeef', 44, 921, accountNode.toBase58());
+    const imported = await wallet.importWalletFromDescriptor({
+      name: 'Descriptor',
+      descriptor: `${body}#${descriptorChecksum(body)}`,
+      password: TEST_PASSWORD,
+      makeActive: true,
+    });
+    expect(derivedAddress).not.toBe(imported.address);
+
+    await wallet.sendTransactionWithManualUTXOs(
+      RECIPIENT,
+      100_000,
+      [{ ...utxos[0], address: derivedAddress }],
+      TEST_PASSWORD,
+    );
+
+    const tx = broadcastTx(broadcast);
+    expect(tx.ins).toHaveLength(1);
+    // Signed with the derived key rather than the wallet's primary key.
+    const [signature, pubkey] = bitcoin.script.decompile(tx.ins[0].script) as Buffer[];
+    expect(signature[signature.length - 1]).toBe(SIGHASH_ALL_FORKID);
+    expect(Buffer.from(pubkey).toString('hex')).toBe(
+      Buffer.from(derivedChild.publicKey).toString('hex'),
+    );
   });
 });
 


### PR DESCRIPTION
## What

A descriptor import already stores the account-level xprv, so the whole account tree is reachable — but two places still equated "HD wallet" with "has a mnemonic", which left descriptor-imported wallets stuck on their first address.

- **`StorageService.hasHdCapability()`** — mnemonic *or* xprv. Replaces the `!!getMnemonic()` gate in `DerivedAddressesPanel`, `SendForm`, `UTXOSelector` and `UTXOOverview`, which hid the derived-address panel and the HD UTXO scan and showed a "not created with HD capabilities" warning.
- **Signing** — `sendTransactionWithManualUTXOs` now falls back to the stored account xprv when signing a UTXO on a derived address, instead of throwing `HD wallet UTXOs detected but no mnemonic found`. Without this, unlocking the UI alone would surface addresses you still couldn't spend from.
- **Script type** — `deriveCurrentWalletAddresses` resolves an unspecified `addressType` to the wallet's own type. `UTXOSelector` and `SendForm` hardcoded `'p2pkh'`, which beat the stored type and scanned addresses a wpkh wallet has never owned. Core v5 `listdescriptors` typically emits `wpkh(...)`, so this would have made the feature silently return nothing. Also fixes the same latent bug for mnemonic-based p2wpkh wallets.

Copy in the panel's fallback message was corrected — it claimed only seed-phrase wallets support derived addresses.

## Testing

`pnpm typecheck`, `pnpm lint` (only pre-existing warnings) and `pnpm test` — 678 pass, up from 672. The two that matter:

- `derivation.test.ts` — a descriptor wallet derives past index 0 onto the same golden addresses the mnemonic produces, on both the receive and change chains, and picks up its own script type when the caller names none.
- `sendTransaction.test.ts` — a UTXO sitting on `0/3` of a descriptor wallet is signed with the *derived* key, asserted via the pubkey in the scriptSig. Fails with "no mnemonic found" against the old code.

## Not included

Import still does no gap-limit scan: it only checks `0/0` for a duplicate and sets that as the wallet address. If the Core wallet's funds sit further down the chain, a fresh import reads as zero until you open the HD Wallet Addresses panel and load. Worth a follow-up.
