### PR TITLE
feat(descriptor): pick which address a descriptor import anchors to

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -96,6 +96,7 @@ export default function OnboardingPage() {
                     name: data.name.trim(),
                     descriptor: data.descriptor!.trim(),
                     password: data.password,
+                    addressIndex: data.addressIndex,
                     makeActive: true,
                 });
             }

--- a/src/components/WalletCreationForm.tsx
+++ b/src/components/WalletCreationForm.tsx
@@ -6,6 +6,7 @@ import * as bip39 from 'bip39';
 import { AddressType, ADDRESS_TYPE_INFO } from '@/services/wallet/WalletService';
 import PasswordStrengthChecker, { PasswordStrength } from '@/components/PasswordStrength';
 import { StorageService } from '@/services/core/StorageService';
+import { useWallet } from '@/contexts/WalletContext';
 
 // Import Shadcn UI components
 import { Button } from '@/components/ui/button';
@@ -25,6 +26,27 @@ import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 // Define the wallet creation modes
 export type WalletCreationMode = 'create' | 'importMnemonic' | 'importWIF' | 'importDescriptor';
 
+// Mirrors WalletService.MAX_IMPORT_ADDRESS_INDEX — the service revalidates on import.
+const MAX_ADDRESS_INDEX = 1000;
+
+/** Blank reads as index 0, the ordinary first receive address. NaN for anything unparseable. */
+const parseAddressIndex = (raw: string): number => {
+  const trimmed = raw.trim();
+  return trimmed === '' ? 0 : Number(trimmed);
+};
+
+// How many addresses one scan step reveals.
+const ADDRESS_PAGE_SIZE = 10;
+
+interface DescriptorAddressPreview {
+  index: number;
+  path: string;
+  address: string;
+  /** Only set when an ElectrumX connection was available during the scan. */
+  balance?: number;
+  assets?: string[];
+}
+
 // Define component props
 interface WalletCreationFormProps {
   mode: WalletCreationMode;
@@ -41,6 +63,7 @@ export interface WalletCreationData {
   mnemonic?: string;
   privateKey?: string;
   descriptor?: string; // BIP380 xprv descriptor
+  addressIndex?: number; // Receive index the descriptor import is anchored to (account/0/N)
   passphrase?: string; // Optional BIP39 passphrase
   mnemonicLength?: '12' | '24'; // Recovery phrase length
   coinType?: 921 | 175; // BIP44 coin type for import compatibility
@@ -54,6 +77,8 @@ export default function WalletCreationForm({
   isSubmitting,
   isFullscreen = false,
 }: WalletCreationFormProps) {
+  const { electrum, isConnected } = useWallet();
+
   // Form state
   const [walletName, setWalletName] = useState('');
   const [password, setPassword] = useState('');
@@ -61,6 +86,10 @@ export default function WalletCreationForm({
   const [mnemonic, setMnemonic] = useState('');
   const [privateKey, setPrivateKey] = useState('');
   const [descriptor, setDescriptor] = useState('');
+  const [addressIndex, setAddressIndex] = useState('0');
+  const [previews, setPreviews] = useState<DescriptorAddressPreview[]>([]);
+  const [scanning, setScanning] = useState(false);
+  const [balancesAvailable, setBalancesAvailable] = useState(false);
   const [passphrase, setPassphrase] = useState('');
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [mnemonicLength, setMnemonicLength] = useState<'12' | '24'>('12');
@@ -73,6 +102,7 @@ export default function WalletCreationForm({
   const [mnemonicError, setMnemonicError] = useState('');
   const [privateKeyError, setPrivateKeyError] = useState('');
   const [descriptorError, setDescriptorError] = useState('');
+  const [addressIndexError, setAddressIndexError] = useState('');
 
   // Password strength
   const [passwordStrength, setPasswordStrength] = useState<PasswordStrength | null>(null);
@@ -85,6 +115,63 @@ export default function WalletCreationForm({
   const [showPassphrase, setShowPassphrase] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  /**
+   * Derives the descriptor's receive addresses so the user can pick the one holding their
+   * funds. Derivation is local — the descriptor carries the key — so this works offline;
+   * balances and asset counts are filled in only when ElectrumX is reachable.
+   */
+  const scanDescriptorAddresses = useCallback(
+    async (startIndex: number) => {
+      const raw = descriptor.trim();
+      if (!raw) return;
+
+      setScanning(true);
+      try {
+        const { WalletService } = await import('@/services/wallet/WalletService');
+        const derived = WalletService.previewDescriptorAddresses(
+          raw,
+          ADDRESS_PAGE_SIZE,
+          startIndex,
+        );
+        setDescriptorError('');
+
+        let enriched: DescriptorAddressPreview[] = derived;
+        if (electrum && isConnected) {
+          enriched = await Promise.all(
+            derived.map(async (entry) => {
+              try {
+                const [balance, assetBalances] = await Promise.all([
+                  electrum.getBalance(entry.address),
+                  electrum.getAssetBalances(entry.address),
+                ]);
+                return {
+                  ...entry,
+                  balance,
+                  assets: Object.keys(assetBalances || {}),
+                };
+              } catch {
+                // A per-address lookup failure must not lose the address itself.
+                return entry;
+              }
+            }),
+          );
+        }
+        setBalancesAvailable(!!electrum && isConnected);
+
+        // startIndex 0 is a fresh scan; anything else extends the list.
+        setPreviews((current) => (startIndex === 0 ? enriched : [...current, ...enriched]));
+      } catch (error) {
+        setPreviews([]);
+        setDescriptorError(
+          error instanceof Error ? error.message : 'Could not derive addresses from this descriptor',
+        );
+      } finally {
+        setScanning(false);
+      }
+    },
+    [descriptor, electrum, isConnected],
+  );
 
   // Generate a creative bird-themed wallet name
   const generateWalletName = useCallback(async () => {
@@ -351,6 +438,13 @@ export default function WalletCreationForm({
         return;
       }
       setDescriptorError('');
+
+      const parsedIndex = parseAddressIndex(addressIndex);
+      if (!Number.isInteger(parsedIndex) || parsedIndex < 0 || parsedIndex > MAX_ADDRESS_INDEX) {
+        setAddressIndexError(`Enter a whole number between 0 and ${MAX_ADDRESS_INDEX}`);
+        return;
+      }
+      setAddressIndexError('');
     }
 
     // Create data object for submission
@@ -377,6 +471,7 @@ export default function WalletCreationForm({
       data.privateKey = privateKey.trim();
     } else if (mode === 'importDescriptor') {
       data.descriptor = descriptor.trim();
+      data.addressIndex = parseAddressIndex(addressIndex);
     }
 
     // Submit form data
@@ -1347,7 +1442,13 @@ export default function WalletCreationForm({
               <Textarea
                 id="descriptor-input"
                 value={descriptor}
-                onChange={(e) => { setDescriptor(e.target.value); setDescriptorError(''); }}
+                onChange={(e) => {
+                  setDescriptor(e.target.value);
+                  setDescriptorError('');
+                  // A different descriptor means different addresses; don't leave a stale pick.
+                  setPreviews([]);
+                  setAddressIndex('0');
+                }}
                 placeholder="wpkh([a1b2c3d4/84h/921h/0h]xprvABC.../0/*)#checksum"
                 disabled={isSubmitting}
                 className="font-mono text-xs min-h-[80px] resize-none"
@@ -1360,6 +1461,90 @@ export default function WalletCreationForm({
               <p className="text-xs text-muted-foreground">
                 Paste a descriptor containing an <strong>xprv</strong> (private key). Descriptors with xpub only cannot sign transactions.
               </p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <Label htmlFor="desc-address-index">Address</Label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void scanDescriptorAddresses(0)}
+                  disabled={isSubmitting || scanning || !descriptor.trim()}
+                >
+                  {scanning ? 'Scanning…' : previews.length ? 'Rescan' : 'Show addresses'}
+                </Button>
+              </div>
+
+              {previews.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  The wallet points at the first receive address by default. If your coins or assets
+                  sit further along the chain, scan the descriptor and pick the address that holds
+                  them — the rest of the account stays derivable either way.
+                </p>
+              ) : (
+                <>
+                  <div className="max-h-64 overflow-y-auto rounded-md border border-border divide-y divide-border">
+                    {previews.map((entry) => (
+                      <label
+                        key={entry.index}
+                        className={`flex items-center gap-3 p-2 cursor-pointer hover:bg-muted/40 ${parseAddressIndex(addressIndex) === entry.index ? 'bg-primary/10' : ''
+                          }`}
+                      >
+                        <input
+                          type="radio"
+                          name="descriptor-address-index"
+                          checked={parseAddressIndex(addressIndex) === entry.index}
+                          onChange={() => { setAddressIndex(String(entry.index)); setAddressIndexError(''); }}
+                          disabled={isSubmitting}
+                        />
+                        <span className="font-mono text-xs text-muted-foreground w-10 shrink-0">
+                          0/{entry.index}
+                        </span>
+                        <span className="font-mono text-xs break-all flex-1">{entry.address}</span>
+                        {entry.balance !== undefined && (
+                          <span
+                            className={`text-xs whitespace-nowrap ${entry.balance > 0 ? 'text-primary font-medium' : 'text-muted-foreground'
+                              }`}
+                          >
+                            {(entry.balance / 100000000).toFixed(4)} AVN
+                          </span>
+                        )}
+                        {entry.assets && entry.assets.length > 0 && (
+                          <span
+                            className="text-xs text-caution whitespace-nowrap"
+                            title={entry.assets.join(', ')}
+                          >
+                            {entry.assets.length} asset{entry.assets.length > 1 ? 's' : ''}
+                          </span>
+                        )}
+                      </label>
+                    ))}
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-xs text-muted-foreground">
+                      Importing at <span className="font-mono">0/{parseAddressIndex(addressIndex)}</span>
+                      {!balancesAvailable && ' — connect to the network to see balances'}
+                    </p>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void scanDescriptorAddresses(previews.length)}
+                      disabled={isSubmitting || scanning || previews.length >= MAX_ADDRESS_INDEX}
+                    >
+                      Show more
+                    </Button>
+                  </div>
+                </>
+              )}
+
+              {addressIndexError && (
+                <Alert variant="destructive">
+                  <AlertDescription>{addressIndexError}</AlertDescription>
+                </Alert>
+              )}
             </div>
 
             <div className="space-y-2">

--- a/src/components/WalletManager.tsx
+++ b/src/components/WalletManager.tsx
@@ -965,6 +965,7 @@ export function WalletManager({ onWalletSelect, onClose }: WalletManagerProps) {
                         name: data.name,
                         descriptor: data.descriptor!,
                         password: data.password,
+                        addressIndex: data.addressIndex,
                         makeActive: true,
                       });
 

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -51,7 +51,12 @@ interface WalletContextType {
     password: string,
     passphrase?: string,
   ) => Promise<void>;
-  importWalletFromDescriptor: (name: string, descriptor: string, password: string) => Promise<void>;
+  importWalletFromDescriptor: (
+    name: string,
+    descriptor: string,
+    password: string,
+    addressIndex?: number,
+  ) => Promise<void>;
   sendTransaction: (
     toAddress: string,
     amount: number,
@@ -973,7 +978,12 @@ export function WalletProvider({ children }: WalletProviderProps) {
     selectElectrumServer,
     testConnection,
     restoreWalletFromMnemonic,
-    importWalletFromDescriptor: async (name: string, descriptor: string, password: string) => {
+    importWalletFromDescriptor: async (
+      name: string,
+      descriptor: string,
+      password: string,
+      addressIndex?: number,
+    ) => {
       if (!wallet) throw new Error('Wallet service not initialized');
       try {
         setIsLoading(true);
@@ -981,6 +991,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
           name,
           descriptor,
           password,
+          addressIndex,
           makeActive: true,
         });
         setAddress(newWallet.address);

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -3072,20 +3072,81 @@ export class WalletService {
         };
     }
 
+    /** Upper bound on the receive index a descriptor import may be anchored to. */
+    static readonly MAX_IMPORT_ADDRESS_INDEX = 1000;
+
+    /**
+     * Receive addresses a descriptor would produce, without importing anything or touching
+     * storage. Lets the import screen show the account's addresses so the user can pick the
+     * one holding their coins or assets instead of having to know its index up front.
+     *
+     * Works for xpub-only descriptors too: addresses need no private key.
+     */
+    static previewDescriptorAddresses(
+        descriptor: string,
+        count = 10,
+        startIndex = 0,
+    ): Array<{ index: number; path: string; address: string }> {
+        const parsed = WalletService.parseDescriptor(descriptor);
+
+        let accountNode: ReturnType<typeof bip32.fromBase58>;
+        try {
+            const rawNode = bip32.fromBase58(parsed.xkey, avianNetwork);
+            accountNode = parsed.accountDerivationPath
+                ? rawNode.derivePath(parsed.accountDerivationPath)
+                : rawNode;
+        } catch {
+            throw new Error(
+                'Invalid extended key in descriptor — check the descriptor is from an Avian mainnet wallet',
+            );
+        }
+
+        const changeNode = accountNode.derive(0);
+        const addresses: Array<{ index: number; path: string; address: string }> = [];
+
+        for (let i = startIndex; i < startIndex + count; i++) {
+            const child = changeNode.derive(i);
+            addresses.push({
+                index: i,
+                path: `m/${parsed.purpose}'/${parsed.coinType}'/${parsed.accountIndex}'/0/${i}`,
+                address: deriveAddress(Buffer.from(child.publicKey), parsed.addrType),
+            });
+        }
+
+        return addresses;
+    }
+
     /**
      * Import a wallet from a BIP380 output script descriptor containing an xprv.
      * Use `listdescriptors true` in Avian Core v5 to obtain the descriptor.
      * The encrypted xprv is stored, enabling full HD address derivation without a mnemonic.
+     *
+     * `addressIndex` anchors the wallet's primary address to account/0/N rather than the
+     * usual account/0/0. Features that read `wallet.address` — the asset list, asset
+     * transfers, Avian Connect — then operate on that address. The whole account tree stays
+     * derivable either way, since the stored xprv is at account level.
      */
     async importWalletFromDescriptor(params: {
         name: string;
         descriptor: string;
         password: string;
+        addressIndex?: number;
         makeActive?: boolean;
     }): Promise<WalletData> {
         try {
             if (!params.password || params.password.length < 8) {
                 throw new Error('Password is required and must be at least 8 characters long');
+            }
+
+            const addressIndex = params.addressIndex ?? 0;
+            if (
+                !Number.isInteger(addressIndex) ||
+                addressIndex < 0 ||
+                addressIndex > WalletService.MAX_IMPORT_ADDRESS_INDEX
+            ) {
+                throw new Error(
+                    `Address index must be a whole number between 0 and ${WalletService.MAX_IMPORT_ADDRESS_INDEX}`,
+                );
             }
 
             const parsed = WalletService.parseDescriptor(params.descriptor);
@@ -3117,8 +3178,8 @@ export class WalletService {
                 throw new Error('Failed to extract private key from xprv');
             }
 
-            // Derive first receiving address: account/0/0
-            const receiveNode = accountNode.derive(0).derive(0);
+            // Derive the anchor receiving address: account/0/addressIndex
+            const receiveNode = accountNode.derive(0).derive(addressIndex);
             if (!receiveNode.privateKey) {
                 throw new Error('Failed to derive child key from xprv');
             }

--- a/src/services/wallet/walletCreation.test.ts
+++ b/src/services/wallet/walletCreation.test.ts
@@ -23,6 +23,8 @@ const bip32 = BIP32Factory(ecc);
 
 const GOLDEN = {
   bip44Avian: 'RMBnRfw6tV7dC7LS4Lr8JBWvocokzHQNeG',
+  /** m/44'/921'/0'/0/1 — the same golden vector derivation.test.ts pins */
+  bip44AvianIndex1: 'RUqbuDKvv8x31EVVmNfmdb31BQ7xG6HDmU',
   bip44AvianWif: 'KwgGM49xXFfGn1FK3JjbaKHzjNq2jydshvoYmwqjnGAsA4FeuqS4',
   bip44Ravencoin: 'RDjNvZL1TJQ7R8L23jDutdEioQG4eTC38V',
   bip84Avian: 'avn1qwq3xtmwmzelhwdtvfc9dslda32mlrngceqk4mr',
@@ -428,6 +430,162 @@ describe('importWalletFromDescriptor', () => {
         password: 'short',
       }),
     ).rejects.toThrow(/at least 8 characters/);
+  });
+
+  describe('addressIndex', () => {
+    it('anchors the wallet to the requested receive address', async () => {
+      const created = await wallet.importWalletFromDescriptor({
+        name: 'Index 1',
+        descriptor: descriptorFor(accountNode.toBase58()),
+        password: TEST_PASSWORD,
+        addressIndex: 1,
+      });
+
+      expect(created.address).toBe(GOLDEN.bip44AvianIndex1);
+      // The stored key is the one for that address, not index 0's.
+      expect((await decryptData(created.privateKey, TEST_PASSWORD)).decrypted).toBe(
+        accountNode.derive(0).derive(1).toWIF(),
+      );
+    });
+
+    it('stores the same account xprv whatever the index, so the chain stays derivable', async () => {
+      const created = await wallet.importWalletFromDescriptor({
+        name: 'Index 5',
+        descriptor: descriptorFor(accountNode.toBase58()),
+        password: TEST_PASSWORD,
+        addressIndex: 5,
+      });
+
+      expect((await decryptData(created.xprv!, TEST_PASSWORD)).decrypted).toBe(
+        accountNode.toBase58(),
+      );
+    });
+
+    it('defaults to index 0', async () => {
+      const created = await wallet.importWalletFromDescriptor({
+        name: 'Default',
+        descriptor: descriptorFor(accountNode.toBase58()),
+        password: TEST_PASSWORD,
+      });
+
+      expect(created.address).toBe(GOLDEN.bip44Avian);
+    });
+
+    it('allows two wallets from one descriptor at different indexes', async () => {
+      const first = await wallet.importWalletFromDescriptor({
+        name: 'First',
+        descriptor: descriptorFor(accountNode.toBase58()),
+        password: TEST_PASSWORD,
+      });
+      const second = await wallet.importWalletFromDescriptor({
+        name: 'Second',
+        descriptor: descriptorFor(accountNode.toBase58()),
+        password: TEST_PASSWORD,
+        addressIndex: 1,
+      });
+
+      expect(second.address).not.toBe(first.address);
+      expect(await StorageService.getWalletCount()).toBe(2);
+    });
+
+    it('still refuses the same index twice', async () => {
+      await wallet.importWalletFromDescriptor({
+        name: 'First',
+        descriptor: descriptorFor(accountNode.toBase58()),
+        password: TEST_PASSWORD,
+        addressIndex: 2,
+      });
+
+      await expect(
+        wallet.importWalletFromDescriptor({
+          name: 'Duplicate',
+          descriptor: descriptorFor(accountNode.toBase58()),
+          password: TEST_PASSWORD,
+          addressIndex: 2,
+        }),
+      ).rejects.toThrow(/already exists/);
+    });
+
+    it.each([-1, 1.5, WalletService.MAX_IMPORT_ADDRESS_INDEX + 1, NaN])(
+      'refuses the out-of-range index %s',
+      async (index) => {
+        await expect(
+          wallet.importWalletFromDescriptor({
+            name: 'Bad',
+            descriptor: descriptorFor(accountNode.toBase58()),
+            password: TEST_PASSWORD,
+            addressIndex: index,
+          }),
+        ).rejects.toThrow(/whole number/);
+      },
+    );
+  });
+
+  describe('previewDescriptorAddresses', () => {
+    it('lists the account addresses so the user can pick one without knowing its index', () => {
+      const preview = WalletService.previewDescriptorAddresses(
+        descriptorFor(accountNode.toBase58()),
+        3,
+      );
+
+      expect(preview).toHaveLength(3);
+      expect(preview[0]).toEqual({
+        index: 0,
+        path: "m/44'/921'/0'/0/0",
+        address: GOLDEN.bip44Avian,
+      });
+      expect(preview[1].address).toBe(GOLDEN.bip44AvianIndex1);
+    });
+
+    it('pages from an offset, matching what importing at that index would produce', async () => {
+      const [preview] = WalletService.previewDescriptorAddresses(
+        descriptorFor(accountNode.toBase58()),
+        1,
+        4,
+      );
+      expect(preview.index).toBe(4);
+
+      const imported = await wallet.importWalletFromDescriptor({
+        name: 'Index 4',
+        descriptor: descriptorFor(accountNode.toBase58()),
+        password: TEST_PASSWORD,
+        addressIndex: 4,
+      });
+      expect(imported.address).toBe(preview.address);
+    });
+
+    it('previews a watch-only xpub descriptor, which import itself would refuse', () => {
+      const preview = WalletService.previewDescriptorAddresses(
+        descriptorFor(accountNode.neutered().toBase58()),
+        2,
+      );
+
+      expect(preview[0].address).toBe(GOLDEN.bip44Avian);
+      expect(preview[1].address).toBe(GOLDEN.bip44AvianIndex1);
+    });
+
+    it('reflects the descriptor script type', () => {
+      const [preview] = WalletService.previewDescriptorAddresses(
+        descriptorFor(
+          bip32
+            .fromSeed(bip39.mnemonicToSeedSync(TEST_MNEMONIC), avianNetwork)
+            .derivePath("m/84'/921'/0'")
+            .toBase58(),
+          'p2wpkh',
+          84,
+        ),
+        1,
+      );
+
+      expect(preview.path).toBe("m/84'/921'/0'/0/0");
+      expect(preview.address).toBe(GOLDEN.bip84Avian);
+    });
+
+    it('refuses a descriptor it cannot parse', () => {
+      expect(() => WalletService.previewDescriptorAddresses('tr(xprvWhatever/0/*)', 1)).toThrow(
+        /Unsupported descriptor type/,
+      );
+    });
   });
 
   it('round-trips: the descriptor it stores re-imports to the same address', async () => {


### PR DESCRIPTION
## What

A descriptor import always anchored the wallet to `account/0/0`. Everything that reads `wallet.address` — the asset list, asset transfers, Avian Connect — therefore could not see coins or assets held further along the receive chain, even though #97 made the rest of the chain derivable.

- **`importWalletFromDescriptor({ addressIndex })`** — default 0, validated 0–1000. Derives `account/0/N` for the primary address and its key. The stored xprv stays at account level, so the whole chain remains derivable however the wallet is anchored.
- **`WalletService.previewDescriptorAddresses(descriptor, count, startIndex)`** — derives an account's receive addresses without importing or writing anything. Local-only, so it works offline, and it works for xpub-only descriptors that import itself refuses.
- **Import form** — paste a descriptor, hit *Show addresses*, and pick from a list showing the path, address, AVN balance and asset count. Balances appear only when ElectrumX is reachable, with a note saying so when it isn't. *Show more* pages another 10. Editing the descriptor clears a stale pick.

So the index never has to be known up front — you choose the address by what's actually on it.

## Testing

`pnpm typecheck`, `pnpm lint` (no new warnings) and `pnpm test` — 692 pass, up from 678. Worth calling out:

- Importing at index 1 lands on the same golden vector `derivation.test.ts` pins, and stores *that* address's key rather than index 0's.
- The preview at offset N matches what importing at N produces.
- Two wallets from one descriptor at different indexes coexist; the same index twice is still refused as a duplicate.
- Out-of-range indexes (negative, fractional, over the cap, NaN) are rejected.

The picker UI itself has not been exercised in a browser — only typecheck and unit tests.

## Known limitation

Fees still come from the anchored address: `sendAssetTransfer` selects fee UTXOs from `wallet.address` only, so an asset address holding no AVN needs funding before a transfer will build. Making asset balances and fee selection span the whole account is the follow-up.
