### PR TITLE
refactor(assets): return a typed result from issuance builders

### DIFF
--- a/src/components/CreateAssetDialog.tsx
+++ b/src/components/CreateAssetDialog.tsx
@@ -7,7 +7,7 @@ import { AlertTriangle, Check, Flame, Lock } from 'lucide-react';
 import { useWallet } from '@/contexts/WalletContext';
 import { useSecurity } from '@/contexts/SecurityContext';
 import { useMediaQuery } from '@/hooks/use-media-query';
-import { WalletService } from '@/services/wallet/WalletService';
+import { WalletService, type AssetTxResult } from '@/services/wallet/WalletService';
 import { parseAssetAmount } from '@/services/wallet/AssetService';
 import { ISSUE_BURN, isValidRootAssetName } from '@/services/wallet/assetScript';
 import { getExplorerUrl } from '@/lib/explorer';
@@ -172,29 +172,29 @@ export default function CreateAssetDialog({
       const service = new WalletService(electrum);
       // With buildOnly the builders return signed raw hex instead of broadcasting.
       const options = dryRun ? { buildOnly: true } : undefined;
-      let id: string;
+      let result: AssetTxResult;
       if (type === 'root') {
-        id = await service.issueAsset(
+        result = await service.issueAsset(
           fullName,
           { amount, units: divisions, reissuable, ipfs: ipfsValue },
           auth.password,
           options,
         );
       } else if (type === 'sub') {
-        id = await service.issueSubAsset(
+        result = await service.issueSubAsset(
           fullName,
           { amount, units: divisions, reissuable, ipfs: ipfsValue },
           auth.password,
           options,
         );
       } else {
-        id = await service.issueUniqueAsset(fullName, ipfsValue, auth.password, options);
+        result = await service.issueUniqueAsset(fullName, ipfsValue, auth.password, options);
       }
 
       if (dryRun) {
-        setDryRunHex(id);
+        setDryRunHex(result.hex);
         try {
-          await navigator.clipboard.writeText(id);
+          await navigator.clipboard.writeText(result.hex);
           toast.success('Raw hex copied — run testmempoolaccept in Core');
         } catch {
           toast.success('Transaction built — copy the hex below');
@@ -202,7 +202,7 @@ export default function CreateAssetDialog({
         return;
       }
 
-      setTxid(id);
+      setTxid(result.txid);
       toast.success(`Created ${fullName}`);
       void refreshAfterTransaction(1500);
       onSuccess?.();

--- a/src/components/ReissueAssetDialog.tsx
+++ b/src/components/ReissueAssetDialog.tsx
@@ -136,7 +136,7 @@ export default function ReissueAssetDialog({
         return;
       }
       const service = new WalletService(electrum);
-      const id = await service.reissueAsset(
+      const result = await service.reissueAsset(
         asset.name,
         { amount, units, reissuable, ipfs: ipfsValue },
         auth.password,
@@ -144,9 +144,9 @@ export default function ReissueAssetDialog({
       );
 
       if (dryRun) {
-        setDryRunHex(id);
+        setDryRunHex(result.hex);
         try {
-          await navigator.clipboard.writeText(id);
+          await navigator.clipboard.writeText(result.hex);
           toast.success('Raw hex copied — run testmempoolaccept in Core');
         } catch {
           toast.success('Transaction built — copy the hex below');
@@ -154,7 +154,7 @@ export default function ReissueAssetDialog({
         return;
       }
 
-      setTxid(id);
+      setTxid(result.txid);
       toast.success(`Reissued ${asset.name}`);
       void refreshAfterTransaction(1500);
       onSuccess?.();

--- a/src/services/wallet/WalletService.ts
+++ b/src/services/wallet/WalletService.ts
@@ -74,6 +74,19 @@ export const ADDRESS_TYPE_INFO: Record<AddressType, { purpose: number; label: st
     p2wpkh:      { purpose: 84, label: 'Native SegWit (P2WPKH)', bipLabel: 'BIP84' },
 };
 
+/**
+ * Outcome of building an asset issuance or reissue. Both the txid and the raw hex are always
+ * present; `broadcast` says whether it was sent. A `buildOnly` dry run returns `broadcast: false`
+ * — the transaction is signed and valid but nothing has been spent, so the txid is what it *would*
+ * have, not something on chain yet.
+ */
+export interface AssetTxResult {
+    txid: string;
+    /** Raw signed transaction, ready for `testmempoolaccept` or a manual broadcast. */
+    hex: string;
+    broadcast: boolean;
+}
+
 export interface WalletData {
     id?: number;
     name: string;
@@ -1191,16 +1204,16 @@ export class WalletService {
      * The scripts are byte-validated against a real Core issuance (see assetScript.ts). Sub/unique
      * issuance (which spends the parent owner token) is a separate method.
      *
-     * `options.buildOnly` signs the transaction but does not broadcast it, returning the raw hex
-     * instead of a txid — feed it to Core's `testmempoolaccept` to have consensus check the shape
-     * before anything is irreversible. It still spends nothing: no broadcast, no history entry.
+     * `options.buildOnly` signs the transaction but does not broadcast it: the result carries
+     * `broadcast: false` and the raw `hex`, which Core's `testmempoolaccept` will check against
+     * consensus before anything is irreversible. Nothing is spent and no history entry is written.
      */
     async issueAsset(
         name: string,
         params: { amount: bigint; units: number; reissuable: boolean; ipfs?: string },
         password?: string,
         options?: { feeRate?: number; changeAddress?: string; buildOnly?: boolean },
-    ): Promise<string> {
+    ): Promise<AssetTxResult> {
         try {
             if (!isAssetIssuanceEnabled()) throw new Error(ASSET_ISSUANCE_DISABLED_MESSAGE);
             if (!isValidRootAssetName(name)) {
@@ -1313,10 +1326,10 @@ export class WalletService {
 
             const txHex = tx.toHex();
             const txId = tx.getId();
-            // Dry run: return the signed hex for `testmempoolaccept` rather than broadcasting.
-            if (options?.buildOnly) return txHex;
+            // Dry run: signed and valid, but nothing spent — for `testmempoolaccept`.
+            if (options?.buildOnly) return { txid: txId, hex: txHex, broadcast: false };
             await this.broadcastRawTransaction(txHex);
-            return txId;
+            return { txid: txId, hex: txHex, broadcast: true };
         } catch (error) {
             walletLogger.error('Asset issuance failed:', error);
             const message = error instanceof Error ? error.message : 'Unknown error';
@@ -1326,14 +1339,14 @@ export class WalletService {
 
     /**
      * Issue a sub-asset (`PARENT/SUB`, burns 100 AVN). Requires owning the `PARENT!` owner token.
-     * `options.buildOnly` returns the signed hex instead of broadcasting (see issueAsset).
+     * `options.buildOnly` signs without broadcasting (see issueAsset).
      */
     async issueSubAsset(
         subName: string,
         params: { amount: bigint; units: number; reissuable: boolean; ipfs?: string },
         password?: string,
         options?: { feeRate?: number; changeAddress?: string; buildOnly?: boolean },
-    ): Promise<string> {
+    ): Promise<AssetTxResult> {
         const slash = subName.lastIndexOf('/');
         if (slash <= 0) throw new Error('A sub-asset name must be PARENT/CHILD');
         return this.issueChildAsset({
@@ -1360,7 +1373,7 @@ export class WalletService {
         ipfs?: string,
         password?: string,
         options?: { feeRate?: number; changeAddress?: string; buildOnly?: boolean },
-    ): Promise<string> {
+    ): Promise<AssetTxResult> {
         const hash = uniqueName.indexOf('#');
         if (hash <= 0) throw new Error('A unique asset name must be PARENT#tag');
         return this.issueChildAsset({
@@ -1400,7 +1413,7 @@ export class WalletService {
         burnAddress: string;
         password?: string;
         options?: { feeRate?: number; changeAddress?: string; buildOnly?: boolean };
-    }): Promise<string> {
+    }): Promise<AssetTxResult> {
         try {
             if (!isAssetIssuanceEnabled()) throw new Error(ASSET_ISSUANCE_DISABLED_MESSAGE);
             const { childName, parentName, amount, units, reissuable, burnAmount, burnAddress } = opts;
@@ -1527,10 +1540,10 @@ export class WalletService {
 
             const txHex = tx.toHex();
             const txId = tx.getId();
-            // Dry run: return the signed hex for `testmempoolaccept` rather than broadcasting.
-            if (opts.options?.buildOnly) return txHex;
+            // Dry run: signed and valid, but nothing spent — for `testmempoolaccept`.
+            if (opts.options?.buildOnly) return { txid: txId, hex: txHex, broadcast: false };
             await this.broadcastRawTransaction(txHex);
-            return txId;
+            return { txid: txId, hex: txHex, broadcast: true };
         } catch (error) {
             walletLogger.error('Child asset issuance failed:', error);
             const message = error instanceof Error ? error.message : 'Unknown error';
@@ -1552,7 +1565,7 @@ export class WalletService {
         params: { amount: bigint; units: number; reissuable: boolean; ipfs?: string },
         password?: string,
         options?: { feeRate?: number; changeAddress?: string; buildOnly?: boolean },
-    ): Promise<string> {
+    ): Promise<AssetTxResult> {
         try {
             if (!isAssetIssuanceEnabled()) throw new Error(ASSET_ISSUANCE_DISABLED_MESSAGE);
             if (params.amount < 0n) throw new Error('Reissue amount cannot be negative');
@@ -1666,10 +1679,10 @@ export class WalletService {
 
             const txHex = tx.toHex();
             const txId = tx.getId();
-            // Dry run: return the signed hex for `testmempoolaccept` rather than broadcasting.
-            if (options?.buildOnly) return txHex;
+            // Dry run: signed and valid, but nothing spent — for `testmempoolaccept`.
+            if (options?.buildOnly) return { txid: txId, hex: txHex, broadcast: false };
             await this.broadcastRawTransaction(txHex);
-            return txId;
+            return { txid: txId, hex: txHex, broadcast: true };
         } catch (error) {
             walletLogger.error('Asset reissue failed:', error);
             const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/services/wallet/assetIssuance.test.ts
+++ b/src/services/wallet/assetIssuance.test.ts
@@ -91,7 +91,7 @@ describe('buildOnly (dry run)', () => {
     const { electrum, broadcast } = createElectrum(address, [600 * COIN]);
     const wallet = new WalletService(electrum as never);
 
-    const hex = await wallet.issueAsset(
+    const result = await wallet.issueAsset(
       'DRYRUN',
       { amount: 1n * BigInt(COIN), units: 0, reissuable: true },
       TEST_PASSWORD,
@@ -99,9 +99,12 @@ describe('buildOnly (dry run)', () => {
     );
 
     expect(broadcast).not.toHaveBeenCalled();
+    expect(result.broadcast).toBe(false);
 
     // What comes back is a complete, signed transaction — the same bytes a real issuance sends.
-    const tx = bitcoin.Transaction.fromHex(hex);
+    const tx = bitcoin.Transaction.fromHex(result.hex);
+    // The txid is the one it *would* have, which is what testmempoolaccept reports back.
+    expect(result.txid).toBe(tx.getId());
     expect(tx.ins.length).toBeGreaterThan(0);
     expect(tx.ins.every((input) => input.script.length > 0)).toBe(true);
     expect(parseAssetScript(tx.outs[tx.outs.length - 1].script as Buffer)).toMatchObject({
@@ -116,11 +119,13 @@ describe('buildOnly (dry run)', () => {
     const dry = await (async () => {
       const { address } = await createActiveWallet();
       const { electrum } = createElectrum(address, [600 * COIN]);
-      return new WalletService(electrum as never).issueAsset('SAME', params, TEST_PASSWORD, {
-        feeRate: 1,
-        buildOnly: true,
-        changeAddress: address,
-      });
+      const built = await new WalletService(electrum as never).issueAsset(
+        'SAME',
+        params,
+        TEST_PASSWORD,
+        { feeRate: 1, buildOnly: true, changeAddress: address },
+      );
+      return built.hex;
     })();
 
     resetStorage();
@@ -128,10 +133,14 @@ describe('buildOnly (dry run)', () => {
     const wet = await (async () => {
       const { address } = await createActiveWallet();
       const { electrum, broadcast } = createElectrum(address, [600 * COIN]);
-      await new WalletService(electrum as never).issueAsset('SAME', params, TEST_PASSWORD, {
-        feeRate: 1,
-        changeAddress: address,
-      });
+      const sent = await new WalletService(electrum as never).issueAsset(
+        'SAME',
+        params,
+        TEST_PASSWORD,
+        { feeRate: 1, changeAddress: address },
+      );
+      expect(sent.broadcast).toBe(true);
+      expect(sent.hex).toBe(broadcast.mock.calls[0][0] as string);
       return broadcast.mock.calls[0][0] as string;
     })();
 


### PR DESCRIPTION
Follow-up cleanup now that the dry run is staying rather than being incident-only tooling.

## The problem

`buildOnly` overloaded the same `Promise<string>` to mean either a txid or raw hex depending on an option:

```ts
const id = await service.issueAsset(name, params, password, options);
```

Both are strings. A caller threading `buildOnly` through a config object gets hex back and can write it to history as a txid, and nothing — not the compiler, not a test — would catch it. That was an acceptable shortcut for a throwaway diagnostic; it isn't for a permanent API.

## The change

The four issuance builders now return:

```ts
export interface AssetTxResult {
  txid: string;
  hex: string;      // ready for testmempoolaccept or a manual broadcast
  broadcast: boolean;
}
```

Both values are always present — a dry run already computes each — so callers take the field they mean, and `broadcast` records what actually happened rather than leaving it implicit in which option was passed.

Making the change, `tsc` flagged all six call sites across both dialogs and the tests. That is the whole point: those were assignments that typechecked while being wrong in the failure case.

`sendAssetTransfer` keeps its plain txid return — it has no `buildOnly` mode and nothing ambiguous to fix. Leaving it alone rather than churning `SendAssetDialog` for symmetry.

## Testing

698 pass, typecheck and lint clean. The dry-run tests now also assert `broadcast` is false on a dry run and true on a real send, and that the returned txid matches the built transaction — the value `testmempoolaccept` echoes back.
